### PR TITLE
Unify literals

### DIFF
--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6f8c3ef9e2c1d655ba04a1797b5fc1721b210f440a86fd345cfe9df4507c0d4a
+-- hash: 9a489241eb1d968ab6ee86c3c3d11816412a6084dac4e9d5387cde63fcbd8b2e
 
 name:           mimsa
 version:        0.1.0.0
@@ -85,6 +85,7 @@ test-suite mimsa-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Test.Helpers
       Test.Interpreter
       Test.Resolver
       Test.Substitutor

--- a/src/Language/Mimsa/Interpreter.hs
+++ b/src/Language/Mimsa/Interpreter.hs
@@ -23,9 +23,7 @@ interpret scope' expr =
 type App = StateT Scope (Either Text)
 
 interpretWithScope :: Expr -> App Expr
-interpretWithScope (MyBool a) = pure $ MyBool a
-interpretWithScope (MyInt a) = pure $ MyInt a
-interpretWithScope (MyString a) = pure $ MyString a
+interpretWithScope (MyLiteral a) = pure $ MyLiteral a
 interpretWithScope (MyLet binder expr body) = do
   modify ((<>) (Scope $ M.singleton binder expr))
   interpretWithScope body
@@ -45,17 +43,14 @@ interpretWithScope (MyApp (MyApp a b) c) = do
 interpretWithScope (MyApp (MyLet a b c) d) = do
   expr <- interpretWithScope (MyLet a b c)
   interpretWithScope (MyApp expr d)
-interpretWithScope (MyApp (MyBool _) _) = throwError "Cannot apply a value to a boolean"
-interpretWithScope (MyApp (MyInt _) _) = throwError "Cannot apply a value to an integer"
-interpretWithScope (MyApp (MyString _) _) = throwError "Cannot apply a value to a string"
+interpretWithScope (MyApp (MyLiteral _) _) = throwError "Cannot apply a value to a literal value"
 interpretWithScope (MyApp (MyIf _ _ _) _) = throwError "Cannot apply a value to an if"
 interpretWithScope (MyLambda a b) = pure (MyLambda a b)
