### PR TITLE
Add :tree command to repl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ you should then see:
 :info <expr> - get the type of <expr>
 :bind <name> = <expr> - binds <expr> to <name> and saves it in the environment
 :list - show a list of current bindings in the environment
+:tree <expr> - draw a dependency tree for <expr>
+<expr> - Evaluate <expr>, returning it's simplified form and type
 :quit - give up and leave
-<expr> - evaluate <expr>, returning it's simplified form and type
 ```
 
 syntax (incomplete):
@@ -29,6 +30,9 @@ True :: Boolean
 
 :> False
 False :: Boolean
+
+:> Unit
+Unit :: Unit
 
 :> 1
 1 :: Int
@@ -90,4 +94,65 @@ Bound fst to \x -> let (a, b) = x in a :: (U2, U3) -> U2
 
 :> fst((1,"horse"))
 1 :: Int
+```
+
+sums:
+
+sum types are either `left` or `right`.
+
+```haskell
+:> Left 1
+Left 1 :: Sum Int U1
+
+:> Right "dog"
+Right "dog" :: Sum U1 String
+
+:> \a -> if a then Left 1 else Right "dog"
+\a -> (if a then Left 1 else Right "dog") :: Boolean -> (Sum Int String)
+
+:> \sum -> case sum of Left (\l -> Left l) | Right (\r -> Right "horse")
+\sum -> case sum of Left (\l -> Left l) | Right (\r -> Right "horse") :: (Sum U7 U3) -> (Sum U7 String)
+```
+
+lists:
+
+lists are never empty.
+
+```haskell
+:> [1]
+[1] :: List Int
+
+:> [1,2,3,4]
+[1, 2, 3, 4] :: List Int
+
+:> []
+Could not parse expression for >>>[]<<<
+
+:> let [a,b] = ([1,2,3]) in a
+1 :: Int
+
+:> let [a,b] = ([1,2,3]) in b
+Right [2, 3] :: Sum Unit (List Int)
+
+:> let [a,b] = ([1]) in b
+Unit :: Sum Unit (List Int)
+```
+
+records:
+
+```haskell
+:> { a: "Dog", b: 123, c: True }
+{a: "Dog", b: 123, c: True} :: {a: String, b: Int, c: Boolean}
+
+:> let record = ({ a: "Dog", b: 123, c: True }) in record.a
+"Dog" :: String
+
+:> let record = ({ a: "Dog", b: 123, c: True }) in record.b
+123 :: Int
+
+:> let record = ({ a: "Dog", b: 123, c: True }) in record.c
+True :: Boolean
+
+:> \i -> if i.predicate then 1 else 2
+\i -> (if i.predicate then 1 else 2) :: {predicate: Boolean} -> Int
 ```

--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c940c5381ac86d1e01414e3572224c400b5bcd01687dd3c13af8684abae39314
+-- hash: 2d1c4ce15bbd009df729a59bab81c402a20df3feb500a59b4fbcbbc0a2bf72b5
 
 name:           mimsa
 version:        0.1.0.0
@@ -101,10 +101,12 @@ test-suite mimsa-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Test.DepGraph
       Test.Helpers
       Test.Interpreter
       Test.Repl
       Test.Resolver
+      Test.StoreData
       Test.Substitutor
       Test.Syntax
       Test.Typechecker

--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7d93762a9bc04c1e44984975c285761d72fd8c7d5febd1276ae3997734001c5f
+-- hash: c940c5381ac86d1e01414e3572224c400b5bcd01687dd3c13af8684abae39314
 
 name:           mimsa
 version:        0.1.0.0
@@ -35,6 +35,7 @@ library
       Language.Mimsa.Repl.Parser
       Language.Mimsa.Repl.Types
       Language.Mimsa.Store
+      Language.Mimsa.Store.DepGraph
       Language.Mimsa.Store.Resolver
       Language.Mimsa.Store.Storage
       Language.Mimsa.Store.Substitutor

