### PR TITLE
Versioned bindings

### DIFF
--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 523c1e47d7b00637ac2515286286f5800dac4015b01a08e1bac140565bc46891
+-- hash: 800b9d190d48f5cb4813f808051eaa9547635790a086f1f879fd8b8c19f787a8
 
 name:           mimsa
 version:        0.1.0.0
@@ -58,10 +58,13 @@ library
       Language.Mimsa.Typechecker.Unify
       Language.Mimsa.Types
       Language.Mimsa.Types.AST
+      Language.Mimsa.Types.Bindings
       Language.Mimsa.Types.Environment
       Language.Mimsa.Types.Error
+      Language.Mimsa.Types.ExprHash
       Language.Mimsa.Types.ForeignFunc
       Language.Mimsa.Types.InterpreterError
+      Language.Mimsa.Types.Library
       Language.Mimsa.Types.MonoType
       Language.Mimsa.Types.Name
       Language.Mimsa.Types.Printer
@@ -70,6 +73,7 @@ library
       Language.Mimsa.Types.Scheme
       Language.Mimsa.Types.Scope
       Language.Mimsa.Types.Store
+      Language.Mimsa.Types.StoreExpression
       Language.Mimsa.Types.Substitutions
       Language.Mimsa.Types.Swaps
       Language.Mimsa.Types.Tui

--- a/src/Language/Mimsa/Actions.hs
+++ b/src/Language/Mimsa/Actions.hs
@@ -13,7 +13,11 @@ import Control.Monad (join)
 import Data.Bifunctor (first)
 import qualified Data.Map as M
 import Data.Text (Text)
-import Language.Mimsa.Store (createStoreExpression, substitute)
+import Language.Mimsa.Store
+  ( createStoreExpression,
+    getCurrentBindings,
+    substitute,
+  )
 import Language.Mimsa.Syntax (parseExpr)
 import Language.Mimsa.Typechecker
 import Language.Mimsa.Types
@@ -47,7 +51,7 @@ fromItem :: Name -> StoreExpression -> ExprHash -> StoreEnv
 fromItem name expr hash =
   StoreEnv
     { store = Store $ M.singleton hash expr,
-      bindings = Bindings $ M.singleton name hash
+      bindings = VersionedBindings $ M.singleton name (pure hash)
     }
 
 evaluateStoreExpression ::
@@ -64,7 +68,7 @@ getTypecheckedStoreExpression ::
   Expr Name ->
   Either Error (MonoType, StoreExpression, Expr Variable, Scope)
 getTypecheckedStoreExpression env expr = do
-  storeExpr <- first ResolverErr $ createStoreExpression (bindings env) expr
+  storeExpr <- first ResolverErr $ createStoreExpression (getCurrentBindings $ bindings env) expr
   evaluateStoreExpression (store env) storeExpr
 
 evaluateText :: StoreEnv -> Text -> Either Error (MonoType, Expr Variable, Scope)

--- a/src/Language/Mimsa/Repl/Actions.hs
+++ b/src/Language/Mimsa/Repl/Actions.hs
@@ -7,7 +7,6 @@ module Language.Mimsa.Repl.Actions
   )
 where
 
-import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Language.Mimsa.Actions
@@ -109,21 +108,16 @@ doReplAction env (Info expr) = do
           <> prettyPrint type'
       pure env
 doReplAction env (Bind name expr) = do
