### PR TITLE
Function application syntax

### DIFF
--- a/src/Language/Mimsa/Syntax/Language.hs
+++ b/src/Language/Mimsa/Syntax/Language.hs
@@ -37,11 +37,17 @@ parseExpr input = P.runParser expressionParser input
 parseExpr' :: Text -> Either Text Expr
 parseExpr' input = snd <$> P.runParser expressionParser input
 
+failer :: Parser Expr
+failer = P.mkParser (\input -> Left $ "Could not parse expression for: " <> input)
+
 expressionParser :: Parser Expr
 expressionParser =
-  literalParser
-    <|> varParser
-    <|> complexParser
+  let parsers =
+        literalParser
+          <|> varParser
+          <|> complexParser
+   in (P.between2 '(' ')' parsers <|> parsers)
+        <|> failer
 
 literalParser :: Parser Expr
 literalParser =

--- a/src/Language/Mimsa/Syntax/Language.hs
+++ b/src/Language/Mimsa/Syntax/Language.hs
@@ -38,14 +38,14 @@ parseExpr' :: Text -> Either Text Expr
 parseExpr' input = snd <$> P.runParser expressionParser input
 
 failer :: Parser Expr
-failer = P.mkParser (\input -> Left $ "Could not parse expression for: " <> input)
+failer = P.mkParser (\input -> Left $ "Could not parse expression for >>>" <> input <> "<<<")
 
 expressionParser :: Parser Expr
 expressionParser =
   let parsers =
         literalParser
-          <|> varParser
           <|> complexParser
+          <|> varParser
    in (P.between2 '(' ')' parsers <|> parsers)
         <|> failer
 
@@ -58,16 +58,17 @@ literalParser =
 
 complexParser :: Parser Expr
 complexParser =
-  let parsers =
-        ( letPairParser
-            <|> letParser
-            <|> ifParser
-            <|> lambdaParser
-            <|> pairParser
-            <|> sumParser
-            <|> caseParser
-        )
-   in (P.between2 '(' ')' (parsers <|> appParser)) <|> parsers
+  ( letPairParser
+      <|> letParser
+      <|> ifParser
+      <|> lambdaParser
+      <|> pairParser
+      <|> sumParser
+      <|> caseParser
+      <|> appParser3
+      <|> appParser2
+      <|> appParser
+  )
 
 protectedNames :: Set Text
 protectedNames =
@@ -178,13 +179,66 @@ arrowExprBinder = P.right (P.thenSpace (P.literal "->")) expressionParser
 -----
 
 appParser :: Parser Expr
-appParser = MyApp <$> funcParser <*> argParser
+appParser = do
+  func <- varParser <|> lambdaParser
+  _ <- P.space0
+  _ <- (P.literal "(")
+  _ <- P.space0
+  arg <- expressionParser
+  _ <- P.space0
+  _ <- (P.literal ")")
+  _ <- P.space0
+  pure $ MyApp func arg
 
+appParser2 :: Parser Expr
+appParser2 = do
+  func <- varParser <|> lambdaParser
+  _ <- P.space0
+  _ <- (P.literal "(")
+  _ <- P.space0
+  arg <- expressionParser
+  _ <- P.space0
+  _ <- (P.literal ")")
+  _ <- P.space0
+  _ <- (P.literal "(")
+  _ <- P.space0
+  arg2 <- expressionParser
+  _ <- P.space0
+  _ <- (P.literal ")")
+  _ <- P.space0
+  pure $ MyApp (MyApp func arg) arg2
+
+appParser3 :: Parser Expr
+appParser3 = do
+  func <- varParser <|> lambdaParser
+  _ <- P.space0
+  _ <- (P.literal "(")
+  _ <- P.space0
+  arg <- expressionParser
+  _ <- P.space0
+  _ <- (P.literal ")")
+  _ <- P.space0
+  _ <- (P.literal "(")
+  _ <- P.space0
+  arg2 <- expressionParser
+  _ <- P.space0
+  _ <- (P.literal ")")
+  _ <- P.space0
+  _ <- (P.literal "(")
+  _ <- P.space0
+  arg3 <- expressionParser
+  _ <- P.space0
+  _ <- (P.literal ")")
+  _ <- P.space0
+  pure $ MyApp (MyApp (MyApp func arg) arg2) arg3
+
+{-
 funcParser :: Parser Expr
 funcParser = P.thenSpace expressionParser
 
 argParser :: Parser Expr
 argParser = literalParser <|> varParser <|> appParser <|> lambdaParser
+-}
 
 -----
 