-interpretWithScope (MyIf (MyBool pred') true false) =
+interpretWithScope (MyIf (MyLiteral (MyBool pred')) true false) =
   if pred'
     then interpretWithScope true
     else interpretWithScope false
-interpretWithScope (MyIf (MyString _) _ _) = throwError "Predicate for If must be a Boolean"
-interpretWithScope (MyIf (MyInt _) _ _) = throwError "Predicate for If must be a Boolean"
+interpretWithScope (MyIf (MyLiteral _) _ _) = throwError "Predicate for If must be a Boolean"
 interpretWithScope (MyIf (MyLambda _ _) _ _) = throwError "Predicate for If must be a Boolean"
 interpretWithScope (MyIf pred' true false) = do
   predExpr <- interpretWithScope pred'

--- a/src/Language/Mimsa/Syntax/Language.hs
+++ b/src/Language/Mimsa/Syntax/Language.hs
@@ -18,6 +18,7 @@ import Language.Mimsa.Syntax.Parser (Parser)
 import qualified Language.Mimsa.Syntax.Parser as P
 import Language.Mimsa.Types
   ( Expr (..),
+    Literal (..),
     Name,
     StringType (..),
     mkName,
@@ -74,20 +75,20 @@ boolParser :: Parser Expr
 boolParser = trueParser <|> falseParser
 
 trueParser :: Parser Expr
-trueParser = P.literal "True" $> MyBool True
+trueParser = P.literal "True" $> MyLiteral (MyBool True)
 
 falseParser :: Parser Expr
-falseParser = P.literal "False" $> MyBool False
+falseParser = P.literal "False" $> MyLiteral (MyBool False)
 
 -----
 
 intParser :: Parser Expr
-intParser = MyInt <$> P.integer
+intParser = MyLiteral <$> MyInt <$> P.integer
 
 -----
 
 stringParser :: Parser Expr
-stringParser = (MyString . StringType) <$> (P.between '"')
+stringParser = (MyLiteral . MyString . StringType) <$> (P.between '"')
 
 -----
 

--- a/src/Language/Mimsa/Syntax/Printer.hs
+++ b/src/Language/Mimsa/Syntax/Printer.hs
@@ -26,11 +26,14 @@ instance Printer StringType where
 instance Printer ExprHash where
   prettyPrint (ExprHash a) = T.pack . show $ a
 
-instance Printer Expr where
+instance Printer Literal where
   prettyPrint (MyInt i) = T.pack (show i)
   prettyPrint (MyBool True) = "True"
   prettyPrint (MyBool False) = "False"
   prettyPrint (MyString str) = "\"" <> prettyPrint str <> "\""
+
+instance Printer Expr where
+  prettyPrint (MyLiteral l) = prettyPrint l
   prettyPrint (MyVar var) = prettyPrint var
   prettyPrint (MyLet var expr1 expr2) =
     "let " <> prettyPrint var

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -26,10 +26,13 @@ doInference env expr =
   where
     either' = runStateT (infer env expr) M.empty
 
+inferLiteral :: Literal -> App MonoType
+inferLiteral (MyInt _) = pure MTInt
+inferLiteral (MyBool _) = pure MTBool
+inferLiteral (MyString _) = pure MTString
+
 infer :: Environment -> Expr -> App MonoType
-infer _ (MyInt _) = pure MTInt
-infer _ (MyBool _) = pure MTBool
-infer _ (MyString _) = pure MTString
+infer _ (MyLiteral a) = inferLiteral a
 infer env (MyVar name) = case M.lookup name env of
   Just a -> pure a
   _ -> throwError $ T.pack ("Unknown variable " <> show name)

--- a/src/Language/Mimsa/Types/AST.hs
+++ b/src/Language/Mimsa/Types/AST.hs
@@ -6,6 +6,7 @@
 
 module Language.Mimsa.Types.AST
   ( Expr (..),
+    Literal (..),
     MonoType (..),
     StringType (..),
     UniVar (..),
@@ -26,10 +27,14 @@ newtype UniVar = UniVar Int
   deriving stock (Eq, Ord, Generic)
   deriving newtype (Show, Num)
 
-data Expr
+data Literal
   = MyInt Int
   | MyBool Bool
   | MyString StringType
+  deriving (Eq, Ord, Show, Generic, JSON.FromJSON, JSON.ToJSON)
+
+data Expr
+  = MyLiteral Literal
   | MyVar Name
   | MyLet Name Expr Expr -- binder, expr, body
   | MyLambda Name Expr -- binder, body

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -7,6 +7,7 @@ module Main where
 import Data.Text (Text)
 import qualified Data.Text as T
 import Language.Mimsa
+import Test.Helpers
 import Test.Hspec
 import qualified Test.Interpreter as Interpreter
 import Test.QuickCheck.Instances ()
@@ -19,28 +20,28 @@ charListToText = foldr T.cons ""
 
 exprs :: [(Expr, Either Text MonoType)]
 exprs =
-  [ (MyInt 1, Right MTInt),
-    (MyBool True, Right MTBool),
-    ( MyString
+  [ (int 1, Right MTInt),
+    (bool True, Right MTBool),
+    ( str
         (StringType "hello"),
       Right MTString
     ),
     (MyVar (mkName "x"), Left "Unknown variable \"x\""),
-    (MyLet (mkName "x") (MyInt 42) (MyBool True), Right MTBool),
-    (MyLet (mkName "x") (MyInt 42) (MyVar (mkName "x")), Right MTInt),
+    (MyLet (mkName "x") (int 42) (bool True), Right MTBool),
+    (MyLet (mkName "x") (int 42) (MyVar (mkName "x")), Right MTInt),
     ( MyLet
         (mkName "x")
-        (MyBool True)
-        (MyLet (mkName "y") (MyInt 42) (MyVar (mkName "x"))),
+        (bool True)
+        (MyLet (mkName "y") (int 42) (MyVar (mkName "x"))),
       Right MTBool
     ),
     ( MyLet
         (mkName "x")
-        (MyBool True)
-        (MyLet (mkName "x") (MyInt 42) (MyVar (mkName "x"))),
+        (bool True)
+        (MyLet (mkName "x") (int 42) (MyVar (mkName "x"))),
       Right MTInt
     ),
-    ( MyLambda (mkName "x") (MyBool True),
+    ( MyLambda (mkName "x") (bool True),
       Right $ MTFunction (MTUnknown (UniVar 1)) MTBool
     ),
     ( identity,
@@ -55,23 +56,23 @@ exprs =
     ( MyApp
         ( MyLambda
             (mkName "x")
-            (MyBool True)
+            (bool True)
         )
-        (MyInt 1),
+        (int 1),
       Right MTBool
     ),
     ( MyApp
         identity
-        (MyInt 1),
+        (int 1),
       Right MTInt
     ),
     ( MyApp
         ( MyLambda
             (mkName "x")
-            ( (MyIf (MyVar (mkName "x")) (MyInt 10) (MyInt 10))
+            ( (MyIf (MyVar (mkName "x")) (int 10) (int 10))
             )
         )
-        (MyInt 100),
+        (int 100),
       Left "Can't match MTBool with MTInt"
     ),
     ( MyLambda (mkName "x") (MyApp (MyVar (mkName "x")) (MyVar (mkName "x"))),
@@ -93,8 +94,8 @@ main = hspec $ do
       _ <- traverse (\(code, expected) -> startInference code `shouldBe` expected) exprs
       pure ()
     it "We can use identity with two different datatypes in one expression" $ do
-      let lambda = (MyLambda (mkName "x") (MyIf (MyApp identity (MyVar (mkName "x"))) (MyApp identity (MyInt 1)) (MyApp identity (MyInt 2))))
-      let expr = MyApp lambda (MyBool True)
+      let lambda = (MyLambda (mkName "x") (MyIf (MyApp identity (MyVar (mkName "x"))) (MyApp identity (int 1)) (MyApp identity (int 2))))
+      let expr = MyApp lambda (bool True)
       (startInference lambda) `shouldBe` Right (MTFunction (MTUnknown 1) MTInt)
       (startInference expr) `shouldBe` Right MTInt
 {-  describe "Serialisation" $ do

--- a/test/Test/Helpers.hs
+++ b/test/Test/Helpers.hs
@@ -1,0 +1,12 @@
+module Test.Helpers where
+
+import Language.Mimsa.Types
+
+bool :: Bool -> Expr
+bool a = MyLiteral (MyBool a)
+
+int :: Int -> Expr
+int a = MyLiteral (MyInt a)
+
+str :: StringType -> Expr
+str a = MyLiteral (MyString a)

--- a/test/Test/Interpreter.hs
+++ b/test/Test/Interpreter.hs
@@ -8,6 +8,7 @@ where
 
 import Language.Mimsa.Interpreter (interpret)
 import Language.Mimsa.Types
+import Test.Helpers
 import Test.Hspec
 
 spec :: Spec
@@ -15,33 +16,33 @@ spec = do
   describe "Interpreter" $ do
     describe "Literals" $ do
       it "Booleans" $ do
-        interpret mempty (MyBool True) `shouldBe` Right (MyBool True)
-        interpret mempty (MyBool False) `shouldBe` Right (MyBool False)
+        interpret mempty (bool True) `shouldBe` Right (bool True)
+        interpret mempty (bool False) `shouldBe` Right (bool False)
       it "Integers" $ do
-        interpret mempty (MyInt (-100)) `shouldBe` Right (MyInt (-100))
-        interpret mempty (MyInt 100) `shouldBe` Right (MyInt 100)
+        interpret mempty (int (-100)) `shouldBe` Right (int (-100))
+        interpret mempty (int 100) `shouldBe` Right (int 100)
       it "Strings" $ do
-        interpret mempty (MyString (StringType "")) `shouldBe` Right (MyString (StringType ""))
-        interpret mempty (MyString (StringType "poo")) `shouldBe` Right (MyString (StringType "poo"))
+        interpret mempty (str (StringType "")) `shouldBe` Right (str (StringType ""))
+        interpret mempty (str (StringType "poo")) `shouldBe` Right (str (StringType "poo"))
     describe "Let and Var" $ do
       it "let x = 1 in 1" $ do
-        let f = (MyLet (mkName "x") (MyInt 1) (MyVar (mkName "x")))
-        interpret mempty f `shouldBe` Right (MyInt 1)
+        let f = (MyLet (mkName "x") (int 1) (MyVar (mkName "x")))
+        interpret mempty f `shouldBe` Right (int 1)
     describe "Lambda and App" $ do
       it "let id = \\x -> x in (id 1)" $ do
         let f =
               ( MyLet
                   (mkName "id")
                   (MyLambda (mkName "x") (MyVar (mkName "x")))
-                  (MyApp (MyVar (mkName "id")) (MyInt 1))
+                  (MyApp (MyVar (mkName "id")) (int 1))
               )
-        interpret mempty f `shouldBe` Right (MyInt 1)
+        interpret mempty f `shouldBe` Right (int 1)
       it "let const = \\a -> \\b -> a in (const 1)" $ do
         let f =
               ( MyLet
                   (mkName "const")
                   (MyLambda (mkName "a") (MyLambda (mkName "b") (MyVar (Name "a"))))
-                  (MyApp (MyVar (Name "const")) (MyInt 1))
+                  (MyApp (MyVar (Name "const")) (int 1))
               )
         interpret mempty f `shouldBe` Right (MyLambda (Name "b") (MyVar (Name "a")))
       it "let const = \\a -> \\b -> a in ((const 1) 2)" $ do
@@ -49,13 +50,13 @@ spec = do
               ( MyLet
                   (mkName "const")
                   (MyLambda (mkName "a") (MyLambda (mkName "b") (MyVar (Name "a"))))
-                  (MyApp (MyApp (MyVar (Name "const")) (MyInt 1)) (MyInt 2))
+                  (MyApp (MyApp (MyVar (Name "const")) (int 1)) (int 2))
               )
-        interpret mempty f `shouldBe` Right (MyInt 1)
+        interpret mempty f `shouldBe` Right (int 1)
     describe "If" $ do
       it "Blows up when passed a non-bool" $ do
-        let f = (MyIf (MyInt 1) (MyBool True) (MyBool False))
+        let f = (MyIf (int 1) (bool True) (bool False))
         interpret mempty f `shouldBe` Left "Predicate for If must be a Boolean"
       it "if True then 1 else 2" $ do
-        let f = (MyIf (MyBool True) (MyInt 1) (MyInt 2))
-        interpret mempty f `shouldBe` Right (MyInt 1)
+        let f = (MyIf (bool True) (int 1) (int 2))
+        interpret mempty f `shouldBe` Right (int 1)

--- a/test/Test/Resolver.hs
+++ b/test/Test/Resolver.hs
@@ -10,6 +10,7 @@ import qualified Data.Map as M
 import qualified Data.Set as S
 import Language.Mimsa.Store.Resolver
 import Language.Mimsa.Types
+import Test.Helpers
 import Test.Hspec
 
 spec :: Spec
@@ -17,9 +18,9 @@ spec = do
   describe "Resolver" $ do
     describe "extractVars" $ do
       it "Finds none where only literals" $ do
-        extractVars (MyBool True) `shouldBe` mempty
-        extractVars (MyInt 1) `shouldBe` mempty
-        extractVars (MyString (StringType "poo")) `shouldBe` mempty
+        extractVars (bool True) `shouldBe` mempty
+        extractVars (int 1) `shouldBe` mempty
+        extractVars (str (StringType "poo")) `shouldBe` mempty
       it "Finds a var" $ do
         extractVars (MyVar (Name "dog")) `shouldBe` S.singleton (Name "dog")
       it "Finds the vars in an if" $ do
@@ -34,7 +35,7 @@ spec = do
         extractVars
           ( MyLet
               (Name "newVar")
-              (MyApp (MyVar (Name "keep")) (MyInt 1))
+              (MyApp (MyVar (Name "keep")) (int 1))
               (MyVar (Name "newVar"))
           )
           `shouldBe` S.singleton (Name "keep")
@@ -43,25 +44,25 @@ spec = do
           `shouldBe` S.singleton (Name "keep")
     describe "createStoreExpression" $ do
       it "Creates expressions from literals with empty StoreEnv" $ do
-        createStoreExpression mempty (MyInt 1)
+        createStoreExpression mempty (int 1)
           `shouldBe` Right
             ( StoreExpression
                 { storeBindings = mempty,
-                  storeExpression = MyInt 1
+                  storeExpression = int 1
                 }
             )
-        createStoreExpression mempty (MyBool True)
+        createStoreExpression mempty (bool True)
           `shouldBe` Right
             ( StoreExpression
                 { storeBindings = mempty,
-                  storeExpression = MyBool True
+                  storeExpression = bool True
                 }
             )
-        createStoreExpression mempty (MyString (StringType "poo"))
+        createStoreExpression mempty (str (StringType "poo"))
           `shouldBe` Right
             ( StoreExpression
                 { storeBindings = mempty,
-                  storeExpression = MyString (StringType "poo")
+                  storeExpression = str (StringType "poo")
                 }
             )
       it "Looks for vars and can't find them" $ do

--- a/test/Test/Substitutor.hs
+++ b/test/Test/Substitutor.hs
@@ -9,10 +9,11 @@ where
 import qualified Data.Map as M
 import Language.Mimsa.Store.Substitutor (substitute)
 import Language.Mimsa.Types
+import Test.Helpers
 import Test.Hspec
 
 trueStoreExpr :: StoreExpression
-trueStoreExpr = StoreExpression mempty (MyBool True)
+trueStoreExpr = StoreExpression mempty (bool True)
 
 falseStoreExpr :: StoreExpression
 falseStoreExpr =
@@ -69,7 +70,7 @@ spec = do
             MyVar (mkName "var0"),
             Scope
               ( M.fromList
-                  [ (Name "var1", MyBool True),
+                  [ (Name "var1", bool True),
                     (Name "var0", MyVar (mkName "var1"))
                   ]
               )


### PR DESCRIPTION
Take `MyInt` `MyBool` and `MyString` out of the big `Expr` type and hide them in `Literal`.