### PR TITLE
Save store expressions

### DIFF
--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f36b8c49bd8f232540cd65c20fb39f9da4902c62f44c99e591768b53c06f40f6
+-- hash: 6f8c3ef9e2c1d655ba04a1797b5fc1721b210f440a86fd345cfe9df4507c0d4a
 
 name:           mimsa
 version:        0.1.0.0
@@ -35,6 +35,7 @@ library
       Language.Mimsa.Repl.Types
       Language.Mimsa.Store
       Language.Mimsa.Store.Resolver
+      Language.Mimsa.Store.Substitutor
       Language.Mimsa.Syntax
       Language.Mimsa.Syntax.Language
       Language.Mimsa.Syntax.Parser
@@ -86,6 +87,7 @@ test-suite mimsa-test
   other-modules:
       Test.Interpreter
       Test.Resolver
+      Test.Substitutor
       Test.Syntax
       Paths_mimsa
   hs-source-dirs:

--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e74c14c9e555fb7d365ba404e80d079d1d1d3bdd0528a50133c3550f9ccb712c
+-- hash: f36b8c49bd8f232540cd65c20fb39f9da4902c62f44c99e591768b53c06f40f6
 
 name:           mimsa
 version:        0.1.0.0
@@ -34,6 +34,7 @@ library
       Language.Mimsa.Repl.Parser
       Language.Mimsa.Repl.Types
       Language.Mimsa.Store
+      Language.Mimsa.Store.Resolver
       Language.Mimsa.Syntax
       Language.Mimsa.Syntax.Language
       Language.Mimsa.Syntax.Parser
@@ -84,6 +85,7 @@ test-suite mimsa-test
   main-is: Spec.hs
   other-modules:
       Test.Interpreter
+      Test.Resolver
       Test.Syntax
       Paths_mimsa
   hs-source-dirs:

--- a/src/Language/Mimsa/Interpreter.hs
+++ b/src/Language/Mimsa/Interpreter.hs
@@ -13,7 +13,7 @@ import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Text (Text)
 import Language.Mimsa.Syntax
-import Language.Mimsa.Types
+import Language.Mimsa.Types hiding (Scope (..))
 
 interpret :: Expr -> Either Text Expr
 interpret expr =

--- a/src/Language/Mimsa/Interpreter.hs
+++ b/src/Language/Mimsa/Interpreter.hs
@@ -39,8 +39,15 @@ interpretWithScope (MyApp (MyVar f) value) = do
   interpretWithScope (MyApp expr value)
 interpretWithScope (MyApp (MyLambda binder expr) value) =
   interpretWithScope (MyLet binder expr value)