@@ -238,12 +292,8 @@ caseParser = do
   sumExpr <- expressionParser
   _ <- P.thenSpace (P.literal "of")
   _ <- P.thenSpace (P.literal "Left")
-  _ <- (P.literal "(")
-  leftExpr <- lambdaParser <|> varParser
-  _ <- P.thenSpace (P.literal ")")
+  leftExpr <- expressionParser
   _ <- P.thenSpace (P.literal "|")
   _ <- P.thenSpace (P.literal "Right")
-  _ <- P.literal "("
-  rightExpr <- lambdaParser <|> varParser
-  _ <- P.literal ")"
+  rightExpr <- expressionParser
   pure (MyCase sumExpr leftExpr rightExpr)

--- a/src/Language/Mimsa/Syntax/Parser.hs
+++ b/src/Language/Mimsa/Syntax/Parser.hs
@@ -167,6 +167,9 @@ between2 char1 char2 parser =
 thenSpace :: Parser a -> Parser a
 thenSpace parser = right space0 (left parser space1)
 
+thenOptionalSpace :: Parser a -> Parser a
+thenOptionalSpace parser = left parser space0
+
 -- recurse, but only once
 leftRec ::
   Parser a ->

--- a/src/Language/Mimsa/Syntax/Printer.hs
+++ b/src/Language/Mimsa/Syntax/Printer.hs
@@ -60,8 +60,22 @@ instance Printer Expr where
       <> prettyPrint binder
       <> " -> "
       <> printSubExpr expr
+  prettyPrint (MyApp (MyApp (MyApp func arg1) arg2) arg3) =
+    printSubExpr func <> "("
+      <> printSubExpr arg1
+      <> ")("
+      <> printSubExpr arg2
+      <> ")("
+      <> printSubExpr arg3
+      <> ")"
+  prettyPrint (MyApp (MyApp func arg1) arg2) =
+    printSubExpr func <> "("
+      <> printSubExpr arg1
+      <> ")("
+      <> printSubExpr arg2
+      <> ")"
   prettyPrint (MyApp func arg) =
-    "(" <> printSubExpr func <> " "
+    printSubExpr func <> "("
       <> printSubExpr arg
       <> ")"
   prettyPrint (MyIf if' then' else') =
@@ -82,13 +96,12 @@ instance Printer Expr where
   prettyPrint (MyCase sumExpr leftFunc rightFunc) =
     "case "
       <> printSubExpr sumExpr
-      <> " of Left ("
+      <> " of Left "
       <> printSubExpr leftFunc
-      <> ") | Right ("
+      <> " | Right "
       <> printSubExpr rightFunc
-      <> ")"
 
-inParens :: Expr -> Text
+inParens :: (Printer a) => a -> Text
 inParens a = "(" <> prettyPrint a <> ")"
 
 -- print simple things with no brackets, and complex things inside brackets
@@ -110,7 +123,13 @@ instance Printer MonoType where
   prettyPrint MTString = "String"
   prettyPrint MTBool = "Boolean"
   prettyPrint MTUnit = "Unit"
-  prettyPrint (MTFunction a b) = prettyPrint a <> " -> " <> prettyPrint b
-  prettyPrint (MTPair a b) = "(" <> prettyPrint a <> ", " <> prettyPrint b <> ")"
+  prettyPrint (MTFunction a b) = printSubType a <> " -> " <> printSubType b
+  prettyPrint (MTPair a b) = "(" <> printSubType a <> ", " <> printSubType b <> ")"
   prettyPrint (MTVar a) = prettyPrint a
-  prettyPrint (MTSum a b) = "Sum " <> prettyPrint a <> " " <> prettyPrint b
+  prettyPrint (MTSum a b) = "Sum " <> printSubType a <> " " <> printSubType b
+
+-- simple things with no brackets, complex things in brackets
+printSubType :: MonoType -> Text
+printSubType all'@(MTSum _ _) = inParens all'
+printSubType all'@(MTFunction _ _) = inParens all'
+printSubType a = prettyPrint a

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -61,7 +61,7 @@ fmapSum = StoreExpression mempty expr
   where
     expr =
       unsafeGetExpr
-        "\\f -> \\a -> case a of Left (\\l -> Left l) | Right (\\r -> Right (f r))"
+        "\\f -> \\a -> case a of Left (\\l -> Left l) | Right (\\r -> Right f(r))"
 
 stdLib :: StoreEnv
 stdLib = StoreEnv store' bindings'
@@ -103,8 +103,8 @@ spec :: Spec
 spec = do
   describe "Repl" $ do
     describe "End to end parsing to evaluation" $ do
-      it "let x = ((1,2)) in (fst x)" $ do
-        result <- eval stdLib "let x = ((1,2)) in (fst x)"
+      it "let x = ((1,2)) in fst(x)" $ do
+        result <- eval stdLib "let x = ((1,2)) in fst(x)"
         result
           `shouldBe` Right
             (MTInt, int 1)
@@ -122,12 +122,12 @@ spec = do
                   )
               )
             )
