### PR TITLE
List

### DIFF
--- a/src/Language/Mimsa/Interpreter.hs
+++ b/src/Language/Mimsa/Interpreter.hs
@@ -130,6 +130,8 @@ interpretWithScope (MyApp (MyLetPair a b c d) e) = do
 interpretWithScope (MySum s a) = do
   expr <- interpretWithScope a
   pure (MySum s expr)
+interpretWithScope (MyList a) = pure (MyList a)
+interpretWithScope (MyApp (MyList _) _) = throwError "Cannot apply a value to a List"
 interpretWithScope (MyApp (MySum MyLeft _) _) = throwError "Cannot apply a value to a Left value"
 interpretWithScope (MyApp (MySum MyRight _) _) = throwError "Cannot apply a value to a Right value"
 interpretWithScope (MyApp (MyLiteral _) _) = throwError "Cannot apply a value to a literal value"

--- a/src/Language/Mimsa/Interpreter.hs
+++ b/src/Language/Mimsa/Interpreter.hs
@@ -87,7 +87,10 @@ unwrapBuiltIn name (TwoArgs _ _) = do
 
 interpretWithScope :: Expr -> App Expr
 interpretWithScope (MyLiteral a) = pure (MyLiteral a)
-interpretWithScope (MyPair a b) = pure (MyPair a b)
+interpretWithScope (MyPair a b) = do
+  exprA <- interpretWithScope a
+  exprB <- interpretWithScope b
+  pure (MyPair exprA exprB)
 interpretWithScope (MyLet binder expr body) = do
   modify ((<>) (Scope $ M.singleton binder expr))
   interpretWithScope body
@@ -147,7 +150,9 @@ interpretWithScope (MySum s a) = do
 interpretWithScope (MyApp (MyLetList a b c d) e) = do
   expr <- interpretWithScope (MyLetList a b c d)
   interpretWithScope (MyApp expr e)
-interpretWithScope (MyList a) = pure (MyList a)
+interpretWithScope (MyList as) = do
+  exprs <- traverse interpretWithScope as
+  pure (MyList exprs)
 interpretWithScope (MyApp (MyList _) _) = throwError "Cannot apply a value to a List"
 interpretWithScope (MyApp (MySum MyLeft _) _) = throwError "Cannot apply a value to a Left value"
 interpretWithScope (MyApp (MySum MyRight _) _) = throwError "Cannot apply a value to a Right value"