--- a/src/Language/Mimsa/Repl/Parser.hs
+++ b/src/Language/Mimsa/Repl/Parser.hs
@@ -12,6 +12,7 @@ replParser =
     <|> infoParser
     <|> bindParser
     <|> listBindingsParser
+    <|> treeParser
     <|> evalParser
 
 helpParser :: Parser ReplAction
@@ -28,6 +29,9 @@ evalParser :: Parser ReplAction
 evalParser =
   Evaluate
     <$> expressionParser
+
+treeParser :: Parser ReplAction
+treeParser = Tree <$> right (thenSpace (literal ":tree")) expressionParser
 
 bindParser :: Parser ReplAction
 bindParser =

--- a/src/Language/Mimsa/Repl/Types.hs
+++ b/src/Language/Mimsa/Repl/Types.hs
@@ -8,5 +8,6 @@ data ReplAction
   = Help
   | Info Expr
   | Evaluate Expr
+  | Tree Expr
   | Bind Name Expr
   | ListBindings

--- a/src/Language/Mimsa/Store.hs
+++ b/src/Language/Mimsa/Store.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Language.Mimsa.Store
-  ( saveExpr,
-    findExpr,
-    loadEnvironment,
+  ( loadEnvironment,
     loadBoundExpressions,
     saveEnvironment,
+    module Language.Mimsa.Store.Storage,
     module Language.Mimsa.Store.Resolver,
     module Language.Mimsa.Store.Substitutor,
+    module Language.Mimsa.Store.DepGraph,
   )
 where
 
@@ -19,6 +19,7 @@ import qualified Data.Map as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)
+import Language.Mimsa.Store.DepGraph
 import Language.Mimsa.Store.Resolver
 import Language.Mimsa.Store.Storage
 import Language.Mimsa.Store.Substitutor