+interpretWithScope (MyApp (MyApp a b) c) = do
+  a' <- interpretWithScope (MyApp a b)
+  interpretWithScope (MyApp a' c)
+interpretWithScope (MyApp (MyBool _) _) = throwError "Cannot apply a value to a boolean"
+interpretWithScope (MyApp (MyInt _) _) = throwError "Cannot apply a value to an integer"
+interpretWithScope (MyApp (MyString _) _) = throwError "Cannot apply a value to a string"
+interpretWithScope (MyApp (MyIf _ _ _) _) = throwError "Cannot apply a value to an if"
+interpretWithScope (MyApp (MyLet _ _ _) _) = throwError "Cannot apply a value to an let"
 interpretWithScope (MyLambda a b) = pure (MyLambda a b)
-interpretWithScope (MyApp _ _) = throwError "Can only apply a value to a lambda"
 interpretWithScope (MyIf (MyBool pred') true false) =
   if pred'
     then interpretWithScope true

--- a/src/Language/Mimsa/Repl/Actions.hs
+++ b/src/Language/Mimsa/Repl/Actions.hs
@@ -10,7 +10,6 @@ import qualified Data.Map as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
-import Debug.Trace
 import Language.Mimsa.Interpreter (interpret)
 import Language.Mimsa.Repl.Types
 import Language.Mimsa.Store
@@ -43,7 +42,7 @@ doReplAction env (Evaluate expr) = do
   case getTypecheckedStoreExpression env expr
     >>= ( \(type', _, expr', scope') ->
             (,) type'
-              <$> interpret (traceShowId scope') (traceShowId expr')
+              <$> interpret scope' expr'
         ) of
     Left e' -> do
       print e'
@@ -101,7 +100,7 @@ chainExprs ::
   Expr ->
   Scope ->
   Expr
-chainExprs expr scope = traceShowId finalExpr
+chainExprs expr scope = finalExpr
   where
     finalExpr =
       foldl
@@ -119,5 +118,5 @@ getTypecheckedStoreExpression :: StoreEnv -> Expr -> Either Text (MonoType, Stor
 getTypecheckedStoreExpression env expr = do
   storeExpr <- createStoreExpression (bindings env) expr
   (_, newExpr, scope) <- substitute (store env) storeExpr
-  exprType <- getType (traceShowId scope) (traceShowId newExpr)
+  exprType <- getType scope newExpr
   pure (exprType, storeExpr, newExpr, scope)

--- a/src/Language/Mimsa/Store.hs
+++ b/src/Language/Mimsa/Store.hs
@@ -7,6 +7,7 @@ module Language.Mimsa.Store
     loadBoundExpressions,
     saveEnvironment,
     module Language.Mimsa.Store.Resolver,
+    module Language.Mimsa.Store.Substitutor,
   )
 where
 
@@ -22,6 +23,7 @@ import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text.IO as T
 import Language.Mimsa.Store.Resolver
+import Language.Mimsa.Store.Substitutor
 import Language.Mimsa.Syntax
 import Language.Mimsa.Types
   ( Bindings (..),

--- a/src/Language/Mimsa/Store/Resolver.hs
+++ b/src/Language/Mimsa/Store/Resolver.hs
@@ -2,9 +2,11 @@
 
 module Language.Mimsa.Store.Resolver where
 
+import qualified Data.Map as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)
+import Language.Mimsa.Syntax
 --
 --
 -- this takes the expression, works out what it needs from it's environment
@@ -26,10 +28,17 @@ extractVars (MyLambda newVar a) = S.delete newVar (extractVars a)
 extractVars (MyApp a b) = extractVars a <> extractVars b
 extractVars _ = mempty
 
+findHashInBindings :: Bindings -> Name -> Either Text ExprHash
+findHashInBindings (Bindings bindings') name = case M.lookup name bindings' of
+  Just a -> Right a
+  _ -> Left $ "A binding for " <> prettyPrint name <> " could not be found"
+
 -- given an expression, and the current environment, create a
 -- store expression that captures the hashes of the functions we'll need
-createStoreExpression :: StoreEnv -> Expr -> Either Text StoreExpression
-createStoreExpression _ (MyInt a) = Right (StoreExpression mempty (MyInt a))
-createStoreExpression _ (MyBool a) = Right (StoreExpression mempty (MyBool a))
-createStoreExpression _ (MyString a) = Right (StoreExpression mempty (MyString a))
-createStoreExpression _ _ = Left "Not implemented yet"
+createStoreExpression :: Bindings -> Expr -> Either Text StoreExpression
+createStoreExpression bindings' expr = do
+  let findHash name =
+        (,) <$> pure name
+          <*> findHashInBindings bindings' name
+  hashes <- traverse findHash (S.toList . extractVars $ expr)
+  Right (StoreExpression (M.fromList hashes) expr)

--- a/src/Language/Mimsa/Store/Resolver.hs
+++ b/src/Language/Mimsa/Store/Resolver.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Store.Resolver where
+
+import Data.Set (Set)
+import qualified Data.Set as S
+import Data.Text (Text)
+--
+--
+-- this takes the expression, works out what it needs from it's environment
+-- and wraps that up
+-- this would be a good place for a simplifying step in future
+-- by replacing all variables internally with a1, a2 etc, we'll get less
+-- repetition, ie \x -> x and \y -> y will be the same function and thus hash
+
+import Language.Mimsa.Types
+
+-- important - we must not count variables brought in via lambdas, as those
+-- aren't external deps
+
+extractVars :: Expr -> Set Name
+extractVars (MyVar a) = S.singleton a
+extractVars (MyIf a b c) = extractVars a <> extractVars b <> extractVars c
+extractVars (MyLet newVar a b) = S.delete newVar (extractVars a <> extractVars b)
+extractVars (MyLambda newVar a) = S.delete newVar (extractVars a)
+extractVars (MyApp a b) = extractVars a <> extractVars b
+extractVars _ = mempty
+
+-- given an expression, and the current environment, create a
+-- store expression that captures the hashes of the functions we'll need
+createStoreExpression :: StoreEnv -> Expr -> Either Text StoreExpression
+createStoreExpression _ (MyInt a) = Right (StoreExpression mempty (MyInt a))
+createStoreExpression _ (MyBool a) = Right (StoreExpression mempty (MyBool a))
+createStoreExpression _ (MyString a) = Right (StoreExpression mempty (MyString a))
+createStoreExpression _ _ = Left "Not implemented yet"

--- a/src/Language/Mimsa/Store/Resolver.hs
+++ b/src/Language/Mimsa/Store/Resolver.hs
@@ -41,4 +41,4 @@ createStoreExpression bindings' expr = do
         (,) <$> pure name
           <*> findHashInBindings bindings' name
   hashes <- traverse findHash (S.toList . extractVars $ expr)
-  Right (StoreExpression (M.fromList hashes) expr)
+  Right (StoreExpression (Bindings (M.fromList hashes)) expr)

--- a/src/Language/Mimsa/Store/Substitutor.hs
+++ b/src/Language/Mimsa/Store/Substitutor.hs
@@ -1,0 +1,21 @@
+module Language.Mimsa.Store.Substitutor where
+
+import Control.Monad.Trans.State.Lazy
+import Data.Text (Text)
+import Language.Mimsa.Types
+
+-- this turns StoreExpressions back into expressions by substituting their
+-- variables for the deps passed in
+--
+-- like the typechecker, as we go though, we replace the varibable names with
+-- var0, var1, var2 etc so we don't have to care about scoping or collisions
+--
+-- we'll also store what our substitutions were for errors sake
+
+type Swaps = [(Name, Name)]
+
+type App = StateT Swaps (Either Text)
+
+substitute :: Store -> StoreExpression -> Either Text (Swaps, StoreExpression, Store)
+substitute _store' (StoreExpression _bindings' _expr') = do
+  pure undefined

--- a/src/Language/Mimsa/Syntax/Printer.hs
+++ b/src/Language/Mimsa/Syntax/Printer.hs
@@ -23,6 +23,9 @@ instance Printer Name where
 instance Printer StringType where
   prettyPrint (StringType s) = s
 
+instance Printer ExprHash where
+  prettyPrint (ExprHash a) = T.pack . show $ a
+
 instance Printer Expr where
   prettyPrint (MyInt i) = T.pack (show i)
   prettyPrint (MyBool True) = "True"

--- a/src/Language/Mimsa/Types.hs
+++ b/src/Language/Mimsa/Types.hs
@@ -17,6 +17,7 @@ where
 
 import qualified Data.Aeson as JSON
 import qualified Data.Map as M
+import GHC.Generics
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Name
 
@@ -60,4 +61,5 @@ data StoreExpression
       { storeBindings :: Bindings,
         storeExpression :: Expr
       }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
+  deriving (JSON.ToJSON, JSON.FromJSON)

--- a/src/Language/Mimsa/Types.hs
+++ b/src/Language/Mimsa/Types.hs
@@ -38,9 +38,14 @@ instance Semigroup StoreEnv where
 
 instance Monoid StoreEnv where
   mempty = StoreEnv mempty mempty
+
 --------
 
 -- a storeExpression contains the AST Expr
 -- and a map of names to hashes with further functions inside
 -- not sure whether to store the builtins we need here too?
--- data StoreExpression = StoreExpression
+data StoreExpression
+  = StoreExpression
+      { bindings :: Map Name ExprHash,
+        expression :: Expr
+      }

--- a/src/Language/Mimsa/Types.hs
+++ b/src/Language/Mimsa/Types.hs
@@ -7,6 +7,7 @@
 module Language.Mimsa.Types
   ( ExprHash (..),
     StoreEnv (..),
+    StoreExpression (..),
     module Language.Mimsa.Types.Name,
     module Language.Mimsa.Types.AST,
   )
@@ -46,6 +47,7 @@ instance Monoid StoreEnv where
 -- not sure whether to store the builtins we need here too?
 data StoreExpression
   = StoreExpression
-      { bindings :: Map Name ExprHash,
-        expression :: Expr
+      { storeBindings :: M.Map Name ExprHash,
+        storeExpression :: Expr
       }
+  deriving (Eq, Ord, Show)

--- a/src/Language/Mimsa/Types.hs
+++ b/src/Language/Mimsa/Types.hs
@@ -46,7 +46,7 @@ instance Monoid StoreEnv where
 --------
 
 -- store is where we keep the big map of hashes to expresions
-newtype Store = Store {getStore :: M.Map ExprHash Expr}
+newtype Store = Store {getStore :: M.Map ExprHash StoreExpression}
   deriving newtype (Eq, Ord, Show, Semigroup, Monoid)
 
 -- a list of names to hashes

--- a/src/Language/Mimsa/Types.hs
+++ b/src/Language/Mimsa/Types.hs
@@ -7,6 +7,8 @@
 module Language.Mimsa.Types
   ( ExprHash (..),
     StoreEnv (..),
+    Bindings (..),
+    Store (..),
     StoreExpression (..),
     module Language.Mimsa.Types.Name,
     module Language.Mimsa.Types.AST,
@@ -30,8 +32,8 @@ newtype ExprHash = ExprHash Int
 -- and a list of mappings of names to those pieces
 data StoreEnv
   = StoreEnv
-      { items :: M.Map ExprHash Expr,
-        bindings :: M.Map Name ExprHash
+      { store :: Store,
+        bindings :: Bindings
       }
 
 instance Semigroup StoreEnv where
@@ -41,6 +43,14 @@ instance Monoid StoreEnv where
   mempty = StoreEnv mempty mempty
 
 --------
+
+-- store is where we keep the big map of hashes to expresions
+newtype Store = Store {getStore :: M.Map ExprHash Expr}
+  deriving newtype (Eq, Ord, Show, Semigroup, Monoid)
+
+-- a list of names to hashes
+newtype Bindings = Bindings {getBindings :: M.Map Name ExprHash}
+  deriving newtype (Eq, Ord, Show, Semigroup, Monoid, JSON.FromJSON, JSON.ToJSON)
 
 -- a storeExpression contains the AST Expr
 -- and a map of names to hashes with further functions inside

--- a/src/Language/Mimsa/Types.hs
+++ b/src/Language/Mimsa/Types.hs
@@ -8,6 +8,7 @@ module Language.Mimsa.Types
   ( ExprHash (..),
     StoreEnv (..),
     Bindings (..),
+    Scope (..),
     Store (..),
     StoreExpression (..),
     module Language.Mimsa.Types.Name,
@@ -36,6 +37,7 @@ data StoreEnv
       { store :: Store,
         bindings :: Bindings
       }
+  deriving (Eq, Ord, Show)
 
 instance Semigroup StoreEnv where
   StoreEnv a a' <> StoreEnv b b' = StoreEnv (a <> b) (a' <> b')
@@ -52,6 +54,10 @@ newtype Store = Store {getStore :: M.Map ExprHash StoreExpression}
 -- a list of names to hashes
 newtype Bindings = Bindings {getBindings :: M.Map Name ExprHash}
   deriving newtype (Eq, Ord, Show, Semigroup, Monoid, JSON.FromJSON, JSON.ToJSON)
+
+-- dependencies resolved into actual expressions
+newtype Scope = Scope {getScope :: M.Map Name Expr}
+  deriving newtype (Eq, Ord, Show, Semigroup, Monoid)
 
 -- a storeExpression contains the AST Expr
 -- and a map of names to hashes with further functions inside

--- a/src/Language/Mimsa/Types.hs
+++ b/src/Language/Mimsa/Types.hs
@@ -57,7 +57,7 @@ newtype Bindings = Bindings {getBindings :: M.Map Name ExprHash}
 -- not sure whether to store the builtins we need here too?
 data StoreExpression
   = StoreExpression
-      { storeBindings :: M.Map Name ExprHash,
+      { storeBindings :: Bindings,
         storeExpression :: Expr
       }
   deriving (Eq, Ord, Show)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -10,6 +10,7 @@ import Language.Mimsa
 import Test.Hspec
 import qualified Test.Interpreter as Interpreter
 import Test.QuickCheck.Instances ()
+import qualified Test.Resolver as Resolver
 import qualified Test.Syntax as Syntax
 
 charListToText :: [Char] -> Text
@@ -84,6 +85,7 @@ main :: IO ()
 main = hspec $ do
   Syntax.spec
   Interpreter.spec
+  Resolver.spec
   describe "Typechecker" $ do
     it "Our expressions typecheck as expected" $ do
       _ <- traverse (\(code, expected) -> startInference code `shouldBe` expected) exprs

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,6 +11,7 @@ import Test.Hspec
 import qualified Test.Interpreter as Interpreter
 import Test.QuickCheck.Instances ()
 import qualified Test.Resolver as Resolver
+import qualified Test.Substitutor as Substitutor
 import qualified Test.Syntax as Syntax
 
 charListToText :: [Char] -> Text
@@ -86,6 +87,7 @@ main = hspec $ do
   Syntax.spec
   Interpreter.spec
   Resolver.spec
+  Substitutor.spec
   describe "Typechecker" $ do
     it "Our expressions typecheck as expected" $ do
       _ <- traverse (\(code, expected) -> startInference code `shouldBe` expected) exprs

--- a/test/Test/Interpreter.hs
+++ b/test/Test/Interpreter.hs
@@ -15,18 +15,18 @@ spec = do
   describe "Interpreter" $ do
     describe "Literals" $ do
       it "Booleans" $ do
-        interpret (MyBool True) `shouldBe` Right (MyBool True)
-        interpret (MyBool False) `shouldBe` Right (MyBool False)
+        interpret mempty (MyBool True) `shouldBe` Right (MyBool True)
+        interpret mempty (MyBool False) `shouldBe` Right (MyBool False)
       it "Integers" $ do
-        interpret (MyInt (-100)) `shouldBe` Right (MyInt (-100))
-        interpret (MyInt 100) `shouldBe` Right (MyInt 100)
+        interpret mempty (MyInt (-100)) `shouldBe` Right (MyInt (-100))
+        interpret mempty (MyInt 100) `shouldBe` Right (MyInt 100)
       it "Strings" $ do
-        interpret (MyString (StringType "")) `shouldBe` Right (MyString (StringType ""))
-        interpret (MyString (StringType "poo")) `shouldBe` Right (MyString (StringType "poo"))
+        interpret mempty (MyString (StringType "")) `shouldBe` Right (MyString (StringType ""))
+        interpret mempty (MyString (StringType "poo")) `shouldBe` Right (MyString (StringType "poo"))
     describe "Let and Var" $ do
       it "let x = 1 in 1" $ do
         let f = (MyLet (mkName "x") (MyInt 1) (MyVar (mkName "x")))
-        interpret f `shouldBe` Right (MyInt 1)
+        interpret mempty f `shouldBe` Right (MyInt 1)
     describe "Lambda and App" $ do
       it "let id = \\x -> x in (id 1)" $ do
         let f =
@@ -35,11 +35,19 @@ spec = do
                   (MyLambda (mkName "x") (MyVar (mkName "x")))
                   (MyApp (MyVar (mkName "id")) (MyInt 1))
               )
-        interpret f `shouldBe` Right (MyInt 1)
+        interpret mempty f `shouldBe` Right (MyInt 1)
+      it "let const = \\a -> \b -> a in ((const 1) 2)" $ do
+        let f =
+              ( MyLet
+                  (mkName "const")
+                  (MyLambda (mkName "a") (MyLambda (mkName "b") (MyVar (Name "a"))))
+                  (MyApp (MyApp (MyVar (Name "const")) (MyInt 1)) (MyInt 2))
+              )
+        interpret mempty f `shouldBe` Right (MyInt 1)
     describe "If" $ do
       it "Blows up when passed a non-bool" $ do
         let f = (MyIf (MyInt 1) (MyBool True) (MyBool False))
-        interpret f `shouldBe` Left "Predicate for If must be a Boolean"
+        interpret mempty f `shouldBe` Left "Predicate for If must be a Boolean"
       it "if True then 1 else 2" $ do
         let f = (MyIf (MyBool True) (MyInt 1) (MyInt 2))
-        interpret f `shouldBe` Right (MyInt 1)
+        interpret mempty f `shouldBe` Right (MyInt 1)

--- a/test/Test/Interpreter.hs
+++ b/test/Test/Interpreter.hs
@@ -36,7 +36,15 @@ spec = do
                   (MyApp (MyVar (mkName "id")) (MyInt 1))
               )
         interpret mempty f `shouldBe` Right (MyInt 1)
-      it "let const = \\a -> \b -> a in ((const 1) 2)" $ do
+      it "let const = \\a -> \\b -> a in (const 1)" $ do
+        let f =
+              ( MyLet
+                  (mkName "const")
+                  (MyLambda (mkName "a") (MyLambda (mkName "b") (MyVar (Name "a"))))
+                  (MyApp (MyVar (Name "const")) (MyInt 1))
+              )
+        interpret mempty f `shouldBe` Right (MyLambda (Name "b") (MyVar (Name "a")))
+      it "let const = \\a -> \\b -> a in ((const 1) 2)" $ do
         let f =
               ( MyLet
                   (mkName "const")

--- a/test/Test/Resolver.hs
+++ b/test/Test/Resolver.hs
@@ -6,6 +6,7 @@ module Test.Resolver
   )
 where
 
+import qualified Data.Map as M
 import qualified Data.Set as S
 import Language.Mimsa.Store.Resolver
 import Language.Mimsa.Types
@@ -61,5 +62,20 @@ spec = do
             ( StoreExpression
                 { storeBindings = mempty,
                   storeExpression = MyString (StringType "poo")
+                }
+            )
+      it "Looks for vars and can't find them" $ do
+        createStoreExpression mempty (MyVar (Name "missing"))
+          `shouldBe` Left "A binding for missing could not be found"
+      it "Looks for vars and finds them" $ do
+        let hash = ExprHash 1234
+            expr = MyVar (Name "missing")
+            storeEnv = StoreEnv mempty (M.singleton (Name "missing") hash)
+            storeExpr = createStoreExpression storeEnv expr
+        storeExpr
+          `shouldBe` Right
+            ( StoreExpression
+                { storeBindings = M.singleton (Name "missing") hash,
+                  storeExpression = expr
                 }
             )

--- a/test/Test/Resolver.hs
+++ b/test/Test/Resolver.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.Resolver
+  ( spec,
+  )
+where
+
+import qualified Data.Set as S
+import Language.Mimsa.Store.Resolver
+import Language.Mimsa.Types
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "Resolver" $ do
+    describe "extractVars" $ do
+      it "Finds none where only literals" $ do
+        extractVars (MyBool True) `shouldBe` mempty
+        extractVars (MyInt 1) `shouldBe` mempty
+        extractVars (MyString (StringType "poo")) `shouldBe` mempty
+      it "Finds a var" $ do
+        extractVars (MyVar (Name "dog")) `shouldBe` S.singleton (Name "dog")
+      it "Finds the vars in an if" $ do
+        extractVars
+          ( MyIf
+              (MyVar (Name "one"))
+              (MyVar (Name "two"))
+              (MyVar (Name "three"))
+          )
+          `shouldBe` S.fromList [Name "one", Name "two", Name "three"]
+      it "Does not include var introduced in Let" $ do
+        extractVars
+          ( MyLet
+              (Name "newVar")
+              (MyApp (MyVar (Name "keep")) (MyInt 1))
+              (MyVar (Name "newVar"))
+          )
+          `shouldBe` S.singleton (Name "keep")
+      it "Does not introduce vars introduced in lambda" $ do
+        extractVars (MyLambda (Name "newVar") (MyApp (MyVar (Name "keep")) (MyVar (Name "newVar"))))
+          `shouldBe` S.singleton (Name "keep")
+    describe "createStoreExpression" $ do
+      it "Creates expressions from literals with empty StoreEnv" $ do
+        createStoreExpression mempty (MyInt 1)
+          `shouldBe` Right
+            ( StoreExpression
+                { storeBindings = mempty,
+                  storeExpression = MyInt 1
+                }
+            )
+        createStoreExpression mempty (MyBool True)
+          `shouldBe` Right
+            ( StoreExpression
+                { storeBindings = mempty,
+                  storeExpression = MyBool True
+                }
+            )
+        createStoreExpression mempty (MyString (StringType "poo"))
+          `shouldBe` Right
+            ( StoreExpression
+                { storeBindings = mempty,
+                  storeExpression = MyString (StringType "poo")
+                }
+            )

--- a/test/Test/Resolver.hs
+++ b/test/Test/Resolver.hs
@@ -70,12 +70,12 @@ spec = do
       it "Looks for vars and finds them" $ do
         let hash = ExprHash 1234
             expr = MyVar (Name "missing")
-            storeEnv = StoreEnv mempty (M.singleton (Name "missing") hash)
-            storeExpr = createStoreExpression storeEnv expr
+            bindings' = Bindings $ M.singleton (Name "missing") hash
+            storeExpr = createStoreExpression bindings' expr
         storeExpr
           `shouldBe` Right
             ( StoreExpression
-                { storeBindings = M.singleton (Name "missing") hash,
+                { storeBindings = Bindings $ M.singleton (Name "missing") hash,
                   storeExpression = expr
                 }
             )

--- a/test/Test/Substitutor.hs
+++ b/test/Test/Substitutor.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.Substitutor
+  ( spec,
+  )
+where
+
+-- import qualified Data.Map as M
+import Language.Mimsa.Store.Substitutor (substitute)
+import Language.Mimsa.Types
+import Test.Hspec
+
+trueStoreExpr :: StoreExpression
+trueStoreExpr = StoreExpression mempty (MyBool True)
+
+{-
+falseStoreExpr :: StoreExpression
+falseStoreExpr =
+  StoreExpression
+    (Bindings $ M.singleton (mkName "true") (ExprHash 1))
+    (MyVar (mkName "true"))
+
+storeWithTrueIn :: Store
+storeWithTrueIn = Store (M.singleton (ExprHash 1) trueStoreExpr)
+-}
+
+spec :: Spec
+spec = do
+  describe "Substitutor" $ do
+    describe "No deps, no problem" $ do
+      it "Just unwraps everything" $ do
+        substitute mempty trueStoreExpr `shouldBe` Right (mempty, trueStoreExpr, mempty)
+{-    describe "One level of dep" $ do
+it "Renames the dep to var0" $ do
+  let hash = ExprHash 1
+      expr = MyVar (Name "exciting")
+      bindings' = Bindings $ M.singleton (Name "exciting") hash
+      storeExpr = StoreExpression bindings' expr
+      store' = Store (M.singleton hash trueStoreExpr)
+  substitute store' storeExpr
+    `shouldBe` Right
+      ( [(Name "exciting", Name "var0")],
+        StoreExpression
+          (Bindings $ M.singleton (Name "var0") hash)
+          (MyVar (Name "var0"))
+      )-}
+{-
+describe "Combine two levels" $ do
+  it "Combines trueStoreExpr and falseStoreExpr" $ do
+     -}

--- a/test/Test/Substitutor.hs
+++ b/test/Test/Substitutor.hs
@@ -6,7 +6,7 @@ module Test.Substitutor
   )
 where
 
--- import qualified Data.Map as M
+import qualified Data.Map as M
 import Language.Mimsa.Store.Substitutor (substitute)
 import Language.Mimsa.Types
 import Test.Hspec
@@ -14,38 +14,63 @@ import Test.Hspec
 trueStoreExpr :: StoreExpression
 trueStoreExpr = StoreExpression mempty (MyBool True)
 
-{-
 falseStoreExpr :: StoreExpression
 falseStoreExpr =
   StoreExpression
     (Bindings $ M.singleton (mkName "true") (ExprHash 1))
     (MyVar (mkName "true"))
 
-storeWithTrueIn :: Store
-storeWithTrueIn = Store (M.singleton (ExprHash 1) trueStoreExpr)
--}
+storeWithBothIn :: Store
+storeWithBothIn =
+  Store
+    ( M.fromList
+        [ (ExprHash 1, trueStoreExpr),
+          (ExprHash 2, falseStoreExpr)
+        ]
+    )
 
 spec :: Spec
 spec = do
   describe "Substitutor" $ do
     describe "No deps, no problem" $ do
       it "Just unwraps everything" $ do
-        substitute mempty trueStoreExpr `shouldBe` Right (mempty, trueStoreExpr, mempty)
-{-    describe "One level of dep" $ do
-it "Renames the dep to var0" $ do
-  let hash = ExprHash 1
-      expr = MyVar (Name "exciting")
-      bindings' = Bindings $ M.singleton (Name "exciting") hash
-      storeExpr = StoreExpression bindings' expr
-      store' = Store (M.singleton hash trueStoreExpr)
-  substitute store' storeExpr
-    `shouldBe` Right
-      ( [(Name "exciting", Name "var0")],
-        StoreExpression
-          (Bindings $ M.singleton (Name "var0") hash)
-          (MyVar (Name "var0"))
-      )-}
-{-
-describe "Combine two levels" $ do
-  it "Combines trueStoreExpr and falseStoreExpr" $ do
-     -}
+        substitute mempty trueStoreExpr `shouldBe` Right (mempty, (storeExpression trueStoreExpr), mempty)
+    describe "Leaves lambda variable alone" $ do
+      it "Leaves x unchanged" $ do
+        let expr = MyLambda (mkName "x") (MyVar (mkName "x"))
+        substitute mempty (StoreExpression mempty expr)
+          `shouldBe` Right (mempty, expr, mempty)
+    describe "One level of dep" $ do
+      it "Renames the dep to var0" $ do
+        let hash = ExprHash 1
+            expr = MyVar (Name "exciting")
+            bindings' = Bindings $ M.singleton (Name "exciting") hash
+            storeExpr = StoreExpression bindings' expr
+            store' = Store (M.singleton hash trueStoreExpr)
+        substitute store' storeExpr
+          `shouldBe` Right
+            ( M.singleton (Name "var0") (Name "exciting"),
+              (MyVar (Name "var0")),
+              Scope (M.singleton (Name "var0") (storeExpression trueStoreExpr))
+            )
+  describe "Combine two levels" $ do
+    it "Combines trueStoreExpr and falseStoreExpr" $ do
+      let hash = ExprHash 2
+          expr = MyVar (mkName "true")
+          bindings' = Bindings (M.singleton (mkName "true") hash)
+          storeExpr = StoreExpression bindings' expr
+          store' = storeWithBothIn
+      substitute store' storeExpr
+        `shouldBe` Right
+          ( M.fromList
+              [ (Name "var0", Name "true"),
+                (Name "var1", Name "true")
+              ],
+            MyVar (mkName "var0"),
+            Scope
+              ( M.fromList
+                  [ (Name "var1", MyBool True),
+                    (Name "var0", MyVar (mkName "var1"))
+                  ]
+              )
+          )


### PR DESCRIPTION
Instead of storing `Expr`, store `StoreExpression`s which are a pair of the Expr and a `Map Name Hash` between it's deps and their hashes. When evaluating, replace all variables with numbered ones so we don't get confusion between them.