### PR TITLE
Tuples

### DIFF
--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 44a598bf77dc9f62d06a6914603daab94a781d9777b0f6d1a021fceb01afa064
+-- hash: 5ac09a939ac959d2d3f778f545afb845312f45e4c88d94356fa5a028d03fa409
 
 name:           mimsa
 version:        0.1.0.0
@@ -95,6 +95,7 @@ test-suite mimsa-test
       Test.Resolver
       Test.Substitutor
       Test.Syntax
+      Test.Typechecker
       Paths_mimsa
   hs-source-dirs:
       test

--- a/src/Language/Mimsa/Interpreter.hs
+++ b/src/Language/Mimsa/Interpreter.hs
@@ -85,7 +85,8 @@ unwrapBuiltIn name (TwoArgs _ _) = do
     )
 
 interpretWithScope :: Expr -> App Expr
-interpretWithScope (MyLiteral a) = pure $ MyLiteral a
+interpretWithScope (MyLiteral a) = pure (MyLiteral a)
+interpretWithScope (MyPair a b) = pure (MyPair a b)
 interpretWithScope (MyLet binder expr body) = do
   modify ((<>) (Scope $ M.singleton binder expr))
   interpretWithScope body
@@ -105,6 +106,7 @@ interpretWithScope (MyApp (MyLet a b c) d) = do
   interpretWithScope (MyApp expr d)
 interpretWithScope (MyApp (MyLiteral _) _) = throwError "Cannot apply a value to a literal value"
 interpretWithScope (MyApp (MyIf _ _ _) _) = throwError "Cannot apply a value to an if"