--- a/src/Language/Mimsa/Store/DepGraph.hs
+++ b/src/Language/Mimsa/Store/DepGraph.hs
@@ -1,0 +1,19 @@
+module Language.Mimsa.Store.DepGraph where
+
+import Data.Map ((!))
+import qualified Data.Map as M
+import Language.Mimsa.Types.Name
+import Language.Mimsa.Types.Store
+
+data DepGraph
+  = Func Name [DepGraph]
+
+createDepGraph :: Name -> Store -> StoreExpression -> DepGraph
+createDepGraph name (Store store') storeExpr' = Func name leaves
+  where
+    leaves =
+      ( \(name', hash) ->
+          createDepGraph name' (Store store') (store' ! hash)
+      )
+        <$> children
+    children = (M.toList . getBindings . storeBindings $ storeExpr')

--- a/src/Language/Mimsa/Store/DepGraph.hs
+++ b/src/Language/Mimsa/Store/DepGraph.hs
@@ -1,16 +1,56 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Language.Mimsa.Store.DepGraph where
 
 import Data.Map ((!))
 import qualified Data.Map as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import Language.Mimsa.Store.Storage
 import Language.Mimsa.Types.Name
+import Language.Mimsa.Types.Printer
 import Language.Mimsa.Types.Store
 
+-----
+
+newtype DepInfo = DepInfo (Name, ExprHash)
+  deriving (Eq, Ord, Show)
+
+instance Printer DepInfo where
+  prettyPrint (DepInfo (name, exprHash)) =
+    "+ " <> prettyPrint name <> "     (" <> prettyPrint exprHash <> ")"
+
+-----
+
 data DepGraph
-  = Func Name [DepGraph]
+  = Func DepInfo [DepGraph]
+  deriving (Eq, Ord, Show)
+
+instance Printer DepGraph where
+  prettyPrint (Func info children) = showFuncLine 0 info children
+
+-----
+
+showFuncLine :: Int -> DepInfo -> [DepGraph] -> Text
+showFuncLine i info children = spaces <> prettyPrint info <> children'
+  where
+    spaces = T.pack (replicate i ' ')
+    children' = case children of
+      [] -> ""
+      (a : as) ->
+        "\n"
+          <> T.intercalate
+            "\n"
+            ( ( \(Func subName subChildren) ->
+                  showFuncLine (i + 2) subName subChildren
+              )
+                <$> (a : as)
+            )
 
 createDepGraph :: Name -> Store -> StoreExpression -> DepGraph
-createDepGraph name (Store store') storeExpr' = Func name leaves
+createDepGraph name (Store store') storeExpr' = Func depInfo leaves
   where
+    depInfo = DepInfo (name, getStoreExpressionHash storeExpr')
     leaves =
       ( \(name', hash) ->
           createDepGraph name' (Store store') (store' ! hash)

--- a/src/Language/Mimsa/Store/Storage.hs
+++ b/src/Language/Mimsa/Store/Storage.hs
@@ -3,6 +3,7 @@
 module Language.Mimsa.Store.Storage
   ( saveExpr,
     findExpr,
+    getStoreExpressionHash,
   )
 where
 
@@ -29,6 +30,9 @@ getHash :: BS.ByteString -> ExprHash
 getHash = ExprHash . Hash.hash
 
 -- the store is where we save all the fucking bullshit
+
+getStoreExpressionHash :: StoreExpression -> ExprHash
+getStoreExpressionHash = getHash . JSON.encode
 
 -- take an expression, save it, return ExprHash
 saveExpr :: StoreExpression -> IO ExprHash

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -7,6 +7,7 @@ module Main
 where
 
 -- import qualified Data.Aeson as JSON
+import qualified Test.DepGraph as DepGraph
 import Test.Hspec
 import qualified Test.Interpreter as Interpreter
 import Test.QuickCheck.Instances ()
@@ -20,6 +21,7 @@ import qualified Test.Unify as Unify
 main :: IO ()
 main = hspec $ do
   Syntax.spec
+  DepGraph.spec
   Interpreter.spec
   Resolver.spec
   Substitutor.spec

--- a/test/Test/DepGraph.hs
+++ b/test/Test/DepGraph.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.DepGraph
+  ( spec,
+  )
+where
+
+import qualified Data.Text.IO as T
+import Language.Mimsa.Store.DepGraph
+import Language.Mimsa.Types
+import Test.Hspec
+import Test.StoreData
+
+spec :: Spec
+spec = do
+  describe "DepGraph" $ do
+    it "list" $ do
+      let result = createDepGraph (mkName "list") (store stdLib) list
+      T.putStrLn (prettyPrint result)
+      True `shouldBe` True

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -7,122 +7,13 @@ module Test.Repl
 where
 
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Map as M
 import Data.Text (Text)
-import qualified Data.Text as T
 import Language.Mimsa.Interpreter
 import Language.Mimsa.Repl
-import Language.Mimsa.Syntax (parseExpr)
 import Language.Mimsa.Types
 import Test.Helpers
 import Test.Hspec
-
-fstExpr :: StoreExpression
-fstExpr =
-  unsafeGetExpr "\\tuple -> let (a,b) = tuple in a"
-
-sndExpr :: StoreExpression
-sndExpr = unsafeGetExpr "\\tuple -> let (a,b) = tuple in b"
-
-isTenExpr :: StoreExpression
-isTenExpr =
-  unsafeGetExpr "\\i -> if eqInt(i)(10) then Right i else Left i"
-
-eqTenExpr :: StoreExpression
-eqTenExpr =
-  unsafeGetExpr "\\i -> eqInt(10)(i)"
-
-fmapSum :: StoreExpression
-fmapSum =
-  unsafeGetExpr
-    "\\f -> \\a -> case a of Left (\\l -> Left l) | Right (\\r -> Right f(r))"
-
-listUncons :: StoreExpression
-listUncons =
-  unsafeGetExpr "\\myList -> let [head,tail] = myList in (head,tail)"
-
-listHead :: StoreExpression
-listHead =
-  unsafeGetExpr' "\\i -> compose(fst)(listUncons)(i)" $ -- why does this work but not compose(fst)(listUncons)
-    Bindings
-      ( M.fromList
-          [ (mkName "compose", ExprHash 6),
-            (mkName "fst", ExprHash 1),
-            (mkName "listUncons", ExprHash 5)
-          ]
-      )
-
-listTail :: StoreExpression
-listTail =
-  unsafeGetExpr' "compose(snd)(listUncons)" $
-    Bindings
-      ( M.fromList
-          [ (mkName "compose", ExprHash 6),
-            (mkName "snd", ExprHash 7),
-            (mkName "listUncons", ExprHash 5)
-          ]
-      )
-
-compose :: StoreExpression
-compose =
-  unsafeGetExpr "\\f -> \\g -> \\a -> f(g(a))"
-
-list :: StoreExpression
-list = unsafeGetExpr' "{ head: listHead, tail: listTail }" bindings'
-  where
-    bindings' =
-      Bindings
-        ( M.fromList
-            [ (mkName "listHead", ExprHash 8),
-              (mkName "listTail", ExprHash 9)
-            ]
-        )
-
-idExpr :: StoreExpression
-idExpr = unsafeGetExpr "\\i -> i"
-
-stdLib :: StoreEnv
-stdLib = StoreEnv store' bindings'
-  where
-    store' =
-      Store $
-        M.fromList
-          [ (ExprHash 1, fstExpr),
-            (ExprHash 2, isTenExpr),
-            (ExprHash 3, eqTenExpr),
-            (ExprHash 4, fmapSum),
-            (ExprHash 5, listUncons),
-            (ExprHash 6, compose),
-            (ExprHash 7, sndExpr),
-            (ExprHash 8, listHead),
-            (ExprHash 9, listTail),
-            (ExprHash 10, list),
-            (ExprHash 11, idExpr)
-          ]
-    bindings' =
-      Bindings $
-        M.fromList
-          [ (mkName "fst", ExprHash 1),
-            (mkName "isTen", ExprHash 2),
-            (mkName "eqTen", ExprHash 3),
-            (mkName "fmapSum", ExprHash 4),
-            (mkName "listUncons", ExprHash 5),
-            (mkName "compose", ExprHash 6),
-            (mkName "snd", ExprHash 7),
-            (mkName "listHead", ExprHash 8),
-            (mkName "listTail", ExprHash 9),
-            (mkName "list", ExprHash 10),
-            (mkName "id", ExprHash 11)
-          ]
-
-unsafeGetExpr' :: Text -> Bindings -> StoreExpression
-unsafeGetExpr' input bindings' =
-  case parseExpr input of
-    Right expr' -> StoreExpression bindings' expr'
-    a -> error $ "Error evaluating " <> T.unpack input <> ": " <> show a
-
-unsafeGetExpr :: Text -> StoreExpression
-unsafeGetExpr input = unsafeGetExpr' input mempty
+import Test.StoreData
 
 eval :: StoreEnv -> Text -> IO (Either Error (MonoType, Expr))
 eval env input =

--- a/test/Test/StoreData.hs
+++ b/test/Test/StoreData.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.StoreData where
+
+import qualified Data.Map as M
+import Data.Text (Text)
+import qualified Data.Text as T
+import Language.Mimsa.Syntax (parseExpr)
+import Language.Mimsa.Types
+
+fstExpr :: StoreExpression
+fstExpr =
+  unsafeGetExpr "\\tuple -> let (a,b) = tuple in a"
+
+sndExpr :: StoreExpression
+sndExpr = unsafeGetExpr "\\tuple -> let (a,b) = tuple in b"
+
+isTenExpr :: StoreExpression
+isTenExpr =
+  unsafeGetExpr "\\i -> if eqInt(i)(10) then Right i else Left i"
+
+eqTenExpr :: StoreExpression
+eqTenExpr =
+  unsafeGetExpr "\\i -> eqInt(10)(i)"
+
+fmapSum :: StoreExpression
+fmapSum =
+  unsafeGetExpr
+    "\\f -> \\a -> case a of Left (\\l -> Left l) | Right (\\r -> Right f(r))"
+
+listUncons :: StoreExpression
+listUncons =
+  unsafeGetExpr "\\myList -> let [head,tail] = myList in (head,tail)"
+
+listHead :: StoreExpression
+listHead =
+  unsafeGetExpr' "\\i -> compose(fst)(listUncons)(i)" $ -- why does this work but not compose(fst)(listUncons)
+    Bindings
+      ( M.fromList
+          [ (mkName "compose", ExprHash 6),
+            (mkName "fst", ExprHash 1),
+            (mkName "listUncons", ExprHash 5)
+          ]
+      )
+
+listTail :: StoreExpression
+listTail =
+  unsafeGetExpr' "compose(snd)(listUncons)" $
+    Bindings
+      ( M.fromList
+          [ (mkName "compose", ExprHash 6),
+            (mkName "snd", ExprHash 7),
+            (mkName "listUncons", ExprHash 5)
+          ]
+      )
+
+compose :: StoreExpression
+compose =
+  unsafeGetExpr "\\f -> \\g -> \\a -> f(g(a))"
+
+list :: StoreExpression
+list = unsafeGetExpr' "{ head: listHead, tail: listTail }" bindings'
+  where
+    bindings' =
+      Bindings
+        ( M.fromList
+            [ (mkName "listHead", ExprHash 8),
+              (mkName "listTail", ExprHash 9)
+            ]
+        )
+
+idExpr :: StoreExpression
+idExpr = unsafeGetExpr "\\i -> i"
+
+stdLib :: StoreEnv
+stdLib = StoreEnv store' bindings'
+  where
+    store' =
+      Store $
+        M.fromList
+          [ (ExprHash 1, fstExpr),
+            (ExprHash 2, isTenExpr),
+            (ExprHash 3, eqTenExpr),
+            (ExprHash 4, fmapSum),
+            (ExprHash 5, listUncons),
+            (ExprHash 6, compose),
+            (ExprHash 7, sndExpr),
+            (ExprHash 8, listHead),
+            (ExprHash 9, listTail),
+            (ExprHash 10, list),
+            (ExprHash 11, idExpr)
+          ]
+    bindings' =
+      Bindings $
+        M.fromList
+          [ (mkName "fst", ExprHash 1),
+            (mkName "isTen", ExprHash 2),
+            (mkName "eqTen", ExprHash 3),
+            (mkName "fmapSum", ExprHash 4),
+            (mkName "listUncons", ExprHash 5),
+            (mkName "compose", ExprHash 6),
+            (mkName "snd", ExprHash 7),
+            (mkName "listHead", ExprHash 8),
+            (mkName "listTail", ExprHash 9),
+            (mkName "list", ExprHash 10),
+            (mkName "id", ExprHash 11)
+          ]
+
+unsafeGetExpr' :: Text -> Bindings -> StoreExpression
+unsafeGetExpr' input bindings' =
+  case parseExpr input of
+    Right expr' -> StoreExpression bindings' expr'
+    a -> error $ "Error evaluating " <> T.unpack input <> ": " <> show a
+
+unsafeGetExpr :: Text -> StoreExpression
+unsafeGetExpr input = unsafeGetExpr' input mempty


### PR DESCRIPTION
As per #17 , it's difficult to follow which functions use which, so this adds `:tree` to the repl.

```bash
:> :tree listHead
+ expression     (2829714720791539061)
  + listHead     (-4232862437495572770)
    + compose     (5160386744376874914)
    + fst     (5088912633165738340)
    + listUncons     (4589531998370215737)
```