-      it "case (isTen 9) of Left (\\l -> \"It's not ten\") | Right (\\r -> \"It's ten!\")" $ do
-        result <- eval stdLib "case (isTen 9) of Left (\\l -> \"It's not ten\") | Right (\\r -> \"It's ten!\")"
+      it "case isTen(9) of Left (\\l -> \"It's not ten\") | Right (\\r -> \"It's ten!\")" $ do
+        result <- eval stdLib "case isTen(9) of Left (\\l -> \"It's not ten\") | Right (\\r -> \"It's ten!\")"
         result
           `shouldBe` Right
             (MTString, str' "It's not ten")
-        result2 <- eval stdLib "case (isTen 10) of Left (\\l -> \"It's not ten\") | Right (\\r -> \"It's ten!\")"
+        result2 <- eval stdLib "case isTen(10) of Left (\\l -> \"It's not ten\") | Right (\\r -> \"It's ten!\")"
         result2
           `shouldBe` Right
             (MTString, str' "It's ten!")
@@ -139,8 +139,8 @@ spec = do
               ( MySum MyLeft (int 1)
               )
             )
-      it "\\sum -> case sum of Left (\\l -> Left l) | Right (\\r -> Right (eqTen r))" $ do
-        result <- eval stdLib "\\sum -> case sum of Left (\\l -> Left l) | Right (\\r -> Right (eqTen r))"
+      it "\\sum -> case sum of Left (\\l -> Left l) | Right (\\r -> Right eqTen(r))" $ do
+        result <- eval stdLib "\\sum -> case sum of Left (\\l -> Left l) | Right (\\r -> Right eqTen(r))"
         result
           `shouldBe` Right
             ( MTFunction
@@ -168,7 +168,7 @@ spec = do
               )
             )
       it "let sum = (Left 1) in ((fmapSum eqTen) sum)" $ do
-        result <- eval stdLib "let sum = (Left 1) in ((fmapSum eqTen) sum)"
+        result <- eval stdLib "let sum = (Left 1) in fmapSum (eqTen) (sum)"
         result
           `shouldBe` Right
             (MTSum MTInt MTBool, MySum MyLeft (int 1))

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -131,7 +131,7 @@ spec = do
       parseExpr "(\\x -> x)"
         `shouldBe` Right (MyLambda (mkName "x") (MyVar (mkName "x")))
     it "Recognises function application in parens" $ do
-      parseExpr "(add 1)"
+      parseExpr "add (1)"
         `shouldBe` Right
           ( MyApp
               ( MyVar (mkName "add")
@@ -139,7 +139,7 @@ spec = do
               (int 1)
           )
     it "Recognises double function application onto a var" $ do
-      parseExpr "((add 1) 2)"
+      parseExpr "add (1)(2)"
         `shouldBe` Right
           ( MyApp
               ( MyApp
@@ -175,7 +175,7 @@ spec = do
               (MyVar (mkName "x"))
           )
     it "Allows a let to use a pair and apply to it" $ do
-      parseExpr "let x = ((1,2)) in (fst x)"
+      parseExpr "let x = ((1,2)) in fst(x)"
         `shouldBe` Right
           ( MyLet
               (mkName "x")
@@ -209,7 +209,7 @@ spec = do
               (MyLambda (mkName "r") (bool False))
           )
     it "Parses a case statement with an apply in the sum" $ do
-      parseExpr "case (isTen 9) of Left (\\r -> \"It's not ten\") | Right (\\l -> \"It's ten!\")"
+      parseExpr "case isTen(9) of Left (\\r -> \"It's not ten\") | Right (\\l -> \"It's ten!\")"
         `shouldBe` Right
           ( MyCase
               ( MyApp


### PR DESCRIPTION
Changed from the confusing `((f a) b)` to `f(a)(b)`. Only goes up to 3-arity atm, easy fix though.