+interpretWithScope (MyApp (MyPair _ _) _) = throwError "Cannot apply a value to a Pair"
 interpretWithScope (MyLambda a b) = pure (MyLambda a b)
 interpretWithScope (MyIf (MyLiteral (MyBool pred')) true false) =
   if pred'

--- a/src/Language/Mimsa/Interpreter.hs
+++ b/src/Language/Mimsa/Interpreter.hs
@@ -94,6 +94,9 @@ interpretWithScope (MyLetPair binderA binderB (MyPair a b) body) = do
   let newScopes = Scope $ M.fromList [(binderA, a), (binderB, b)]
   modify ((<>) newScopes)
   interpretWithScope body
+interpretWithScope (MyLetPair binderA binderB (MyVar v) body) = do
+  expr <- interpretWithScope (MyVar v)
+  interpretWithScope (MyLetPair binderA binderB expr body)
 interpretWithScope (MyLetPair _ _ a _) =
   throwError $ "Cannot destructure value " <> prettyPrint a <> " as a pair"
 interpretWithScope (MyVar name) =

--- a/src/Language/Mimsa/Syntax/Language.hs
+++ b/src/Language/Mimsa/Syntax/Language.hs
@@ -39,8 +39,8 @@ parseExpr' input = snd <$> P.runParser expressionParser input
 expressionParser :: Parser Expr
 expressionParser =
   literalParser
-    <|> complexParser
     <|> varParser
+    <|> complexParser
 
 literalParser :: Parser Expr
 literalParser =
@@ -55,6 +55,7 @@ complexParser =
         ( letParser
             <|> ifParser
             <|> lambdaParser
+            <|> pairParser
         )
    in (P.between2 '(' ')' (parsers <|> appParser)) <|> parsers
 
@@ -160,3 +161,10 @@ thenParser = P.right (P.thenSpace (P.literal "then")) expressionParser
 
 elseParser :: Parser Expr
 elseParser = P.right (P.thenSpace (P.literal "else")) expressionParser
+
+-----
+
+pairParser :: Parser Expr
+pairParser =
+  MyPair <$> (P.right (P.literal "(") expressionParser)
+    <*> P.left (P.right (P.thenSpace (P.literal ",")) expressionParser) (P.literal ")")

--- a/src/Language/Mimsa/Syntax/Language.hs
+++ b/src/Language/Mimsa/Syntax/Language.hs
@@ -114,17 +114,14 @@ nameParser =
 -----
 
 letParser :: Parser Expr
-letParser = MyLet <$> binderParser <*> equalsParser <*> inParser
-
-binderParser :: Parser Name
-binderParser = P.right (P.thenSpace (P.literal "let")) (P.thenSpace nameParser)
-
-equalsParser :: Parser Expr
-equalsParser =
-  P.right (P.thenSpace (P.literal "=")) (P.thenSpace expressionParser)
-
-inParser :: Parser Expr
-inParser = P.right (P.thenSpace (P.literal "in")) expressionParser
+letParser = do
+  _ <- P.thenSpace (P.literal "let")
+  name <- P.thenSpace nameParser
+  _ <- P.thenSpace (P.literal "=")
+  expr <- P.thenSpace expressionParser
+  _ <- P.thenSpace (P.literal "in")
+  inExpr <- expressionParser
+  pure (MyLet name expr inExpr)
 
 -----
 
@@ -145,6 +142,13 @@ letPairParser = MyLetPair <$> binder1 <*> binder2 <*> equalsParser <*> inParser
       _ <- P.space0
       _ <- P.thenSpace (P.literal ")")
       pure name
+
+equalsParser :: Parser Expr
+equalsParser =
+  P.right (P.thenSpace (P.literal "=")) (P.thenSpace expressionParser)
+
+inParser :: Parser Expr
+inParser = P.right (P.thenSpace (P.literal "in")) expressionParser
 
 -----
 

--- a/src/Language/Mimsa/Syntax/Printer.hs
+++ b/src/Language/Mimsa/Syntax/Printer.hs
@@ -6,6 +6,7 @@ module Language.Mimsa.Syntax.Printer
   )
 where
 
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import Language.Mimsa.Types
@@ -16,6 +17,9 @@ class Printer a where
 
   default prettyPrint :: (Show a) => a -> Text
   prettyPrint = T.pack . show
+
+instance (Printer a) => Printer (S.Set a) where
+  prettyPrint as = foldr (\a as' -> prettyPrint a <> ", " <> as') "" as
 
 instance Printer Name where
   prettyPrint = getName
@@ -98,4 +102,4 @@ instance Printer MonoType where
   prettyPrint MTUnit = "Unit"
   prettyPrint (MTFunction a b) = prettyPrint a <> " -> " <> prettyPrint b
   prettyPrint (MTPair a b) = "(" <> prettyPrint a <> ", " <> prettyPrint b <> ")"
-  prettyPrint (MTUnknown a) = "U" <> prettyPrint a
+  prettyPrint (MTVar a) = "U" <> prettyPrint a

--- a/src/Language/Mimsa/Syntax/Printer.hs
+++ b/src/Language/Mimsa/Syntax/Printer.hs
@@ -45,6 +45,12 @@ instance Printer Expr where
       <> printSubExpr expr1
       <> " in "
       <> printSubExpr expr2
+  prettyPrint (MyLetPair var1 var2 expr1 body) =
+    "let (" <> prettyPrint var1 <> ", " <> prettyPrint var2
+      <> ") = "
+      <> printSubExpr expr1
+      <> " in "
+      <> printSubExpr body
   prettyPrint (MyLambda binder expr) =
     "\\"
       <> prettyPrint binder

--- a/src/Language/Mimsa/Syntax/Printer.hs
+++ b/src/Language/Mimsa/Syntax/Printer.hs
@@ -61,6 +61,12 @@ instance Printer Expr where
       <> printSubExpr then'
       <> " else "
       <> printSubExpr else'
+  prettyPrint (MyPair a b) =
+    "("
+      <> printSubExpr a
+      <> ", "
+      <> printSubExpr b
+      <> ")"
 
 inParens :: Expr -> Text
 inParens a = "(" <> prettyPrint a <> ")"
@@ -85,4 +91,5 @@ instance Printer MonoType where
   prettyPrint MTBool = "Boolean"
   prettyPrint MTUnit = "Unit"
   prettyPrint (MTFunction a b) = prettyPrint a <> " -> " <> prettyPrint b
+  prettyPrint (MTPair a b) = "(" <> prettyPrint a <> ", " <> prettyPrint b <> ")"
   prettyPrint (MTUnknown a) = "U" <> prettyPrint a

--- a/src/Language/Mimsa/Syntax/Printer.hs
+++ b/src/Language/Mimsa/Syntax/Printer.hs
@@ -102,4 +102,4 @@ instance Printer MonoType where
   prettyPrint MTUnit = "Unit"
   prettyPrint (MTFunction a b) = prettyPrint a <> " -> " <> prettyPrint b
   prettyPrint (MTPair a b) = "(" <> prettyPrint a <> ", " <> prettyPrint b <> ")"
-  prettyPrint (MTVar a) = "U" <> prettyPrint a
+  prettyPrint (MTVar a) = prettyPrint a

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -73,6 +73,10 @@ infer env (MyIf condition thenCase elseCase) = do
   _ <- unify tyCond MTBool
   _ <- unify tyThen tyElse
   pure tyThen
+infer env (MyPair a b) = do
+  tyA <- infer env a
+  tyB <- infer env b
+  pure (MTPair tyA tyB)
 
 getUniVars :: MonoType -> [UniVar] -> [UniVar]
 getUniVars (MTFunction argument result) as = (getUniVars argument as) ++ (getUniVars result as)

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -54,6 +54,13 @@ infer env (MyLet binder expr body) = do
   tyExpr <- infer env expr
   let newEnv = M.insert binder tyExpr env
   infer newEnv body
+infer env (MyLetPair binder1 binder2 expr body) = do
+  tyExpr <- infer env expr
+  case tyExpr of
+    (MTPair a b) -> do
+      let newEnv = M.insert binder1 a (M.insert binder2 b env)
+      infer newEnv body
+    a -> throwError $ "Expected a pair but instead found " <> prettyPrint a
 infer env (MyLambda binder body) = do
   tyArg <- getUnknown
   let newEnv = M.insert binder tyArg env

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -10,162 +10,158 @@ where
 
 import Control.Applicative
 import Control.Monad.Except
-import Control.Monad.Trans.State.Lazy
+import Control.Monad.State (State, get, put, runState)
 import qualified Data.Map as M
+import Data.Maybe (fromMaybe)
+import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
-import Debug.Trace
 import Language.Mimsa.Library
 import Language.Mimsa.Syntax
 import Language.Mimsa.Types
 
-type App = StateT Substitutions (Except Text)
+type App = ExceptT Text (State Int)
 
-type Environment = M.Map Name MonoType
+type Environment = M.Map Name Scheme
+
+type Substitutions = M.Map Name MonoType
 
 startInference :: Expr -> Either Text MonoType
-startInference expr = doInference M.empty expr
+startInference expr = snd <$> doInference M.empty expr
 
-doInference :: Environment -> Expr -> Either Text MonoType
+doInference :: Environment -> Expr -> Either Text (Substitutions, MonoType)
 doInference env expr =
-  (fst <$> either')
+  fst either'
   where
-    either' = runExcept $ runStateT (infer env expr) M.empty
+    either' = runState (runExceptT (infer env expr)) 1
 
-inferLiteral :: Literal -> App MonoType
-inferLiteral (MyInt _) = pure MTInt
-inferLiteral (MyBool _) = pure MTBool
-inferLiteral (MyString _) = pure MTString
-inferLiteral (MyUnit) = pure MTUnit
+inferLiteral :: Literal -> App (Substitutions, MonoType)
+inferLiteral (MyInt _) = pure (mempty, MTInt)
+inferLiteral (MyBool _) = pure (mempty, MTBool)
+inferLiteral (MyString _) = pure (mempty, MTString)
+inferLiteral (MyUnit) = pure (mempty, MTUnit)
 
-inferBuiltIn :: Name -> App MonoType
+inferBuiltIn :: Name -> App (Substitutions, MonoType)
 inferBuiltIn name = case getLibraryFunction name of
-  Just ff -> pure $ getFFType ff
+  Just ff -> pure (mempty, getFFType ff)
   _ -> throwError $ "Could not find built-in function " <> prettyPrint name
 
-inferVarFromScope :: Environment -> Name -> App MonoType
-inferVarFromScope env name = case M.lookup name env of
-  Just a -> pure a
-  _ -> throwError $ T.pack ("Unknown variable " <> show name)
+instantiate :: Scheme -> App MonoType
+instantiate (Scheme vars ty) = do
+  newVars <- traverse (const getUnknown) vars
+  let subst = M.fromList (zip vars newVars)
+  pure (applySubst subst ty)
 
-infer :: Environment -> Expr -> App MonoType
+applySubstScheme :: Substitutions -> Scheme -> Scheme
+applySubstScheme subst (Scheme vars t) =
+  -- The fold takes care of name shadowing
+  Scheme vars (applySubst (foldr M.delete subst vars) t)
+
+applySubstCtx :: Substitutions -> Environment -> Environment
+applySubstCtx subst ctx = M.map (applySubstScheme subst) ctx
+
+applySubst :: Substitutions -> MonoType -> MonoType
+applySubst subst ty = case ty of
+  MTVar i ->
+    fromMaybe (MTVar i) (M.lookup i subst)
+  MTFunction arg res ->
+    MTFunction (applySubst subst arg) (applySubst subst res)
+  MTPair a b ->
+    MTPair
+      (applySubst subst a)
+      (applySubst subst b)
+  a -> a
+
+composeSubst :: Substitutions -> Substitutions -> Substitutions
+composeSubst s1 s2 = M.union (M.map (applySubst s1) s2) s1
+
+inferVarFromScope :: Environment -> Name -> App (Substitutions, MonoType)
+inferVarFromScope env name =
+  case M.lookup name env of
+    Just scheme -> do
+      ty <- instantiate scheme
+      pure (mempty, ty)
+    _ -> throwError $ T.pack ("Unknown variable " <> show name)
+
+infer :: Environment -> Expr -> App (Substitutions, MonoType)
 infer _ (MyLiteral a) = inferLiteral a
-infer env (MyVar name) = (inferVarFromScope env name) <|> (inferBuiltIn name)
+infer env (MyVar name) =
+  (inferVarFromScope env name)
+    <|> (inferBuiltIn name)
 infer env (MyLet binder expr body) = do
-  tyExpr <- infer env expr
-  let newEnv = M.insert binder tyExpr env
-  infer newEnv body
-infer env (MyLetPair binder1 binder2 expr body) = do
-  tyExpr <- infer env expr
+  (s1, tyExpr) <- infer env expr
+  let scheme = Scheme [] (applySubst s1 tyExpr)
+  let newEnv = M.insert binder scheme env
+  (s2, tyBody) <- infer (applySubstCtx s1 newEnv) body
+  pure (s2 `composeSubst` s1, tyBody)
+infer env (MyLetPair _binder1 _binder2 expr _body) = do
+  (_s1, tyExpr) <- infer env expr
   case tyExpr of
-    (MTPair a b) -> do
-      _ <- unify tyExpr (MTPair a b)
-      let newEnv = M.insert binder1 a (M.insert binder2 b env)
-      infer newEnv body
-    (MTUnknown i) -> do
-      unknownA <- getUnknown
-      unknownB <- getUnknown
-      _ <- modify (\s -> traceShowId s)
-      let matches =
-            (\name -> (name, MTPair unknownA unknownB))
-              <$> findByUniVar env i
-      let newEnv =
-            ( M.fromList
-                [ (binder1, unknownA),
-                  (binder2, unknownB)
-                ]
-            )
-              <> M.fromList matches
-              <> env
-      infer (traceShowId newEnv) body
     a -> throwError $ "Expected a pair but instead found " <> prettyPrint a
 infer env (MyLambda binder body) = do
-  tyArg <- getUnknown
-  let newEnv = M.insert binder tyArg env
-  tyBody <- infer newEnv body
-  pure $ MTFunction tyArg tyBody
+  tyBinder <- getUnknown
+  let tmpCtx = M.insert binder (Scheme [] tyBinder) env
+  (s1, tyBody) <- infer tmpCtx body
+  pure (s1, MTFunction (applySubst s1 tyBinder) tyBody)
 infer env (MyApp function argument) = do
-  tyArg <- infer env argument
-  tyFun <- infer env function
   tyRes <- getUnknown
-  -- tyFun = tyArg -> tyRes
-  _ <- unify tyFun (MTFunction tyArg tyRes)
-  apply tyRes
+  (s1, tyFun) <- infer env function
+  (s2, tyArg) <- infer (applySubstCtx s1 env) argument
+  s3 <- unify (applySubst s2 tyFun) (MTFunction tyArg tyRes)
+  pure (s3 `composeSubst` s2 `composeSubst` s1, applySubst s3 tyRes)
 infer env (MyIf condition thenCase elseCase) = do
-  tyCond <- infer env condition
-  tyThen <- infer env thenCase
-  tyElse <- infer env elseCase
-  _ <- unify tyCond MTBool
-  _ <- unify tyThen tyElse
-  pure tyThen
+  (s1, tyCond) <- infer env condition
+  (s2, tyThen) <- infer (applySubstCtx s1 env) thenCase
+  (s3, tyElse) <- infer (applySubstCtx s2 env) elseCase
+  s4 <- unify tyCond MTBool
+  s5 <- unify tyThen tyElse
+  pure
+    ( s5 `composeSubst` s4 `composeSubst` s3
+        `composeSubst` s2
+        `composeSubst` s1,
+      tyThen
+    )
 infer env (MyPair a b) = do
-  tyA <- infer env a
-  tyB <- infer env b
-  pure (MTPair tyA tyB)
+  (s1, tyA) <- infer env a
+  (s2, tyB) <- infer (applySubstCtx s1 env) b
+  pure (s2 `composeSubst` s1, MTPair tyA tyB)
 
-findByUniVar :: Environment -> UniVar -> [Name]
-findByUniVar env i = M.keys $ M.filter ((==) (MTUnknown i)) env
+freeTypeVars :: MonoType -> S.Set Name
+freeTypeVars ty = case ty of
+  MTVar var ->
+    S.singleton var
+  MTFunction t1 t2 ->
+    S.union (freeTypeVars t1) (freeTypeVars t2)
+  _ ->
+    S.empty
 
-getUniVars :: MonoType -> [UniVar] -> [UniVar]
-getUniVars (MTFunction argument result) as = (getUniVars argument as) ++ (getUniVars result as)
-getUniVars (MTUnknown a) as = [a] ++ as
-getUniVars _ as = as
+-- | Creates a fresh unification variable and binds it to the given type
+varBind :: Name -> MonoType -> App Substitutions
+varBind var ty
+  | ty == MTVar var = pure mempty
+  | S.member var (freeTypeVars ty) =
+    throwError $
+      prettyPrint var <> " fails occurs check"
+  | otherwise = pure (M.singleton var ty)
 
-unknowns :: MonoType -> [UniVar]
-unknowns mType = getUniVars mType []
-
-unify :: MonoType -> MonoType -> App ()
-unify ty1' ty2' = do
-  ty1 <- apply ty1'
-  ty2 <- apply ty2'
-  unify' ty1 ty2
-
-unify' :: MonoType -> MonoType -> App ()
-unify' a b | a == b = pure ()
-unify' (MTFunction args result) (MTFunction args' result') = do
-  unify args args'
-  unify result result'
-unify' (MTUnknown i) b = do
-  occursCheck i b
-  unifyVariable i b
-unify' a (MTUnknown i) = do
-  occursCheck i a
-  unifyVariable i a
-unify' (MTPair a b) (MTPair a' b') = do
-  unify a a'
-  unify b b'
-unify' a b =
+unify :: MonoType -> MonoType -> App Substitutions
+unify a b | a == b = pure mempty
+unify (MTFunction l r) (MTFunction l' r') = do
+  s1 <- unify l l'
+  s2 <- unify (applySubst s1 r) (applySubst s1 r')
+  pure (s2 `composeSubst` s1)
+unify (MTPair a b) (MTPair a' b') = do
+  s1 <- unify a a'
+  s2 <- unify b b'
+  pure (s2 `composeSubst` s1)
+unify (MTVar u) t = varBind u t
+unify t (MTVar u) = varBind u t
+unify a b =
   throwError $ T.pack $
     "Can't match " <> show a <> " with " <> show b
 
-occursCheck :: UniVar -> MonoType -> App ()
-occursCheck i mt =
-  if (not $ elem i (unknowns mt))
-    then pure ()
-    else
-      throwError $ T.pack $
-        "Cannot unify as " <> show (MTUnknown i) <> " occurs within " <> show mt
-
--- all the Ints we've matched back to types
-type Substitutions = M.Map UniVar (Maybe MonoType)
-
--- replace unknowns with knowns from the substitution list where possible
-apply :: MonoType -> App MonoType
-apply (MTUnknown i) = do
-  sub <- join <$> gets (M.lookup i)
-  case sub of
-    Just mType -> (apply mType)
-    Nothing -> pure (MTUnknown i)
-apply (MTFunction args result) =
-  MTFunction <$> (apply args) <*> (apply result)
-apply (MTPair a b) = MTPair <$> (apply a) <*> (apply b)
-apply other = pure other
-
 getUnknown :: App MonoType
 getUnknown = do
-  nextUniVar <- gets (\subs -> (M.foldlWithKey (\k k' _ -> max k k') 0 subs) + 1)
-  modify (M.insert nextUniVar Nothing)
-  pure (MTUnknown nextUniVar)
-
-unifyVariable :: UniVar -> MonoType -> App ()
-unifyVariable i mType = modify (M.insert i (Just mType))
+  nextUniVar <- get
+  put (nextUniVar + 1)
+  pure (MTVar (mkName $ "U" <> T.pack (show nextUniVar)))

--- a/src/Language/Mimsa/Types/AST.hs
+++ b/src/Language/Mimsa/Types/AST.hs
@@ -44,9 +44,11 @@ data Expr
   = MyLiteral Literal
   | MyVar Name
   | MyLet Name Expr Expr -- binder, expr, body
+      --  | MyLetPair Name Name Expr Expr -- binderA, binderB, expr, body
   | MyLambda Name Expr -- binder, body
   | MyApp Expr Expr -- function, argument
   | MyIf Expr Expr Expr -- expr, thencase, elsecase
+  | MyPair Expr Expr -- (a,b)
   deriving (Eq, Ord, Show, Generic, JSON.FromJSON, JSON.ToJSON)
 
 data MonoType
@@ -55,6 +57,7 @@ data MonoType
   | MTBool
   | MTUnit
   | MTFunction MonoType MonoType -- argument, result
+  | MTPair MonoType MonoType -- (a,b)
   | MTUnknown (UniVar)
   deriving (Eq, Ord, Show)
 

--- a/src/Language/Mimsa/Types/AST.hs
+++ b/src/Language/Mimsa/Types/AST.hs
@@ -12,6 +12,7 @@ module Language.Mimsa.Types.AST
     StringType (..),
     UniVar (..),
     ForeignFunc (..),
+    Scheme (..),
   )
 where
 
@@ -58,8 +59,10 @@ data MonoType
   | MTUnit
   | MTFunction MonoType MonoType -- argument, result
   | MTPair MonoType MonoType -- (a,b)
-  | MTUnknown (UniVar)
+  | MTVar Name
   deriving (Eq, Ord, Show)
+
+data Scheme = Scheme [Name] MonoType
 
 ------
 

--- a/src/Language/Mimsa/Types/AST.hs
+++ b/src/Language/Mimsa/Types/AST.hs
@@ -44,7 +44,7 @@ data Expr
   = MyLiteral Literal
   | MyVar Name
   | MyLet Name Expr Expr -- binder, expr, body
-      --  | MyLetPair Name Name Expr Expr -- binderA, binderB, expr, body
+  | MyLetPair Name Name Expr Expr -- binderA, binderB, expr, body
   | MyLambda Name Expr -- binder, body
   | MyApp Expr Expr -- function, argument
   | MyIf Expr Expr Expr -- expr, thencase, elsecase

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,87 +1,19 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Main where
+module Main
+  ( main,
+  )
+where
 
 -- import qualified Data.Aeson as JSON
-import Data.Text (Text)
-import qualified Data.Text as T
-import Language.Mimsa
-import Test.Helpers
 import Test.Hspec
 import qualified Test.Interpreter as Interpreter
 import Test.QuickCheck.Instances ()
 import qualified Test.Resolver as Resolver
 import qualified Test.Substitutor as Substitutor
 import qualified Test.Syntax as Syntax
-
-charListToText :: [Char] -> Text
-charListToText = foldr T.cons ""
-
-exprs :: [(Expr, Either Text MonoType)]
-exprs =
-  [ (int 1, Right MTInt),
-    (bool True, Right MTBool),
-    ( str
-        (StringType "hello"),
-      Right MTString
-    ),
-    -- (MyVar (mkName "x"), Left "Unknown variable \"x\""),
-    (MyLet (mkName "x") (int 42) (bool True), Right MTBool),
-    (MyLet (mkName "x") (int 42) (MyVar (mkName "x")), Right MTInt),
-    ( MyLet
-        (mkName "x")
-        (bool True)
-        (MyLet (mkName "y") (int 42) (MyVar (mkName "x"))),
-      Right MTBool
-    ),
-    ( MyLet
-        (mkName "x")
-        (bool True)
-        (MyLet (mkName "x") (int 42) (MyVar (mkName "x"))),
-      Right MTInt
-    ),
-    ( MyLambda (mkName "x") (bool True),
-      Right $ MTFunction (MTUnknown (UniVar 1)) MTBool
-    ),
-    ( identity,
-      Right $ MTFunction (MTUnknown (UniVar 1)) (MTUnknown (UniVar 1))
-    ),
-    ( MyLambda (mkName "x") (MyLambda (mkName "y") (MyVar (mkName "x"))),
-      Right $
-        MTFunction
-          (MTUnknown (UniVar 1))
-          (MTFunction (MTUnknown (UniVar 2)) (MTUnknown (UniVar 1)))
-    ),
-    ( MyApp
-        ( MyLambda
-            (mkName "x")
-            (bool True)
-        )
-        (int 1),
-      Right MTBool
-    ),
-    ( MyApp
-        identity
-        (int 1),
-      Right MTInt
-    ),
-    ( MyApp
-        ( MyLambda
-            (mkName "x")
-            ( (MyIf (MyVar (mkName "x")) (int 10) (int 10))
-            )
-        )
-        (int 100),
-      Left "Can't match MTBool with MTInt"
-    ),
-    ( MyLambda (mkName "x") (MyApp (MyVar (mkName "x")) (MyVar (mkName "x"))),
-      Left "Cannot unify as MTUnknown 1 occurs within MTFunction (MTUnknown 1) (MTUnknown 2)"
-    )
-  ]
-
-identity :: Expr
-identity = (MyLambda (mkName "x") (MyVar (mkName "x")))
+import qualified Test.Typechecker as Typechecker
 
 main :: IO ()
 main = hspec $ do
@@ -89,16 +21,4 @@ main = hspec $ do
   Interpreter.spec
   Resolver.spec
   Substitutor.spec
-  describe "Typechecker" $ do
-    it "Our expressions typecheck as expected" $ do
-      _ <- traverse (\(code, expected) -> startInference code `shouldBe` expected) exprs
-      pure ()
-    it "We can use identity with two different datatypes in one expression" $ do
-      let lambda = (MyLambda (mkName "x") (MyIf (MyApp identity (MyVar (mkName "x"))) (MyApp identity (int 1)) (MyApp identity (int 2))))
-      let expr = MyApp lambda (bool True)
-      (startInference lambda) `shouldBe` Right (MTFunction (MTUnknown 1) MTInt)
-      (startInference expr) `shouldBe` Right MTInt
-{-  describe "Serialisation" $ do
-it "Round trip" $ do
-  property $ \x -> JSON.decode (JSON.encode x) == (Just x :: Maybe Expr)
--}
+  Typechecker.spec

--- a/test/Test/Helpers.hs
+++ b/test/Test/Helpers.hs
@@ -10,3 +10,8 @@ int a = MyLiteral (MyInt a)
 
 str :: StringType -> Expr
 str a = MyLiteral (MyString a)
+
+--
+--
+unknown :: Int -> MonoType
+unknown i = MTUnknown (UniVar i)

--- a/test/Test/Helpers.hs
+++ b/test/Test/Helpers.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Test.Helpers where
 
+import qualified Data.Text as T
 import Language.Mimsa.Types
 
 bool :: Bool -> Expr
@@ -12,6 +15,5 @@ str :: StringType -> Expr
 str a = MyLiteral (MyString a)
 
 --
---
 unknown :: Int -> MonoType
-unknown i = MTUnknown (UniVar i)
+unknown i = MTVar (mkName $ "U" <> (T.pack (show i)))

--- a/test/Test/Interpreter.hs
+++ b/test/Test/Interpreter.hs
@@ -123,7 +123,15 @@ spec = do
         let f =
               ( MyLet
                   (mkName "fst")
-                  (MyLambda (mkName "tuple") (MyLetPair (mkName "a") (mkName "b") (MyVar (mkName "tuple")) (MyVar (mkName "a"))))
+                  ( MyLambda
+                      (mkName "tuple")
+                      ( MyLetPair
+                          (mkName "a")
+                          (mkName "b")
+                          (MyVar (mkName "tuple"))
+                          (MyVar (mkName "a"))
+                      )
+                  )
                   ( MyLet
                       (mkName "x")
                       (MyPair (int 1) (int 2))

--- a/test/Test/Interpreter.hs
+++ b/test/Test/Interpreter.hs
@@ -119,6 +119,19 @@ spec = do
             scope' = mempty
         result <- interpret scope' f
         result `shouldBe` Right (int 0)
+      it "Destructures a pair" $ do
+        let f =
+              ( MyLet
+                  (mkName "fst")
+                  (MyLambda (mkName "tuple") (MyLetPair (mkName "a") (mkName "b") (MyVar (mkName "tuple")) (MyVar (mkName "a"))))
+                  ( MyLet
+                      (mkName "x")
+                      (MyPair (int 1) (int 2))
+                      (MyApp (MyVar (mkName "fst")) (MyVar (mkName "x")))
+                  )
+              )
+        result <- interpret mempty f
+        result `shouldBe` Right (int 1)
       it "Uses var names in lambdas that conflict with the ones inside our built-in function without breaking" $ do
         let ifFunc =
               MyLambda

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -143,6 +143,8 @@ spec = do
     it "Recognises an if statement with lots of whitespace" $ do
       let expected = MyIf (bool True) (int 1) (int 2)
       parseExpr "if   True    then    1    else    2" `shouldBe` Right expected
+    it "Parses a pair of things" $ do
+      parseExpr "(2, 2)" `shouldBe` Right (MyPair (int 2) (int 2))
   describe "Expression" $ do
     it "Printing and parsing is an iso" $ do
       property $ \(WellTypedExpr x) -> do

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -145,6 +145,26 @@ spec = do
       parseExpr "if   True    then    1    else    2" `shouldBe` Right expected
     it "Parses a pair of things" $ do
       parseExpr "(2, 2)" `shouldBe` Right (MyPair (int 2) (int 2))
+    it "Parses a pair of things with silly whitespace" $ do
+      parseExpr "(     2    ,   2     )" `shouldBe` Right (MyPair (int 2) (int 2))
+    it "Parses a destructuring of pairs" $ do
+      parseExpr' "let (a,b) = ((True,1)) in a"
+        `shouldBe` Right
+          ( MyLetPair
+              (mkName "a")
+              (mkName "b")
+              (MyPair (bool True) (int 1))
+              (MyVar (mkName "a"))
+          )
+    it "Parses a destructuring of pairs with silly whitespace" $ do
+      parseExpr' "let   (    a ,      b ) =    ((       True, 1) ) in a"
+        `shouldBe` Right
+          ( MyLetPair
+              (mkName "a")
+              (mkName "b")
+              (MyPair (bool True) (int 1))
+              (MyVar (mkName "a"))
+          )
   describe "Expression" $ do
     it "Printing and parsing is an iso" $ do
       property $ \(WellTypedExpr x) -> do

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -130,10 +130,23 @@ spec = do
         `shouldBe` Right (MyLambda (mkName "x") (MyVar (mkName "x")))
     it "Recognises function application in parens" $ do
       parseExpr "(add 1)"
-        `shouldBe` Right (MyApp (MyVar (mkName "add")) (int 1))
+        `shouldBe` Right
+          ( MyApp
+              ( MyVar (mkName "add")
+              )
+              (int 1)
+          )
     it "Recognises double function application onto a var" $ do
       parseExpr "((add 1) 2)"
-        `shouldBe` Right (MyApp (MyApp (MyVar (mkName "add")) (int 1)) (int 2))
+        `shouldBe` Right
+          ( MyApp
+              ( MyApp
+                  ( MyVar (mkName "add")
+                  )
+                  (int 1)
+              )
+              (int 2)
+          )
     it "Recognises an if statement" $ do
       let expected = MyIf (bool True) (int 1) (int 2)
       parseExpr' "if True then 1 else 2" `shouldBe` Right expected
@@ -144,9 +157,29 @@ spec = do
       let expected = MyIf (bool True) (int 1) (int 2)
       parseExpr "if   True    then    1    else    2" `shouldBe` Right expected
     it "Parses a pair of things" $ do
-      parseExpr "(2, 2)" `shouldBe` Right (MyPair (int 2) (int 2))
+      parseExpr "(2, 2)"
+        `shouldBe` Right
+          (MyPair (int 2) (int 2))
     it "Parses a pair of things with silly whitespace" $ do
-      parseExpr "(     2    ,   2     )" `shouldBe` Right (MyPair (int 2) (int 2))
+      parseExpr "(     2    ,   2     )"
+        `shouldBe` Right
+          (MyPair (int 2) (int 2))
+    it "Allows a let to use a pair" $ do
+      parseExpr "let x = ((1,2)) in x"
+        `shouldBe` Right
+          ( MyLet
+              (mkName "x")
+              (MyPair (int 1) (int 2))
+              (MyVar (mkName "x"))
+          )
+    it "Allows a let to use a pair and apply to it" $ do
+      parseExpr "let x = ((1,2)) in (fst x)"
+        `shouldBe` Right
+          ( MyLet
+              (mkName "x")
+              (MyPair (int 1) (int 2))
+              (MyApp (MyVar (mkName "fst")) (MyVar (mkName "x")))
+          )
     it "Parses a destructuring of pairs" $ do
       parseExpr' "let (a,b) = ((True,1)) in a"
         `shouldBe` Right

--- a/test/Test/Typechecker.hs
+++ b/test/Test/Typechecker.hs
@@ -76,6 +76,16 @@ exprs =
     (MyPair (int 1) (bool True), Right (MTPair MTInt MTBool)),
     ( MyLetPair (mkName "a") (mkName "b") (MyPair (int 1) (bool True)) (MyVar (mkName "a")),
       Right MTInt
+    ),
+    ( MyLambda
+        (mkName "x")
+        ( MyLetPair
+            (mkName "a")
+            (mkName "b")
+            (MyVar (mkName "x"))
+            (MyVar (mkName "a"))
+        ),
+      Right (MTFunction (MTPair (unknown 1) (unknown 2)) (unknown 1))
     )
   ]
 

--- a/test/Test/Typechecker.hs
+++ b/test/Test/Typechecker.hs
@@ -73,7 +73,10 @@ exprs =
     ( MyLambda (mkName "x") (MyApp (MyVar (mkName "x")) (MyVar (mkName "x"))),
       Left "Cannot unify as MTUnknown 1 occurs within MTFunction (MTUnknown 1) (MTUnknown 2)"
     ),
-    (MyPair (int 1) (bool True), Right (MTPair MTInt MTBool))
+    (MyPair (int 1) (bool True), Right (MTPair MTInt MTBool)),
+    ( MyLetPair (mkName "a") (mkName "b") (MyPair (int 1) (bool True)) (MyVar (mkName "a")),
+      Right MTInt
+    )
   ]
 
 identity :: Expr

--- a/test/Test/Typechecker.hs
+++ b/test/Test/Typechecker.hs
@@ -37,16 +37,16 @@ exprs =
       Right MTInt
     ),
     ( MyLambda (mkName "x") (bool True),
-      Right $ MTFunction (MTUnknown (UniVar 1)) MTBool
+      Right $ MTFunction (unknown 1) MTBool
     ),
     ( identity,
-      Right $ MTFunction (MTUnknown (UniVar 1)) (MTUnknown (UniVar 1))
+      Right $ MTFunction (unknown 1) (unknown 1)
     ),
     ( MyLambda (mkName "x") (MyLambda (mkName "y") (MyVar (mkName "x"))),
       Right $
         MTFunction
-          (MTUnknown (UniVar 1))
-          (MTFunction (MTUnknown (UniVar 2)) (MTUnknown (UniVar 1)))
+          (unknown 1)
+          (MTFunction (unknown 2) (unknown 1))
     ),
     ( MyApp
         ( MyLambda
@@ -71,7 +71,7 @@ exprs =
       Left "Can't match MTBool with MTInt"
     ),
     ( MyLambda (mkName "x") (MyApp (MyVar (mkName "x")) (MyVar (mkName "x"))),
-      Left "Cannot unify as MTUnknown 1 occurs within MTFunction (MTUnknown 1) (MTUnknown 2)"
+      Left "U1 fails occurs check"
     ),
     (MyPair (int 1) (bool True), Right (MTPair MTInt MTBool)),
     ( MyLetPair (mkName "a") (mkName "b") (MyPair (int 1) (bool True)) (MyVar (mkName "a")),
@@ -99,9 +99,17 @@ spec = do
       _ <- traverse (\(code, expected) -> startInference code `shouldBe` expected) exprs
       pure ()
     it "We can use identity with two different datatypes in one expression" $ do
-      let lambda = (MyLambda (mkName "x") (MyIf (MyApp identity (MyVar (mkName "x"))) (MyApp identity (int 1)) (MyApp identity (int 2))))
+      let lambda =
+            ( MyLambda
+                (mkName "x")
+                ( MyIf
+                    (MyApp identity (MyVar (mkName "x")))
+                    (MyApp identity (int 1))
+                    (MyApp identity (int 2))
+                )
+            )
       let expr = MyApp lambda (bool True)
-      (startInference lambda) `shouldBe` Right (MTFunction (MTUnknown 1) MTInt)
+      (startInference lambda) `shouldBe` Right (MTFunction MTBool MTInt)
       (startInference expr) `shouldBe` Right MTInt
 {-  describe "Serialisation" $ do
 it "Round trip" $ do

--- a/test/Test/Typechecker.hs
+++ b/test/Test/Typechecker.hs
@@ -85,7 +85,17 @@ exprs =
             (MyVar (mkName "x"))
             (MyVar (mkName "a"))
         ),
-      Right (MTFunction (MTPair (unknown 1) (unknown 2)) (unknown 1))
+      Right (MTFunction (MTPair (unknown 2) (unknown 3)) (unknown 2))
+    ),
+    ( MyLet
+        (mkName "fst")
+        (MyLambda (mkName "tuple") (MyLetPair (mkName "a") (mkName "b") (MyVar (mkName "tuple")) (MyVar (mkName "a"))))
+        ( MyLet
+            (mkName "x")
+            (MyPair (int 1) (int 2))
+            (MyApp (MyVar (mkName "fst")) (MyVar (mkName "x")))
+        ),
+      Right MTInt
     )
   ]
 

--- a/test/Test/Typechecker.hs
+++ b/test/Test/Typechecker.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.Typechecker
+  ( spec,
+  )
+where
+
+-- import qualified Data.Aeson as JSON
+import Data.Text (Text)
+import Language.Mimsa
+import Test.Helpers
+import Test.Hspec
+import Test.QuickCheck.Instances ()
+
+exprs :: [(Expr, Either Text MonoType)]
+exprs =
+  [ (int 1, Right MTInt),
+    (bool True, Right MTBool),
+    ( str
+        (StringType "hello"),
+      Right MTString
+    ),
+    -- (MyVar (mkName "x"), Left "Unknown variable \"x\""),
+    (MyLet (mkName "x") (int 42) (bool True), Right MTBool),
+    (MyLet (mkName "x") (int 42) (MyVar (mkName "x")), Right MTInt),
+    ( MyLet
+        (mkName "x")
+        (bool True)
+        (MyLet (mkName "y") (int 42) (MyVar (mkName "x"))),
+      Right MTBool
+    ),
+    ( MyLet
+        (mkName "x")
+        (bool True)
+        (MyLet (mkName "x") (int 42) (MyVar (mkName "x"))),
+      Right MTInt
+    ),
+    ( MyLambda (mkName "x") (bool True),
+      Right $ MTFunction (MTUnknown (UniVar 1)) MTBool
+    ),
+    ( identity,
+      Right $ MTFunction (MTUnknown (UniVar 1)) (MTUnknown (UniVar 1))
+    ),
+    ( MyLambda (mkName "x") (MyLambda (mkName "y") (MyVar (mkName "x"))),
+      Right $
+        MTFunction
+          (MTUnknown (UniVar 1))
+          (MTFunction (MTUnknown (UniVar 2)) (MTUnknown (UniVar 1)))
+    ),
+    ( MyApp
+        ( MyLambda
+            (mkName "x")
+            (bool True)
+        )
+        (int 1),
+      Right MTBool
+    ),
+    ( MyApp
+        identity
+        (int 1),
+      Right MTInt
+    ),
+    ( MyApp
+        ( MyLambda
+            (mkName "x")
+            ( (MyIf (MyVar (mkName "x")) (int 10) (int 10))
+            )
+        )
+        (int 100),
+      Left "Can't match MTBool with MTInt"
+    ),
+    ( MyLambda (mkName "x") (MyApp (MyVar (mkName "x")) (MyVar (mkName "x"))),
+      Left "Cannot unify as MTUnknown 1 occurs within MTFunction (MTUnknown 1) (MTUnknown 2)"
+    ),
+    (MyPair (int 1) (bool True), Right (MTPair MTInt MTBool))
+  ]
+
+identity :: Expr
+identity = (MyLambda (mkName "x") (MyVar (mkName "x")))
+
+spec :: Spec
+spec = do
+  describe "Typechecker" $ do
+    it "Our expressions typecheck as expected" $ do
+      _ <- traverse (\(code, expected) -> startInference code `shouldBe` expected) exprs
+      pure ()
+    it "We can use identity with two different datatypes in one expression" $ do
+      let lambda = (MyLambda (mkName "x") (MyIf (MyApp identity (MyVar (mkName "x"))) (MyApp identity (int 1)) (MyApp identity (int 2))))
+      let expr = MyApp lambda (bool True)
+      (startInference lambda) `shouldBe` Right (MTFunction (MTUnknown 1) MTInt)
+      (startInference expr) `shouldBe` Right MTInt
+{-  describe "Serialisation" $ do
+it "Round trip" $ do
+  property $ \x -> JSON.decode (JSON.encode x) == (Just x :: Maybe Expr)
+-}


### PR DESCRIPTION
Adds support for creating and destructuring tuples.

Allows `fst = \x -> let (a,b) = x in a` and `tuple = \x -> \y -> (x,y)`.

Changed typechecker to pretty much a wholesale steal of https://github.com/kritzcreek/fby19/blob/master/src/Typechecker.hs as was having problems keeping half our findings inside the Monad state and half outside.