### PR TITLE
Add mapList built in

### DIFF
--- a/src/Language/Mimsa/Library.hs
+++ b/src/Language/Mimsa/Library.hs
@@ -32,7 +32,8 @@ libraryFunctions =
         (FuncName "appendList", appendList),
         (FuncName "reduceList", reduceList),
         (FuncName "addInt", addInt),
-        (FuncName "mapList", mapList)
+        (FuncName "mapList", mapList),
+        (FuncName "foldList", foldList)
       ]
 
 isLibraryName :: Name -> Bool
@@ -142,6 +143,14 @@ mapList =
    in TwoArgs
         (tyAToB, MTList tyA, MTList tyB)
         (\aToB (MyList as) -> pure $ MyList (MyApp aToB <$> as))
+
+foldList :: ForeignFunc
+foldList =
+  let tyA = MTVar (NamedVar (Name "a"))
+      tyAppend = MTFunction tyA (MTFunction tyA tyA)
+   in TwoArgs
+        (tyAppend, MTList tyA, tyA)
+        (\append (MyList as) -> pure $ foldr1 (\a a' -> MyApp (MyApp append a) a') as)
 
 getFFType :: ForeignFunc -> MonoType
 getFFType (NoArgs out _) = out

--- a/src/Language/Mimsa/Library.hs
+++ b/src/Language/Mimsa/Library.hs
@@ -31,7 +31,8 @@ libraryFunctions =
         (FuncName "logBool", logBool),
         (FuncName "appendList", appendList),
         (FuncName "reduceList", reduceList),
-        (FuncName "addInt", addInt)
+        (FuncName "addInt", addInt),
+        (FuncName "mapList", mapList)
       ]
 
 isLibraryName :: Name -> Bool
@@ -132,6 +133,15 @@ reduce f starting as =
   let varF = NamedVar (Name "f")
       result = foldr (\a' b' -> MyApp (MyApp (MyVar varF) a') b') starting as
    in MyLet varF f result
+
+mapList :: ForeignFunc
+mapList =
+  let tyA = MTVar (NamedVar (Name "a"))
+      tyB = MTVar (NamedVar (Name "b"))
+      tyAToB = MTFunction tyA tyB
+   in TwoArgs
+        (tyAToB, MTList tyA, MTList tyB)
+        (\aToB (MyList as) -> pure $ MyList (MyApp aToB <$> as))
 
 getFFType :: ForeignFunc -> MonoType
 getFFType (NoArgs out _) = out

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -60,7 +60,7 @@ inferLiteral MyUnit = pure (mempty, MTUnit)
 
 inferBuiltIn :: Variable -> TcMonad (Substitutions, MonoType)
 inferBuiltIn name = case getLibraryFunction name of
-  Just ff -> pure (mempty, getFFType ff)
+  Just ff -> instantiate (generalise mempty (getFFType ff))
   _ -> throwError $ MissingBuiltIn name
 
 inferVarFromScope :: Environment -> Variable -> TcMonad (Substitutions, MonoType)

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -234,3 +234,8 @@ spec =
             ( MTSum MTUnit (MTList MTInt),
               MySum MyRight (MyList (NE.fromList [int 10, int 10]))
             )
+      it "foldList(appendList)([[1,2],[3,4]])" $ do
+        result <- eval stdLib "foldList(appendList)([[1,2],[3,4]])"
+        result
+          `shouldBe` Right
+            (MTList MTInt, MyList $ NE.fromList [int 1, int 2, int 3, int 4])

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -218,3 +218,6 @@ spec =
       it "addInt(1)(addInt(addInt(2)(4))(5))" $ do
         result <- eval stdLib "addInt(1)(addInt(addInt(2)(4))(5))"
         result `shouldBe` Right (MTInt, int 12)
+      it "mapList(incrementInt)([1,2,3])" $ do
+        result <- eval stdLib "mapList(incrementInt)([1,2,3])"
+        result `shouldBe` Right (MTList MTInt, MyList (NE.fromList [int 2, int 3, int 4]))

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -221,3 +221,16 @@ spec =
       it "mapList(incrementInt)([1,2,3])" $ do
         result <- eval stdLib "mapList(incrementInt)([1,2,3])"
         result `shouldBe` Right (MTList MTInt, MyList (NE.fromList [int 2, int 3, int 4]))
+      it "foldList(addInt)([1,2,3])" $ do
+        result <- eval stdLib "foldList(addInt)([1,2,3])"
+        result `shouldBe` Right (MTInt, int 6)
+      it "listFilter(\\a -> eqInt(10)(a))([1])" $ do
+        result <- eval stdLib "listFilter(\\a -> eqInt(10)(a))([1])"
+        result `shouldBe` Right (MTSum MTUnit (MTList MTInt), MySum MyLeft (MyLiteral MyUnit))
+      it "listFilter(\\a -> eqInt(10)(a))([10,10,30])" $ do
+        result <- eval stdLib "listFilter(\\a -> eqInt(10)(a))([10,10,30])"
+        result
+          `shouldBe` Right
+            ( MTSum MTUnit (MTList MTInt),
+              MySum MyRight (MyList (NE.fromList [int 10, int 10]))
+            )

--- a/test/Test/StoreData.hs
+++ b/test/Test/StoreData.hs
@@ -90,6 +90,17 @@ maybeExpr =
         )
     )
 
+listCons :: StoreExpression
+listCons =
+  unsafeGetExpr
+    "\\a -> (\\maybeList -> case maybeList of Left (\\l -> [a]) | Right (\\as -> (appendList(as)([a]))))"
+
+listFilter :: StoreExpression
+listFilter =
+  unsafeGetExpr'
+    "\\pred -> \\as -> let foldFunc = \\a -> \\total -> if pred(a) then Right listCons(a)(total) else total in reduceList(foldFunc)(Left Unit)(as)"
+    (Bindings $ M.singleton (mkName "listCons") (ExprHash 15))
+
 stdLib :: Project
 stdLib = Project store' bindings'
   where
@@ -109,7 +120,9 @@ stdLib = Project store' bindings'
             (ExprHash 11, idExpr),
             (ExprHash 12, justExpr),
             (ExprHash 13, nothingExpr),
-            (ExprHash 14, maybeExpr)
+            (ExprHash 14, maybeExpr),
+            (ExprHash 15, listCons),
+            (ExprHash 16, listFilter)
           ]
     bindings' =
       VersionedBindings $
@@ -125,7 +138,9 @@ stdLib = Project store' bindings'
             (mkName "listTail", pure $ ExprHash 9),
             (mkName "list", pure $ ExprHash 10),
             (mkName "id", pure $ ExprHash 11),
-            (mkName "maybe", pure $ ExprHash 14)
+            (mkName "maybe", pure $ ExprHash 14),
+            (mkName "listCons", pure $ ExprHash 15),
+            (mkName "listFilter", pure $ ExprHash 16)
           ]
 
 unsafeGetExpr' :: Text -> Bindings -> StoreExpression


### PR DESCRIPTION
I had hoped to implement `map` in terms of `reduce`, however, because a Mimsa `List` cannot be empty (let's not question the wisdom of this for the time being) we cannot. This implements it as a built-in instead.