-  if M.member name (getBindings $ getCurrentBindings $ bindings env)
-    then do
-      T.putStrLn $ T.pack (show name) <> " is already bound"
+  case getTypecheckedStoreExpression env expr of
+    Left e' -> do
+      T.putStrLn (prettyPrint e')
       pure env
-    else do
-      case getTypecheckedStoreExpression env expr of
-        Left e' -> do
-          T.putStrLn (prettyPrint e')
-          pure env
-        Right (type', storeExpr, _, _) -> do
-          hash <- saveExpr storeExpr
-          T.putStrLn $
-            "Bound " <> prettyPrint name <> " to " <> prettyPrint expr
-              <> " :: "
-              <> prettyPrint type'
-          let newEnv = fromItem name storeExpr hash
-          pure (env <> newEnv)
+    Right (type', storeExpr, _, _) -> do
+      hash <- saveExpr storeExpr
+      T.putStrLn $
+        "Bound " <> prettyPrint name <> " to " <> prettyPrint expr
+          <> " :: "
+          <> prettyPrint type'
+      let newEnv = fromItem name storeExpr hash
+      pure (env <> newEnv)
 ----------

--- a/src/Language/Mimsa/Repl/Actions.hs
+++ b/src/Language/Mimsa/Repl/Actions.hs
@@ -14,7 +14,11 @@ import Language.Mimsa.Actions
 import Language.Mimsa.Interpreter (interpret)
 import Language.Mimsa.Repl.Types
 import Language.Mimsa.Repl.Watcher
-import Language.Mimsa.Store (createDepGraph, saveExpr)
+import Language.Mimsa.Store
+  ( createDepGraph,
+    getCurrentBindings,
+    saveExpr,
+  )
 import Language.Mimsa.Syntax (parseExpr)
 import Language.Mimsa.Tui (goTui)
 import Language.Mimsa.Types
@@ -35,7 +39,7 @@ doReplAction env (ListBindings) = do
         Right (type', _, _, _) ->
           prettyPrint name <> " :: " <> prettyPrint type'
         _ -> ""
-  _ <- traverse showBind (getExprPairs (store env) (bindings env))
+  _ <- traverse showBind (getExprPairs (store env) (getCurrentBindings $ bindings env))
   pure env
 doReplAction env Tui = do
   goTui env
@@ -105,7 +109,7 @@ doReplAction env (Info expr) = do
           <> prettyPrint type'
       pure env
 doReplAction env (Bind name expr) = do
-  if M.member name (getBindings $ bindings env)
+  if M.member name (getBindings $ getCurrentBindings $ bindings env)
     then do
       T.putStrLn $ T.pack (show name) <> " is already bound"
       pure env

--- a/src/Language/Mimsa/Store/DepGraph.hs
+++ b/src/Language/Mimsa/Store/DepGraph.hs
@@ -7,9 +7,7 @@ import qualified Data.Map as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import Language.Mimsa.Store.Storage
-import Language.Mimsa.Types.Name
-import Language.Mimsa.Types.Printer
-import Language.Mimsa.Types.Store
+import Language.Mimsa.Types
 
 -----
 

--- a/src/Language/Mimsa/Store/ResolvedDeps.hs
+++ b/src/Language/Mimsa/Store/ResolvedDeps.hs
@@ -2,9 +2,7 @@ module Language.Mimsa.Store.ResolvedDeps (resolveDeps) where
 
 import Data.Either (partitionEithers)
 import qualified Data.Map as M
-import Language.Mimsa.Types.Name
-import Language.Mimsa.Types.ResolvedDeps
-import Language.Mimsa.Types.Store
+import Language.Mimsa.Types
 
 -- we spend so much time passing the whole store around to match hashes
 -- lets create one way of resolving a pile of them and be done with it

--- a/src/Language/Mimsa/Tui/State.hs
+++ b/src/Language/Mimsa/Tui/State.hs
@@ -14,6 +14,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
 import qualified Data.Vector as Vec
 import qualified Graphics.Vty as V
+import Language.Mimsa.Store (getCurrentBindings)
 import Language.Mimsa.Store.ResolvedDeps
 import Language.Mimsa.Tui.Evaluate
 import Language.Mimsa.Types
@@ -87,7 +88,7 @@ initialState storeEnv' =
     }
   where
     initialUiState =
-      case resolveDeps (store storeEnv') (bindings storeEnv') of
+      case resolveDeps (store storeEnv') (getCurrentBindings $ bindings storeEnv') of
         Right resolvedDeps ->
           ViewBindings $
             pure

--- a/src/Language/Mimsa/Types.hs
+++ b/src/Language/Mimsa/Types.hs
@@ -6,6 +6,7 @@
 
 module Language.Mimsa.Types
   ( module Language.Mimsa.Types.Name,
+    module Language.Mimsa.Types.ExprHash,
     module Language.Mimsa.Types.AST,
     module Language.Mimsa.Types.Store,
     module Language.Mimsa.Types.TypeError,
@@ -24,14 +25,20 @@ module Language.Mimsa.Types
     module Language.Mimsa.Types.Swaps,
     module Language.Mimsa.Types.UniVar,
     module Language.Mimsa.Types.Tui,
+    module Language.Mimsa.Types.Library,
+    module Language.Mimsa.Types.Bindings,
+    module Language.Mimsa.Types.StoreExpression,
   )
 where
 
 import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Bindings
 import Language.Mimsa.Types.Environment
 import Language.Mimsa.Types.Error
+import Language.Mimsa.Types.ExprHash
 import Language.Mimsa.Types.ForeignFunc
 import Language.Mimsa.Types.InterpreterError
+import Language.Mimsa.Types.Library
 import Language.Mimsa.Types.MonoType
 import Language.Mimsa.Types.Name
 import Language.Mimsa.Types.Printer
@@ -40,6 +47,7 @@ import Language.Mimsa.Types.ResolverError
 import Language.Mimsa.Types.Scheme
 import Language.Mimsa.Types.Scope
 import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.StoreExpression
 import Language.Mimsa.Types.Substitutions
 import Language.Mimsa.Types.Swaps
 import Language.Mimsa.Types.Tui

--- a/src/Language/Mimsa/Types/Bindings.hs
+++ b/src/Language/Mimsa/Types/Bindings.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Types.Bindings where
+
+import qualified Data.Aeson as JSON
+import Data.Map (Map)
+import qualified Data.Map as M
+import qualified Data.Text as T
+import Language.Mimsa.Types.ExprHash
+import Language.Mimsa.Types.Name
+import Language.Mimsa.Types.Printer
+
+-- a list of names to hashes
+newtype Bindings = Bindings {getBindings :: Map Name ExprHash}
+  deriving newtype (Eq, Ord, Show, Semigroup, Monoid, JSON.FromJSON, JSON.ToJSON)
+
+instance Printer Bindings where
+  prettyPrint (Bindings b) = "{ " <> T.intercalate ", " (prettyPrint <$> M.keys b) <> " }"

--- a/src/Language/Mimsa/Types/ExprHash.hs
+++ b/src/Language/Mimsa/Types/ExprHash.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Types.ExprHash where
+
+import qualified Data.Aeson as JSON
+import qualified Data.Text as T
+import Language.Mimsa.Types.Printer
+
+------------
+
+newtype ExprHash = ExprHash Int
+  deriving (Eq, Ord, Show)
+  deriving newtype (JSON.FromJSON, JSON.ToJSON)
+
+instance Printer ExprHash where
+  prettyPrint (ExprHash a) = T.pack . show $ a

--- a/src/Language/Mimsa/Types/Library.hs
+++ b/src/Language/Mimsa/Types/Library.hs
@@ -1,0 +1,9 @@
+module Language.Mimsa.Types.Library where
+
+import Data.Map (Map)
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.ForeignFunc
+
+-- our built-in functions for doing IO things etc
+-- statically defined and made available in all computations for now
+newtype Library = Library {getLibrary :: Map FuncName ForeignFunc}

--- a/src/Language/Mimsa/Types/ResolvedDeps.hs
+++ b/src/Language/Mimsa/Types/ResolvedDeps.hs
@@ -7,7 +7,7 @@ import qualified Data.Map as M
 import qualified Data.Text as T
 import Language.Mimsa.Types.Name
 import Language.Mimsa.Types.Printer
-import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.StoreExpression
 
 newtype ResolvedDeps = ResolvedDeps {getResolvedDeps :: Map Name StoreExpression}
 

--- a/src/Language/Mimsa/Types/ResolverError.hs
+++ b/src/Language/Mimsa/Types/ResolverError.hs
@@ -4,9 +4,9 @@ module Language.Mimsa.Types.ResolverError where
 
 import qualified Data.Map as M
 import qualified Data.Text as T
+import Language.Mimsa.Types.Bindings
 import Language.Mimsa.Types.Name
 import Language.Mimsa.Types.Printer
-import Language.Mimsa.Types.Store
 
 data ResolverError = MissingBinding Name Bindings
   deriving (Eq, Ord, Show)

--- a/src/Language/Mimsa/Types/Store.hs
+++ b/src/Language/Mimsa/Types/Store.hs
@@ -1,29 +1,14 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Language.Mimsa.Types.Store where
 
-import qualified Data.Aeson as JSON
+import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
-import qualified Data.Map as M
-import qualified Data.Text as T
-import GHC.Generics
-import Language.Mimsa.Types.AST
-import Language.Mimsa.Types.ForeignFunc
+import Language.Mimsa.Types.Bindings
+import Language.Mimsa.Types.ExprHash
 import Language.Mimsa.Types.Name
-import Language.Mimsa.Types.Printer
-
-------------
-
-newtype ExprHash = ExprHash Int
-  deriving (Eq, Ord, Show)
-  deriving newtype (JSON.FromJSON, JSON.ToJSON)
-
-instance Printer ExprHash where
-  prettyPrint (ExprHash a) = T.pack . show $ a
+import Language.Mimsa.Types.StoreExpression
 
 -------
 
@@ -48,24 +33,6 @@ instance Monoid StoreEnv where
 newtype Store = Store {getStore :: Map ExprHash StoreExpression}
   deriving newtype (Eq, Ord, Show, Semigroup, Monoid)
 
--- our built-in functions for doing IO things etc
--- statically defined and made available in all computations for now
-newtype Library = Library {getLibrary :: Map FuncName ForeignFunc}
-
--- a list of names to hashes
-newtype Bindings = Bindings {getBindings :: Map Name ExprHash}
-  deriving newtype (Eq, Ord, Show, Semigroup, Monoid, JSON.FromJSON, JSON.ToJSON)
-
-instance Printer Bindings where
-  prettyPrint (Bindings b) = "{ " <> T.intercalate ", " (prettyPrint <$> M.keys b) <> " }"
-
--- a storeExpression contains the AST Expr
--- and a map of names to hashes with further functions inside
--- not sure whether to store the builtins we need here too?
-data StoreExpression
-  = StoreExpression
-      { storeBindings :: Bindings,
-        storeExpression :: Expr Name
-      }
-  deriving (Eq, Ord, Show, Generic)
-  deriving (JSON.ToJSON, JSON.FromJSON)
+-- allows us to version our bindings
+newtype VersionedBindings
+  = VersionedBindings {getVersionedBindings :: Map Name (NonEmpty ExprHash)}

--- a/src/Language/Mimsa/Types/Store.hs
+++ b/src/Language/Mimsa/Types/Store.hs
@@ -6,6 +6,7 @@ module Language.Mimsa.Types.Store where
 import qualified Data.Aeson as JSON
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
+import qualified Data.Map as M
 import Language.Mimsa.Types.ExprHash
 import Language.Mimsa.Types.Name
 import Language.Mimsa.Types.StoreExpression
@@ -36,5 +37,9 @@ newtype Store = Store {getStore :: Map ExprHash StoreExpression}
 -- allows us to version our bindings
 newtype VersionedBindings
   = VersionedBindings {getVersionedBindings :: Map Name (NonEmpty ExprHash)}
-  deriving newtype (Eq, Ord, Show, Semigroup, Monoid)
+  deriving newtype (Eq, Ord, Show, Monoid)
   deriving (JSON.ToJSON, JSON.FromJSON)
+
+instance Semigroup VersionedBindings where
+  (VersionedBindings a) <> (VersionedBindings b) =
+    VersionedBindings (M.unionWith (<>) a b)

--- a/src/Language/Mimsa/Types/Store.hs
+++ b/src/Language/Mimsa/Types/Store.hs
@@ -3,9 +3,9 @@
 
 module Language.Mimsa.Types.Store where
 
+import qualified Data.Aeson as JSON
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
-import Language.Mimsa.Types.Bindings
 import Language.Mimsa.Types.ExprHash
 import Language.Mimsa.Types.Name
 import Language.Mimsa.Types.StoreExpression
@@ -17,7 +17,7 @@ import Language.Mimsa.Types.StoreExpression
 data StoreEnv
   = StoreEnv
       { store :: Store,
-        bindings :: Bindings
+        bindings :: VersionedBindings
       }
   deriving (Eq, Ord, Show)
 
@@ -36,3 +36,5 @@ newtype Store = Store {getStore :: Map ExprHash StoreExpression}
 -- allows us to version our bindings
 newtype VersionedBindings
   = VersionedBindings {getVersionedBindings :: Map Name (NonEmpty ExprHash)}
+  deriving newtype (Eq, Ord, Show, Semigroup, Monoid)
+  deriving (JSON.ToJSON, JSON.FromJSON)

--- a/src/Language/Mimsa/Types/StoreExpression.hs
+++ b/src/Language/Mimsa/Types/StoreExpression.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Types.StoreExpression where
+
+import qualified Data.Aeson as JSON
+import GHC.Generics
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Bindings
+import Language.Mimsa.Types.Name
+
+-- a storeExpression contains the AST Expr
+-- and a map of names to hashes with further functions inside
+-- not sure whether to store the builtins we need here too?
+data StoreExpression
+  = StoreExpression
+      { storeBindings :: Bindings,
+        storeExpression :: Expr Name
+      }
+  deriving (Eq, Ord, Show, Generic, JSON.ToJSON, JSON.FromJSON)

--- a/test/Test/StoreData.hs
+++ b/test/Test/StoreData.hs
@@ -112,20 +112,20 @@ stdLib = StoreEnv store' bindings'
             (ExprHash 14, maybeExpr)
           ]
     bindings' =
-      Bindings $
+      VersionedBindings $
         M.fromList
-          [ (mkName "fst", ExprHash 1),
-            (mkName "isTen", ExprHash 2),
-            (mkName "eqTen", ExprHash 3),
-            (mkName "fmapSum", ExprHash 4),
-            (mkName "listUncons", ExprHash 5),
-            (mkName "compose", ExprHash 6),
-            (mkName "snd", ExprHash 7),
-            (mkName "listHead", ExprHash 8),
-            (mkName "listTail", ExprHash 9),
-            (mkName "list", ExprHash 10),
-            (mkName "id", ExprHash 11),
-            (mkName "maybe", ExprHash 14)
+          [ (mkName "fst", pure $ ExprHash 1),
+            (mkName "isTen", pure $ ExprHash 2),
+            (mkName "eqTen", pure $ ExprHash 3),
+            (mkName "fmapSum", pure $ ExprHash 4),
+            (mkName "listUncons", pure $ ExprHash 5),
+            (mkName "compose", pure $ ExprHash 6),
+            (mkName "snd", pure $ ExprHash 7),
+            (mkName "listHead", pure $ ExprHash 8),
+            (mkName "listTail", pure $ ExprHash 9),
+            (mkName "list", pure $ ExprHash 10),
+            (mkName "id", pure $ ExprHash 11),
+            (mkName "maybe", pure $ ExprHash 14)
           ]
 
 unsafeGetExpr' :: Text -> Bindings -> StoreExpression


### PR DESCRIPTION
Changes the store environment to have a `NonEmpty` list of `ExprHash` instead of a single one. This way we can talk about previous versions of a named function.