--- a/src/Language/Mimsa/Store/Resolver.hs
+++ b/src/Language/Mimsa/Store/Resolver.hs
@@ -33,6 +33,7 @@ extractVars_ (MyApp a b) = extractVars_ a <> extractVars_ b
 extractVars_ (MyLiteral _) = mempty
 extractVars_ (MyCase sum' l r) = extractVars_ sum' <> extractVars_ l <> extractVars_ r
 extractVars_ (MyLetPair newVarA newVarB a b) = S.delete newVarA (S.delete newVarB (extractVars_ a <> extractVars_ b))
+extractVars_ (MyLetList newVarA newVarB a b) = S.delete newVarA (S.delete newVarB (extractVars_ a <> extractVars_ b))
 extractVars_ (MyPair a b) = extractVars_ a <> extractVars_ b
 extractVars_ (MySum _ a) = extractVars_ a
 extractVars_ (MyList as) = foldMap extractVars_ as

--- a/src/Language/Mimsa/Store/Resolver.hs
+++ b/src/Language/Mimsa/Store/Resolver.hs
@@ -35,6 +35,7 @@ extractVars_ (MyCase sum' l r) = extractVars_ sum' <> extractVars_ l <> extractV
 extractVars_ (MyLetPair newVarA newVarB a b) = S.delete newVarA (S.delete newVarB (extractVars_ a <> extractVars_ b))
 extractVars_ (MyPair a b) = extractVars_ a <> extractVars_ b
 extractVars_ (MySum _ a) = extractVars_ a
+extractVars_ (MyList as) = foldMap extractVars_ as
 
 filterBuiltIns :: Set Name -> Set Name
 filterBuiltIns = S.filter (not . isLibraryName)

--- a/src/Language/Mimsa/Store/Substitutor.hs
+++ b/src/Language/Mimsa/Store/Substitutor.hs
@@ -124,4 +124,7 @@ mapVar p (MySum side a) = MySum <$> pure side <*> (mapVar p a)
 mapVar p (MyCase a b c) =
   MyCase <$> (mapVar p a) <*> (mapVar p b)
     <*> (mapVar p c)
+mapVar p (MyList as) = do
+  mas <- traverse (mapVar p) as
+  pure (MyList mas)
 mapVar _ (MyLiteral a) = pure (MyLiteral a)

--- a/src/Language/Mimsa/Store/Substitutor.hs
+++ b/src/Language/Mimsa/Store/Substitutor.hs
@@ -120,6 +120,11 @@ mapVar p (MyLetPair nameA nameB a b) =
     <$> pure nameA <*> pure nameB
       <*> (mapVar (p <> [nameA, nameB]) a)
       <*> (mapVar (p <> [nameA, nameB]) b)
+mapVar p (MyLetList nameHead nameRest a b) =
+  MyLetList <$> pure nameHead
+    <*> pure nameRest
+    <*> (mapVar (p <> [nameHead, nameRest]) a)
+    <*> (mapVar (p <> [nameHead, nameRest]) b)
 mapVar p (MySum side a) = MySum <$> pure side <*> (mapVar p a)
 mapVar p (MyCase a b c) =
   MyCase <$> (mapVar p a) <*> (mapVar p b)

--- a/src/Language/Mimsa/Syntax/Language.hs
+++ b/src/Language/Mimsa/Syntax/Language.hs
@@ -60,6 +60,7 @@ literalParser =
 complexParser :: Parser Expr
 complexParser =
   ( letPairParser
+      <|> letListParser
       <|> letParser
       <|> ifParser
       <|> lambdaParser
@@ -141,6 +142,26 @@ letParser = do
 
 -----
 
+letListParser :: Parser Expr
+letListParser = MyLetList <$> binder1 <*> binder2 <*> equalsParser <*> inParser
+  where
+    binder1 = do
+      _ <- P.thenSpace (P.literal "let")
+      _ <- P.literal "["
+      _ <- P.space0
+      name <- nameParser
+      _ <- P.space0
+      pure name
+    binder2 = do
+      _ <- P.literal ","
+      _ <- P.space0
+      name <- nameParser
+      _ <- P.space0
+      _ <- P.thenSpace (P.literal "]")
+      pure name
+
+-----
+
 letPairParser :: Parser Expr
 letPairParser = MyLetPair <$> binder1 <*> binder2 <*> equalsParser <*> inParser
   where
@@ -158,6 +179,8 @@ letPairParser = MyLetPair <$> binder1 <*> binder2 <*> equalsParser <*> inParser
       _ <- P.space0
       _ <- P.thenSpace (P.literal ")")
       pure name
+
+-----
 
 equalsParser :: Parser Expr
 equalsParser =

--- a/src/Language/Mimsa/Syntax/Language.hs
+++ b/src/Language/Mimsa/Syntax/Language.hs
@@ -10,6 +10,7 @@ where
 
 import Control.Applicative ((<|>))
 import Data.Functor
+import qualified Data.List.NonEmpty as NE
 import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -68,6 +69,7 @@ complexParser =
       <|> appParser3
       <|> appParser2
       <|> appParser
+      <|> listParser
   )
 
 protectedNames :: Set Text
@@ -232,13 +234,18 @@ appParser3 = do
   _ <- P.space0
   pure $ MyApp (MyApp (MyApp func arg) arg2) arg3
 
-{-
-funcParser :: Parser Expr
-funcParser = P.thenSpace expressionParser
+-----
 
-argParser :: Parser Expr
-argParser = literalParser <|> varParser <|> appParser <|> lambdaParser
--}
+listParser :: Parser Expr
+listParser = do
+  _ <- P.literal "["
+  _ <- P.space0
+  args <- P.zeroOrMore (P.left expressionParser (P.literal ","))
+  last' <- expressionParser
+  _ <- P.space0
+  _ <- P.literal "]"
+  _ <- P.space0
+  pure (MyList (NE.fromList (args <> [last'])))
 
 -----
 

--- a/src/Language/Mimsa/Syntax/Printer.hs
+++ b/src/Language/Mimsa/Syntax/Printer.hs
@@ -6,6 +6,7 @@ module Language.Mimsa.Syntax.Printer
   )
 where
 
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -100,6 +101,9 @@ instance Printer Expr where
       <> printSubExpr leftFunc
       <> " | Right "
       <> printSubExpr rightFunc
+  prettyPrint (MyList as) = "[" <> T.intercalate ", " exprs' <> "]"
+    where
+      exprs' = NE.toList $ printSubExpr <$> as
 
 inParens :: (Printer a) => a -> Text
 inParens a = "(" <> prettyPrint a <> ")"
@@ -127,6 +131,7 @@ instance Printer MonoType where
   prettyPrint (MTPair a b) = "(" <> printSubType a <> ", " <> printSubType b <> ")"
   prettyPrint (MTVar a) = prettyPrint a
   prettyPrint (MTSum a b) = "Sum " <> printSubType a <> " " <> printSubType b
+  prettyPrint (MTList a) = "List " <> printSubType a
 
 -- simple things with no brackets, complex things in brackets
 printSubType :: MonoType -> Text

--- a/src/Language/Mimsa/Syntax/Printer.hs
+++ b/src/Language/Mimsa/Syntax/Printer.hs
@@ -143,4 +143,5 @@ instance Printer MonoType where
 printSubType :: MonoType -> Text
 printSubType all'@(MTSum _ _) = inParens all'
 printSubType all'@(MTFunction _ _) = inParens all'
+printSubType all'@(MTList _) = inParens all'
 printSubType a = prettyPrint a

--- a/src/Language/Mimsa/Syntax/Printer.hs
+++ b/src/Language/Mimsa/Syntax/Printer.hs
@@ -56,6 +56,12 @@ instance Printer Expr where
       <> printSubExpr expr1
       <> " in "
       <> printSubExpr body
+  prettyPrint (MyLetList var1 var2 expr body) =
+    "let [" <> prettyPrint var1 <> ", " <> prettyPrint var2
+      <> "] = "
+      <> printSubExpr expr
+      <> " in "
+      <> printSubExpr body
   prettyPrint (MyLambda binder expr) =
     "\\"
       <> prettyPrint binder

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -132,73 +132,56 @@ infer env (MyLet binder expr body) = do
   pure (s2 `composeSubst` s1, tyBody)
 infer env (MyCase sumExpr (MyLambda binderL exprL) (MyLambda binderR exprR)) = do
   (s1, tySum) <- infer env sumExpr
-  case tySum of
-    (MTSum tyA tyB) -> do
-      (s2, tyLeftRes) <- inferFuncReturn env binderL exprL (applySubst s1 tyA)
-      (s3, tyRightRes) <- inferFuncReturn env binderR exprR (applySubst s1 tyB)
-      let subs =
-            s3
-              `composeSubst` s2
-              `composeSubst` s1
-      s4 <- unify tyLeftRes tyRightRes
-      pure (s4 `composeSubst` subs, applySubst (s4 `composeSubst` subs) tyLeftRes)
+  (tyL, tyR) <- case tySum of
+    (MTSum tyL tyR) -> pure (tyL, tyR)
     (MTVar _a) -> do
-      tyVarL <- getUnknown
-      tyVarR <- getUnknown
-      s2 <- unify (MTSum tyVarL tyVarR) tySum
-      (s3, tyLeftRes) <- inferFuncReturn env binderL exprL (applySubst (s2 `composeSubst` s1) tyVarL)
-      (s4, tyRightRes) <- inferFuncReturn env binderR exprR (applySubst (s2 `composeSubst` s1) tyVarR)
-      let subs =
-            s4 `composeSubst` s3
-              `composeSubst` s2
-              `composeSubst` s1
-      s5 <- unify tyLeftRes tyRightRes
-      pure (s5 `composeSubst` subs, applySubst (s5 `composeSubst` subs) tyLeftRes)
+      tyL <- getUnknown
+      tyR <- getUnknown
+      pure (tyL, tyR)
     a -> throwError $ "Expected to case match on a pair but instead found " <> prettyPrint a
+  s2 <- unify (MTSum tyL tyR) tySum
+  (s3, tyLeftRes) <- inferFuncReturn env binderL exprL (applySubst (s2 `composeSubst` s1) tyL)
+  (s4, tyRightRes) <- inferFuncReturn env binderR exprR (applySubst (s2 `composeSubst` s1) tyR)
+  let subs =
+        s4 `composeSubst` s3
+          `composeSubst` s2
+          `composeSubst` s1
+  s5 <- unify tyLeftRes tyRightRes
+  pure (s5 `composeSubst` subs, applySubst (s5 `composeSubst` subs) tyLeftRes)
 infer _env (MyCase _ _ _) = throwError "Arguments to case match must be lambda functions"
 infer env (MyLetPair binder1 binder2 expr body) = do
   (s1, tyExpr) <- infer env expr
-  case tyExpr of
+  (tyA, tyB) <- case tyExpr of
     (MTVar _a) -> do
       tyA <- getUnknown
       tyB <- getUnknown
-      let schemeA = Scheme [] (applySubst s1 tyA)
-          schemeB = Scheme [] (applySubst s1 tyB)
-          newEnv = M.insert binder1 schemeA (M.insert binder2 schemeB env)
-      s2 <- unify tyExpr (MTPair tyA tyB)
-      (s3, tyBody) <- infer (applySubstCtx (s2 `composeSubst` s1) newEnv) body
-      pure (s3 `composeSubst` s2 `composeSubst` s1, tyBody)
-    (MTPair a b) -> do
-      let schemeA = Scheme [] (applySubst s1 a)
-          schemeB = Scheme [] (applySubst s1 b)
-          newEnv = M.insert binder1 schemeA (M.insert binder2 schemeB env)
-      s2 <- unify tyExpr (MTPair a b)
-      (s3, tyBody) <- infer (applySubstCtx (s2 `composeSubst` s1) newEnv) body
-      pure (s3 `composeSubst` s2 `composeSubst` s1, tyBody)
+      pure (tyA, tyB)
+    (MTPair a b) -> pure (a, b)
     a -> throwError $ "Expected a pair but instead found " <> prettyPrint a
+  let schemeA = Scheme [] (applySubst s1 tyA)
+      schemeB = Scheme [] (applySubst s1 tyB)
+      newEnv = M.insert binder1 schemeA (M.insert binder2 schemeB env)
+  s2 <- unify tyExpr (MTPair tyA tyB)
+  (s3, tyBody) <- infer (applySubstCtx (s2 `composeSubst` s1) newEnv) body
+  pure (s3 `composeSubst` s2 `composeSubst` s1, tyBody)
 infer env (MyLetList binder1 binder2 expr body) = do
   (s1, tyExpr) <- infer env expr
-  case tyExpr of
+  (tyHead, tyRest) <- case tyExpr of
     (MTVar _a) -> do
       tyHead <- getUnknown
       tyRest <- getUnknown
-      let schemeHead = Scheme [] (applySubst s1 tyHead)
-          schemeRest = Scheme [] (applySubst s1 tyRest)
-          newEnv = M.insert binder1 schemeHead (M.insert binder2 schemeRest env)
-      s2 <- unify tyExpr (MTList tyHead)
-      s3 <- unify tyRest (MTSum MTUnit (MTList tyHead))
-      (s4, tyBody) <- infer (applySubstCtx (s3 `composeSubst` s2 `composeSubst` s1) newEnv) body
-      pure (s4 `composeSubst` s3 `composeSubst` s2 `composeSubst` s1, tyBody)
+      pure (tyHead, tyRest)
     (MTList tyHead) -> do
       tyRest <- getUnknown
-      let schemeHead = Scheme [] (applySubst s1 tyHead)
-          schemeRest = Scheme [] (applySubst s1 tyRest)
-          newEnv = M.insert binder1 schemeHead (M.insert binder2 schemeRest env)
-      s2 <- unify tyExpr (MTList tyHead)
-      s3 <- unify tyRest (MTSum MTUnit (MTList tyHead))
-      (s4, tyBody) <- infer (applySubstCtx (s3 `composeSubst` s2 `composeSubst` s1) newEnv) body
-      pure (s4 `composeSubst` s3 `composeSubst` s2 `composeSubst` s1, tyBody)
+      pure (tyHead, tyRest)
     a -> throwError $ "Expected a list but instead found " <> prettyPrint a
+  let schemeHead = Scheme [] (applySubst s1 tyHead)
+      schemeRest = Scheme [] (applySubst s1 tyRest)
+      newEnv = M.insert binder1 schemeHead (M.insert binder2 schemeRest env)
+  s2 <- unify tyExpr (MTList tyHead)
+  s3 <- unify tyRest (MTSum MTUnit (MTList tyHead))
+  (s4, tyBody) <- infer (applySubstCtx (s3 `composeSubst` s2 `composeSubst` s1) newEnv) body
+  pure (s4 `composeSubst` s3 `composeSubst` s2 `composeSubst` s1, tyBody)
 infer env (MyLambda binder body) = do
   tyBinder <- getUnknown
   let tmpCtx = M.insert binder (Scheme [] tyBinder) env
@@ -270,6 +253,7 @@ unify (MTSum a b) (MTSum a' b') = do
   s2 <- unify (applySubst s1 b) (applySubst s1 b')
   pure (s2 `composeSubst` s1)
 unify (MTVar u) t = varBind u t
+unify (MTList a) (MTList a') = unify a a'
 unify t (MTVar u) = varBind u t
 unify a b =
   throwError $ T.pack $

--- a/src/Language/Mimsa/Types/AST.hs
+++ b/src/Language/Mimsa/Types/AST.hs
@@ -51,6 +51,7 @@ data Expr
   | MyVar Name
   | MyLet Name Expr Expr -- binder, expr, body
   | MyLetPair Name Name Expr Expr -- binderA, binderB, expr, body
+  | MyLetList Name Name Expr Expr -- binderHead, binderHead, expr, body
   | MyLambda Name Expr -- binder, body
   | MyApp Expr Expr -- function, argument
   | MyIf Expr Expr Expr -- expr, thencase, elsecase

--- a/src/Language/Mimsa/Types/AST.hs
+++ b/src/Language/Mimsa/Types/AST.hs
@@ -18,6 +18,7 @@ module Language.Mimsa.Types.AST
 where
 
 import qualified Data.Aeson as JSON
+import Data.List.NonEmpty
 import Data.Text (Text)
 import GHC.Generics
 import Language.Mimsa.Types.Name
@@ -56,6 +57,7 @@ data Expr
   | MyCase Expr Expr Expr -- sumExpr, leftCase, rightCase
   | MyPair Expr Expr -- (a,b)
   | MySum SumSide Expr -- Left a | Right b
+  | MyList (NonEmpty Expr) -- [a]
   deriving (Eq, Ord, Show, Generic, JSON.FromJSON, JSON.ToJSON)
 
 data MonoType
@@ -66,6 +68,7 @@ data MonoType
   | MTFunction MonoType MonoType -- argument, result
   | MTPair MonoType MonoType -- (a,b)
   | MTSum MonoType MonoType -- a | b
+  | MTList MonoType -- [a]
   | MTVar Name
   deriving (Eq, Ord, Show)
 

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -6,6 +6,7 @@ module Test.Repl
   )
 where
 
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
 import Data.Text (Text)
 import Language.Mimsa.Interpreter
@@ -172,3 +173,14 @@ spec = do
         result
           `shouldBe` Right
             (MTSum MTInt MTBool, MySum MyLeft (int 1))
+      it "let [head, tail] = ([1,2,3]) in head" $ do
+        result <- eval stdLib "let [head, tail] = ([1,2,3]) in head"
+        result
+          `shouldBe` Right (MTInt, int 1)
+      it "let [head, tail] = ([1,2,3]) in tail" $ do
+        result <- eval stdLib "let [head, tail] = ([1,2,3]) in tail"
+        result
+          `shouldBe` Right
+            ( MTSum MTUnit (MTList MTInt),
+              MySum MyRight $ MyList $ NE.fromList [int 2, int 3]
+            )

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -8,6 +8,7 @@ where
 
 import qualified Data.Char as Ch
 import Data.Either (isLeft, isRight)
+import qualified Data.List.NonEmpty as NE
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
@@ -182,6 +183,9 @@ spec = do
               (MyPair (int 1) (int 2))
               (MyApp (MyVar (mkName "fst")) (MyVar (mkName "x")))
           )
+    it "Parses a list" $ do
+      parseExpr "[1,2,3]"
+        `shouldBe` Right (MyList (NE.fromList [int 1, int 2, int 3]))
     it "Parses a destructuring of pairs" $ do
       parseExpr' "let (a,b) = ((True,1)) in a"
         `shouldBe` Right

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -186,6 +186,24 @@ spec = do
     it "Parses a list" $ do
       parseExpr "[1,2,3]"
         `shouldBe` Right (MyList (NE.fromList [int 1, int 2, int 3]))
+    it "Parses a destructuring of a list" $ do
+      parseExpr "let [head, rest] = ([1,2,3]) in head"
+        `shouldBe` Right
+          ( MyLetList
+              (mkName "head")
+              (mkName "rest")
+              (MyList $ NE.fromList [int 1, int 2, int 3])
+              (MyVar (mkName "head"))
+          )
+    it "Parses a destructuring of a list with a var" $ do
+      parseExpr "let [head, rest] = myList in head"
+        `shouldBe` Right
+          ( MyLetList
+              (mkName "head")
+              (mkName "rest")
+              (MyVar (mkName "myList"))
+              (MyVar (mkName "head"))
+          )
     it "Parses a destructuring of pairs" $ do
       parseExpr' "let (a,b) = ((True,1)) in a"
         `shouldBe` Right

--- a/test/Test/Typechecker.hs
+++ b/test/Test/Typechecker.hs
@@ -7,6 +7,7 @@ module Test.Typechecker
 where
 
 -- import qualified Data.Aeson as JSON
+import qualified Data.List.NonEmpty as NE
 import Data.Text (Text)
 import Language.Mimsa
 import Test.Helpers
@@ -118,6 +119,20 @@ exprs =
         (MyLambda (mkName "l") (str' "Left!"))
         (MyLambda (mkName "r") (str' "Right!")),
       Right MTString
+    ),
+    ( MyLetList
+        (mkName "head")
+        (mkName "tail")
+        (MyList $ NE.fromList [int 1])
+        (MyVar (mkName "head")),
+      Right $ MTInt
+    ),
+    ( MyLetList
+        (mkName "head")
+        (mkName "tail")
+        (MyList $ NE.fromList [int 1])
+        (MyVar (mkName "tail")),
+      Right $ (MTSum MTUnit (MTList MTInt))
     )
   ]
 


### PR DESCRIPTION
This PR adds list literals:

`[1,2,3,4] :: List Int`

and destructuring:

`let [head, tail] = ([1,2,3,4]) in (head, tail) ::  (List U2) -> (U2, (Sum Unit (List U2)))`

Lists always have at least one item in them. An empty list of A is represented with `Sum Unit (List A)`. This means we never have a `List of A` that has no `A` in it and we never have a Maybe List that is `Just []` and other madness. This means destructuring, like above, returns `head :: A` and `tail :: Sum Unit (List A)` - that is - a head that is guaranteed to be there, and perhaps another list.

This is probably the most controversial design feature thus far, but YOLO.