### PR TITLE
Datatype declarations

### DIFF
--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 51586156c4354e672fc8e283d5b182752ef4575e1b45f9e4af3baabd8d374050
+-- hash: 5ba4aa6af2a1e4efaa024fb95a5cc1f0ba57f6d8e19a26a299d4db8da582d1db
 
 name:           mimsa
 version:        0.1.0.0
@@ -88,6 +88,7 @@ library
       Language.Mimsa.Types.Swaps
       Language.Mimsa.Types.Tui
       Language.Mimsa.Types.TypeError
+      Language.Mimsa.Types.TypeName
       Language.Mimsa.Types.UniVar
       Language.Mimsa.Types.Usage
       Language.Mimsa.Types.Variable

--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5ba4aa6af2a1e4efaa024fb95a5cc1f0ba57f6d8e19a26a299d4db8da582d1db
+-- hash: 1e6f0f2e4511c83c046d01cb49fbbc775eeba50f9112aa540da7a8dbcf9100c3
 
 name:           mimsa
 version:        0.1.0.0
@@ -31,6 +31,7 @@ library
       Language.Mimsa.Actions
       Language.Mimsa.Interpreter
       Language.Mimsa.Interpreter.Interpret
+      Language.Mimsa.Interpreter.PatternMatch
       Language.Mimsa.Interpreter.SwapName
       Language.Mimsa.Interpreter.Types
       Language.Mimsa.Library
@@ -60,8 +61,10 @@ library
       Language.Mimsa.Tui.Styles
       Language.Mimsa.Typechecker
       Language.Mimsa.Typechecker.DataTypes
+      Language.Mimsa.Typechecker.Environment
       Language.Mimsa.Typechecker.Generalise
       Language.Mimsa.Typechecker.Infer
+      Language.Mimsa.Typechecker.Patterns
       Language.Mimsa.Typechecker.TcMonad
       Language.Mimsa.Typechecker.Unify
       Language.Mimsa.Types

--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f83c08d7d0acbfffa4fe7ef658066b022e8f7d88c1c24500e36d15bf9625d0ef
+-- hash: 51586156c4354e672fc8e283d5b182752ef4575e1b45f9e4af3baabd8d374050
 
 name:           mimsa
 version:        0.1.0.0
@@ -59,6 +59,7 @@ library
       Language.Mimsa.Tui.State
       Language.Mimsa.Tui.Styles
       Language.Mimsa.Typechecker
+      Language.Mimsa.Typechecker.DataTypes
       Language.Mimsa.Typechecker.Generalise
       Language.Mimsa.Typechecker.Infer
       Language.Mimsa.Typechecker.TcMonad

--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f967607f3199df6e27e273945f46e3e13f4e7bf286024d0c58c8a655a28f575c
+-- hash: f83c08d7d0acbfffa4fe7ef658066b022e8f7d88c1c24500e36d15bf9625d0ef
 
 name:           mimsa
 version:        0.1.0.0
@@ -66,6 +66,7 @@ library
       Language.Mimsa.Types
       Language.Mimsa.Types.AST
       Language.Mimsa.Types.Bindings
+      Language.Mimsa.Types.Construct
       Language.Mimsa.Types.Environment
       Language.Mimsa.Types.Error
       Language.Mimsa.Types.ExprHash

--- a/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -206,3 +206,4 @@ interpretWithScope interpretExpr =
       interpretWithScope (MyIf predExpr true false)
     (MyData _tyName _constructors expr) -> interpretWithScope expr
     (MyConstructor a) -> pure (MyConstructor a)
+    (MyConsApp fn val) -> pure (MyConsApp fn val)

--- a/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -210,5 +210,6 @@ interpretWithScope interpretExpr =
     (MyData _tyName _tyArgs _constructors expr) -> interpretWithScope expr
     (MyConstructor a) -> pure (MyConstructor a)
     (MyConsApp fn val) -> pure (MyConsApp fn val)
-    (MyCaseMatch expr' matches catchAll) ->
-      patternMatch expr' matches catchAll >>= interpretWithScope
+    (MyCaseMatch expr' matches catchAll) -> do
+      expr'' <- interpretWithScope expr'
+      patternMatch expr'' matches catchAll >>= interpretWithScope

--- a/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -11,6 +11,7 @@ import Control.Applicative
 import Control.Monad.Except
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
+import Language.Mimsa.Interpreter.PatternMatch
 import Language.Mimsa.Interpreter.SwapName
 import Language.Mimsa.Interpreter.Types
 import Language.Mimsa.Library
@@ -155,6 +156,8 @@ interpretWithScope interpretExpr =
       interpretWithScope (MyApp expr value)
     (MyApp (MyLambda binder expr) value) ->
       interpretWithScope (MyLet binder value expr)
+    (MyApp (MyLiteral a) _) ->
+      throwError $ CannotApplyToNonFunction (MyLiteral a)
     (MyApp other value) -> do
       expr <- interpretWithScope other
       interpretWithScope (MyApp expr value)
@@ -207,3 +210,5 @@ interpretWithScope interpretExpr =
     (MyData _tyName _tyArgs _constructors expr) -> interpretWithScope expr
     (MyConstructor a) -> pure (MyConstructor a)
     (MyConsApp fn val) -> pure (MyConsApp fn val)
+    (MyCaseMatch expr' matches catchAll) ->
+      patternMatch expr' matches catchAll >>= interpretWithScope

--- a/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -204,5 +204,5 @@ interpretWithScope interpretExpr =
     (MyIf pred' true false) -> do
       predExpr <- interpretWithScope pred'
       interpretWithScope (MyIf predExpr true false)
-    (MyData tyName constructors expr) -> pure (MyData tyName constructors expr) -- no-op for now
+    (MyData _tyName _constructors expr) -> interpretWithScope expr
     (MyConstructor a) -> pure (MyConstructor a)

--- a/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -204,3 +204,5 @@ interpretWithScope interpretExpr =
     (MyIf pred' true false) -> do
       predExpr <- interpretWithScope pred'
       interpretWithScope (MyIf predExpr true false)
+    (MyData tyName constructors expr) -> pure (MyData tyName constructors expr) -- no-op for now
+    (MyConstructor a) -> pure (MyConstructor a)

--- a/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -204,6 +204,6 @@ interpretWithScope interpretExpr =
     (MyIf pred' true false) -> do
       predExpr <- interpretWithScope pred'
       interpretWithScope (MyIf predExpr true false)
-    (MyData _tyName _constructors expr) -> interpretWithScope expr
+    (MyData _tyName _tyArgs _constructors expr) -> interpretWithScope expr
     (MyConstructor a) -> pure (MyConstructor a)
     (MyConsApp fn val) -> pure (MyConsApp fn val)

--- a/src/Language/Mimsa/Interpreter/PatternMatch.hs
+++ b/src/Language/Mimsa/Interpreter/PatternMatch.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Interpreter.PatternMatch where
+
+import Control.Monad.Except
+import Language.Mimsa.Interpreter.Types
+import Language.Mimsa.Logging
+import Language.Mimsa.Types
+
+patternMatch ::
+  Expr Variable ->
+  [(Construct, Expr Variable)] ->
+  Maybe (Expr Variable) ->
+  App (Expr Variable)
+patternMatch expr' options catchAll = do
+  const' <- findConstructor expr'
+  case filter (\(c, _) -> c == const') options of
+    [(_, found)] -> pure $ createMatchExpression found $ debugPretty "expr" expr'
+    _ ->
+      case catchAll of
+        Just catchAll' -> pure catchAll'
+        _ -> throwError $ PatternMatchFailure expr'
+
+-- when given an applied constructor, find the name for matching
+findConstructor :: Expr Variable -> App Construct
+findConstructor (MyConstructor c) = pure c
+findConstructor (MyConsApp c _) = findConstructor c
+findConstructor e = throwError $ PatternMatchFailure e
+
+-- apply each part of the constructor to the output function
+createMatchExpression :: Expr Variable -> Expr Variable -> Expr Variable
+createMatchExpression f (MyConsApp c a) = MyApp (createMatchExpression f c) a
+createMatchExpression f _ = f

--- a/src/Language/Mimsa/Interpreter/SwapName.hs
+++ b/src/Language/Mimsa/Interpreter/SwapName.hs
@@ -61,3 +61,4 @@ swapName _ _ (MyLiteral a) = pure (MyLiteral a)
 swapName from to (MyData tyName constructors expr) =
   MyData tyName constructors <$> swapName from to expr
 swapName _ _ (MyConstructor n) = pure (MyConstructor n)
+swapName _ _ (MyConsApp a b) = pure (MyConsApp a b)

--- a/src/Language/Mimsa/Interpreter/SwapName.hs
+++ b/src/Language/Mimsa/Interpreter/SwapName.hs
@@ -58,7 +58,7 @@ swapName from to (MyRecord map') = do
   map2 <- traverse (swapName from to) map'
   pure (MyRecord map2)
 swapName _ _ (MyLiteral a) = pure (MyLiteral a)
-swapName from to (MyData tyName constructors expr) =
-  MyData tyName constructors <$> swapName from to expr
+swapName from to (MyData tyName tyArgs constructors expr) =
+  MyData tyName tyArgs constructors <$> swapName from to expr
 swapName _ _ (MyConstructor n) = pure (MyConstructor n)
 swapName _ _ (MyConsApp a b) = pure (MyConsApp a b)

--- a/src/Language/Mimsa/Interpreter/SwapName.hs
+++ b/src/Language/Mimsa/Interpreter/SwapName.hs
@@ -58,3 +58,6 @@ swapName from to (MyRecord map') = do
   map2 <- traverse (swapName from to) map'
   pure (MyRecord map2)
 swapName _ _ (MyLiteral a) = pure (MyLiteral a)
+swapName from to (MyData tyName constructors expr) =
+  MyData tyName constructors <$> swapName from to expr
+swapName _ _ (MyConstructor n) = pure (MyConstructor n)

--- a/src/Language/Mimsa/Interpreter/SwapName.hs
+++ b/src/Language/Mimsa/Interpreter/SwapName.hs
@@ -62,3 +62,4 @@ swapName from to (MyData tyName tyArgs constructors expr) =
   MyData tyName tyArgs constructors <$> swapName from to expr
 swapName _ _ (MyConstructor n) = pure (MyConstructor n)
 swapName _ _ (MyConsApp a b) = pure (MyConsApp a b)
+swapName _ _ (MyCaseMatch a b c) = pure (MyCaseMatch a b c)

--- a/src/Language/Mimsa/Store/Resolver.hs
+++ b/src/Language/Mimsa/Store/Resolver.hs
@@ -30,8 +30,14 @@ extractVars_ (MyLambda newVar a) = S.delete newVar (extractVars_ a)
 extractVars_ (MyApp a b) = extractVars_ a <> extractVars_ b
 extractVars_ (MyLiteral _) = mempty
 extractVars_ (MyCase sum' l r) = extractVars_ sum' <> extractVars_ l <> extractVars_ r
-extractVars_ (MyLetPair newVarA newVarB a b) = S.delete newVarA (S.delete newVarB (extractVars_ a <> extractVars_ b))
-extractVars_ (MyLetList newVarA newVarB a b) = S.delete newVarA (S.delete newVarB (extractVars_ a <> extractVars_ b))
+extractVars_ (MyLetPair newVarA newVarB a b) =
+  S.delete
+    newVarA
+    (S.delete newVarB (extractVars_ a <> extractVars_ b))
+extractVars_ (MyLetList newVarA newVarB a b) =
+  S.delete
+    newVarA
+    (S.delete newVarB (extractVars_ a <> extractVars_ b))
 extractVars_ (MyPair a b) = extractVars_ a <> extractVars_ b
 extractVars_ (MySum _ a) = extractVars_ a
 extractVars_ (MyList as) = foldMap extractVars_ as
@@ -40,6 +46,10 @@ extractVars_ (MyRecordAccess a _) = extractVars_ a
 extractVars_ (MyData _ _ _ a) = extractVars_ a
 extractVars_ (MyConstructor _) = mempty
 extractVars_ (MyConsApp a b) = extractVars_ a <> extractVars_ b
+extractVars_ (MyCaseMatch sum' matches catchAll) =
+  extractVars sum'
+    <> mconcat (extractVars . snd <$> matches)
+    <> maybe mempty extractVars catchAll
 
 filterBuiltIns :: Set Name -> Set Name
 filterBuiltIns = S.filter (not . isLibraryName)

--- a/src/Language/Mimsa/Store/Resolver.hs
+++ b/src/Language/Mimsa/Store/Resolver.hs
@@ -37,6 +37,8 @@ extractVars_ (MySum _ a) = extractVars_ a
 extractVars_ (MyList as) = foldMap extractVars_ as
 extractVars_ (MyRecord map') = foldMap extractVars_ map'
 extractVars_ (MyRecordAccess a _) = extractVars_ a
+extractVars_ (MyData _ _ a) = extractVars_ a
+extractVars_ (MyConstructor _) = mempty
 
 filterBuiltIns :: Set Name -> Set Name
 filterBuiltIns = S.filter (not . isLibraryName)

--- a/src/Language/Mimsa/Store/Resolver.hs
+++ b/src/Language/Mimsa/Store/Resolver.hs
@@ -37,7 +37,7 @@ extractVars_ (MySum _ a) = extractVars_ a
 extractVars_ (MyList as) = foldMap extractVars_ as
 extractVars_ (MyRecord map') = foldMap extractVars_ map'
 extractVars_ (MyRecordAccess a _) = extractVars_ a
-extractVars_ (MyData _ _ a) = extractVars_ a
+extractVars_ (MyData _ _ _ a) = extractVars_ a
 extractVars_ (MyConstructor _) = mempty
 extractVars_ (MyConsApp a b) = extractVars_ a <> extractVars_ b
 

--- a/src/Language/Mimsa/Store/Resolver.hs
+++ b/src/Language/Mimsa/Store/Resolver.hs
@@ -39,6 +39,7 @@ extractVars_ (MyRecord map') = foldMap extractVars_ map'
 extractVars_ (MyRecordAccess a _) = extractVars_ a
 extractVars_ (MyData _ _ a) = extractVars_ a
 extractVars_ (MyConstructor _) = mempty
+extractVars_ (MyConsApp a b) = extractVars_ a <> extractVars_ b
 
 filterBuiltIns :: Set Name -> Set Name
 filterBuiltIns = S.filter (not . isLibraryName)

--- a/src/Language/Mimsa/Store/Substitutor.hs
+++ b/src/Language/Mimsa/Store/Substitutor.hs
@@ -146,3 +146,4 @@ mapVar p (MyRecord map') = do
 mapVar _ (MyLiteral a) = pure (MyLiteral a)
 mapVar p (MyData a b c) = MyData a b <$> mapVar p c
 mapVar _ (MyConstructor name) = pure (MyConstructor name)
+mapVar p (MyConsApp fn var) = MyConsApp <$> mapVar p fn <*> mapVar p var

--- a/src/Language/Mimsa/Store/Substitutor.hs
+++ b/src/Language/Mimsa/Store/Substitutor.hs
@@ -144,6 +144,6 @@ mapVar p (MyRecord map') = do
   map2 <- traverse (mapVar p) map'
   pure (MyRecord map2)
 mapVar _ (MyLiteral a) = pure (MyLiteral a)
-mapVar p (MyData a b c) = MyData a b <$> mapVar p c
+mapVar p (MyData a b c d) = MyData a b c <$> mapVar p d
 mapVar _ (MyConstructor name) = pure (MyConstructor name)
 mapVar p (MyConsApp fn var) = MyConsApp <$> mapVar p fn <*> mapVar p var

--- a/src/Language/Mimsa/Store/Substitutor.hs
+++ b/src/Language/Mimsa/Store/Substitutor.hs
@@ -144,3 +144,5 @@ mapVar p (MyRecord map') = do
   map2 <- traverse (mapVar p) map'
   pure (MyRecord map2)
 mapVar _ (MyLiteral a) = pure (MyLiteral a)
+mapVar p (MyData a b c) = MyData a b <$> mapVar p c
+mapVar _ (MyConstructor name) = pure (MyConstructor name)

--- a/src/Language/Mimsa/Store/Substitutor.hs
+++ b/src/Language/Mimsa/Store/Substitutor.hs
@@ -147,3 +147,8 @@ mapVar _ (MyLiteral a) = pure (MyLiteral a)
 mapVar p (MyData a b c d) = MyData a b c <$> mapVar p d
 mapVar _ (MyConstructor name) = pure (MyConstructor name)
 mapVar p (MyConsApp fn var) = MyConsApp <$> mapVar p fn <*> mapVar p var
+mapVar p (MyCaseMatch expr' matches catchAll) = do
+  let mapVarPair (name, expr'') = (,) <$> pure name <*> mapVar p expr''
+  matches' <- traverse mapVarPair matches
+  catchAll' <- traverse (mapVar p) catchAll
+  MyCaseMatch <$> mapVar p expr' <*> pure matches' <*> pure catchAll'

--- a/src/Language/Mimsa/Syntax/Language.hs
+++ b/src/Language/Mimsa/Syntax/Language.hs
@@ -473,7 +473,7 @@ caseMatchParser = do
     matchesParser <|> pure <$> matchParser
       <|> pure mempty
   catchAll <-
-    Just <$> otherwiseParser (null matches)
+    Just <$> otherwiseParser (not . null $ matches)
       <|> pure Nothing
   pure $ MyCaseMatch sumExpr matches catchAll
 

--- a/src/Language/Mimsa/Syntax/Language.hs
+++ b/src/Language/Mimsa/Syntax/Language.hs
@@ -453,8 +453,19 @@ oneTypeConstructor = do
 
 typeNameParser :: Parser TypeName
 typeNameParser =
-  ConsName <$> constructParser <*> pure mempty
-    <|> VarName <$> nameParser
+  emptyConsParser <|> varNameParser <|> inBrackets parameterisedConsParser <|> varNameParser
+
+emptyConsParser :: Parser TypeName
+emptyConsParser = ConsName <$> constructParser <*> pure mempty
+
+parameterisedConsParser :: Parser TypeName
+parameterisedConsParser = do
+  c <- constructParser
+  params <- P.zeroOrMore (P.right P.space1 typeNameParser)
+  pure $ ConsName c params
+
+varNameParser :: Parser TypeName
+varNameParser = VarName <$> nameParser
 
 ---
 --

--- a/src/Language/Mimsa/Syntax/Language.hs
+++ b/src/Language/Mimsa/Syntax/Language.hs
@@ -445,5 +445,6 @@ oneTypeConstructor = do
 
 constructorAppParser :: Parser ParserExpr
 constructorAppParser = do
-  cons <- P.thenSpace constructParser
-  MyConsApp (MyConstructor cons) <$> expressionParser
+  cons <- constructParser
+  exprs <- P.oneOrMore (P.right P.space1 (orInBrackets expressionParser))
+  pure (foldl (\a rest -> MyConsApp a rest) (MyConstructor cons) exprs)

--- a/src/Language/Mimsa/Syntax/Language.hs
+++ b/src/Language/Mimsa/Syntax/Language.hs
@@ -453,7 +453,7 @@ oneTypeConstructor = do
 
 typeNameParser :: Parser TypeName
 typeNameParser =
-  ConsName <$> constructParser
+  ConsName <$> constructParser <*> pure mempty
     <|> VarName <$> nameParser
 
 ---
@@ -473,7 +473,7 @@ caseMatchParser = do
     matchesParser <|> pure <$> matchParser
       <|> pure mempty
   catchAll <-
-    Just <$> otherwiseParser (length matches > 0)
+    Just <$> otherwiseParser (null matches)
       <|> pure Nothing
   pure $ MyCaseMatch sumExpr matches catchAll
 

--- a/src/Language/Mimsa/Syntax/Language.hs
+++ b/src/Language/Mimsa/Syntax/Language.hs
@@ -429,20 +429,27 @@ typeParserWithCons = do
   _ <- P.thenSpace (P.literal "in")
   MyData tyName constructors <$> expressionParser
 
-manyTypeConstructors :: Parser (Map Construct [Construct])
+manyTypeConstructors :: Parser (Map Construct [TypeName])
 manyTypeConstructors = do
   cons <- NE.toList <$> P.oneOrMore (P.left oneTypeConstructor (P.thenSpace (P.literal "|")))
   lastCons <- oneTypeConstructor
   pure (mconcat cons <> lastCons)
 
-oneTypeConstructor :: Parser (Map Construct [Construct])
+oneTypeConstructor :: Parser (Map Construct [TypeName])
 oneTypeConstructor = do
   name <- constructParser
-  args <- P.zeroOrMore (P.right P.space1 constructParser)
+  args <- P.zeroOrMore (P.right P.space1 typeNameParser)
   pure (M.singleton name args)
 
 -----
 
+typeNameParser :: Parser TypeName
+typeNameParser =
+  ConsName <$> constructParser
+    <|> VarName <$> nameParser
+
+---
+--
 constructorAppParser :: Parser ParserExpr
 constructorAppParser = do
   cons <- constructParser

--- a/src/Language/Mimsa/Syntax/Language.hs
+++ b/src/Language/Mimsa/Syntax/Language.hs
@@ -78,6 +78,7 @@ complexParser =
     <|> listParser
     <|> recordParser
     <|> typeParser
+    <|> constructorAppParser
 
 protectedNames :: Set Text
 protectedNames =
@@ -429,3 +430,10 @@ oneTypeConstructor = do
   name <- constructParser
   args <- P.zeroOrMore (P.right P.space1 constructParser)
   pure (name, args)
+
+-----
+
+constructorAppParser :: Parser ParserExpr
+constructorAppParser = do
+  cons <- P.thenSpace constructParser
+  MyConsApp (MyConstructor cons) <$> expressionParser

--- a/src/Language/Mimsa/Syntax/Language.hs
+++ b/src/Language/Mimsa/Syntax/Language.hs
@@ -447,4 +447,4 @@ constructorAppParser :: Parser ParserExpr
 constructorAppParser = do
   cons <- constructParser
   exprs <- P.oneOrMore (P.right P.space1 (orInBrackets expressionParser))
-  pure (foldl (\a rest -> MyConsApp a rest) (MyConstructor cons) exprs)
+  pure (foldl MyConsApp (MyConstructor cons) exprs)

--- a/src/Language/Mimsa/Syntax/Language.hs
+++ b/src/Language/Mimsa/Syntax/Language.hs
@@ -417,17 +417,18 @@ typeParserEmpty = do
   _ <- P.thenSpace (P.literal "type")
   tyName <- P.thenSpace constructParser
   _ <- P.thenSpace (P.literal "in")
-  MyData tyName mempty <$> expressionParser
+  MyData tyName mempty mempty <$> expressionParser
 
 typeParserWithCons :: Parser ParserExpr
 typeParserWithCons = do
   _ <- P.thenSpace (P.literal "type")
   tyName <- P.thenSpace constructParser
+  tyArgs <- P.zeroOrMore (P.left nameParser P.space1)
   _ <- P.thenSpace (P.literal "=")
   constructors <- manyTypeConstructors <|> oneTypeConstructor
   _ <- P.space1
   _ <- P.thenSpace (P.literal "in")
-  MyData tyName constructors <$> expressionParser
+  MyData tyName tyArgs constructors <$> expressionParser
 
 manyTypeConstructors :: Parser (Map Construct [TypeName])
 manyTypeConstructors = do

--- a/src/Language/Mimsa/Syntax/Parser.hs
+++ b/src/Language/Mimsa/Syntax/Parser.hs
@@ -101,6 +101,14 @@ predicate parser predicate' =
             else Left $ "Predicate did not hold for " <> T.pack (show a)
     )
 
+maybePred :: (Show a) => Parser a -> (a -> Maybe b) -> Parser b
+maybePred parser predicate' =
+  mkParser
+    ( runParser parser >=> \(next, a) -> case predicate' a of
+        Just b -> Right (next, b)
+        Nothing -> Left $ "Predicate did not hold for " <> T.pack (show a)
+    )
+
 literal :: Text -> Parser Text
 literal lit =
   mkParser

--- a/src/Language/Mimsa/Typechecker/DataTypes.hs
+++ b/src/Language/Mimsa/Typechecker/DataTypes.hs
@@ -2,12 +2,17 @@
 
 module Language.Mimsa.Typechecker.DataTypes where
 
+import Data.Map (Map)
 import qualified Data.Map as M
 import Language.Mimsa.Types.Construct
 import Language.Mimsa.Types.Environment
+import Language.Mimsa.Types.MonoType
 
 defaultEnv :: Environment
 defaultEnv = Environment mempty dts
   where
     dts =
       M.fromList [(mkConstruct "String", mempty), (mkConstruct "Int", mempty)]
+
+builtInTypes :: Map Construct MonoType
+builtInTypes = M.fromList [(mkConstruct "String", MTString), (mkConstruct "Int", MTInt)]

--- a/src/Language/Mimsa/Typechecker/DataTypes.hs
+++ b/src/Language/Mimsa/Typechecker/DataTypes.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Typechecker.DataTypes where
+
+import qualified Data.Map as M
+import Language.Mimsa.Types.Construct
+import Language.Mimsa.Types.Environment
+
+defaultEnv :: Environment
+defaultEnv = Environment mempty dts
+  where
+    dts =
+      M.fromList [(mkConstruct "String", mempty), (mkConstruct "Int", mempty)]

--- a/src/Language/Mimsa/Typechecker/DataTypes.hs
+++ b/src/Language/Mimsa/Typechecker/DataTypes.hs
@@ -12,7 +12,7 @@ defaultEnv :: Environment
 defaultEnv = Environment mempty dts
   where
     dts =
-      M.fromList [(mkConstruct "String", mempty), (mkConstruct "Int", mempty)]
+      mempty <$ builtInTypes
 
 builtInTypes :: Map Construct MonoType
 builtInTypes = M.fromList [(mkConstruct "String", MTString), (mkConstruct "Int", MTInt)]

--- a/src/Language/Mimsa/Typechecker/Environment.hs
+++ b/src/Language/Mimsa/Typechecker/Environment.hs
@@ -1,0 +1,19 @@
+module Language.Mimsa.Typechecker.Environment where
+
+import Control.Monad.Except
+import Data.Map (Map)
+import qualified Data.Map as M
+import Language.Mimsa.Typechecker.TcMonad
+import Language.Mimsa.Types
+
+-- given a constructor name, return the type it lives in
+lookupConstructor ::
+  Environment ->
+  Construct ->
+  TcMonad (Construct, ([Name], Map Construct [TypeName]))
+lookupConstructor env name =
+  let hasMatchingConstructor (_, items) = M.member name items
+   in case M.toList $ M.filter hasMatchingConstructor (getDataTypes env) of
+        [a] -> pure a -- we only want a single match
+        (_ : _) -> throwError (ConflictingConstructors name)
+        _ -> throwError (TypeConstructorNotInScope env name)

--- a/src/Language/Mimsa/Typechecker/Generalise.hs
+++ b/src/Language/Mimsa/Typechecker/Generalise.hs
@@ -19,7 +19,6 @@ freeVars MTString = mempty
 freeVars MTBool = mempty
 freeVars MTUnit = mempty
 freeVars (MTData _) = mempty
-freeVars (MTFun a b) = freeVars a <> freeVars b
 
 generalise :: Substitutions -> MonoType -> Scheme
 generalise (Substitutions subst) ty = Scheme free ty

--- a/src/Language/Mimsa/Typechecker/Generalise.hs
+++ b/src/Language/Mimsa/Typechecker/Generalise.hs
@@ -18,7 +18,8 @@ freeVars MTInt = mempty
 freeVars MTString = mempty
 freeVars MTBool = mempty
 freeVars MTUnit = mempty
-freeVars (MTConstructor _) = mempty
+freeVars (MTData _) = mempty
+freeVars (MTFun a b) = freeVars a <> freeVars b
 
 generalise :: Substitutions -> MonoType -> Scheme
 generalise (Substitutions subst) ty = Scheme free ty

--- a/src/Language/Mimsa/Typechecker/Generalise.hs
+++ b/src/Language/Mimsa/Typechecker/Generalise.hs
@@ -18,6 +18,7 @@ freeVars MTInt = mempty
 freeVars MTString = mempty
 freeVars MTBool = mempty
 freeVars MTUnit = mempty
+freeVars (MTConstructor _) = mempty
 
 generalise :: Substitutions -> MonoType -> Scheme
 generalise (Substitutions subst) ty = Scheme free ty

--- a/src/Language/Mimsa/Typechecker/Generalise.hs
+++ b/src/Language/Mimsa/Typechecker/Generalise.hs
@@ -18,7 +18,7 @@ freeVars MTInt = mempty
 freeVars MTString = mempty
 freeVars MTBool = mempty
 freeVars MTUnit = mempty
-freeVars (MTData _) = mempty
+freeVars (MTData _ _) = mempty
 
 generalise :: Substitutions -> MonoType -> Scheme
 generalise (Substitutions subst) ty = Scheme free ty

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -212,7 +212,7 @@ inferDataConstructor env name = do
   args <- findConstructorArgs env constructors name
   case args of
     [] -> pure (mempty, MTData ty)
-    as -> pure (mempty, foldr (\a rest -> MTFun a rest) (MTData ty) as)
+    as -> pure (mempty, foldr (\a rest -> MTFunction a rest) (MTData ty) as)
 
 -- given a constructor name, return the type it lives in
 lookupConstructor ::
@@ -252,7 +252,7 @@ inferConstructorApplication env consName value = do
     (tyExpectedArg : _) -> do
       (s2, tyArg) <- infer env value
       s3 <- unify tyExpectedArg tyArg
-      s4 <- unify (applySubst s3 tyCons) (MTFun tyArg tyRes)
+      s4 <- unify (applySubst s3 tyCons) (MTFunction tyArg tyRes)
       pure (s4 <> s3 <> s2 <> s1, applySubst (s4 <> s3) tyRes)
     _ -> throwError (CannotApplyToType consName)
 

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -229,7 +229,7 @@ inferArgTypes env type' tyNames tyArgs = do
   let pairWithUnknown a = (,) <$> pure a <*> getUnknown
   tyVars <- traverse pairWithUnknown tyNames
   let findType ty = case ty of
-        ConsName cn -> inferType env cn
+        ConsName cn vs -> inferType env cn vs
         VarName var ->
           case filter (\(tyName, _) -> tyName == var) tyVars of
             [(_, tyFound)] -> pure tyFound
@@ -253,8 +253,8 @@ lookupBuiltIn name = M.lookup name builtInTypes
 
 -- parse a type from it's name
 -- this will soon become insufficient for more complex types
-inferType :: Environment -> Construct -> TcMonad MonoType
-inferType env tyName =
+inferType :: Environment -> Construct -> [TypeName] -> TcMonad MonoType
+inferType env tyName _vs =
   if M.member tyName (getDataTypes env)
     then case lookupBuiltIn tyName of
       Just mt -> pure mt

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -212,7 +212,7 @@ inferDataConstructor env name = do
   args <- findConstructorArgs env constructors name
   case args of
     [] -> pure (mempty, MTData ty)
-    as -> pure (mempty, foldr (\a rest -> MTFunction a rest) (MTData ty) as)
+    as -> pure (mempty, foldr MTFunction (MTData ty) as)
 
 -- given a constructor name, return the type it lives in
 lookupConstructor ::
@@ -222,7 +222,7 @@ lookupConstructor ::
 lookupConstructor env name =
   let hasMatchingConstructor = M.member name
    in case M.toList $ M.filter hasMatchingConstructor (getDataTypes env) of
-        (a : []) -> pure a -- we only want a single match
+        [a] -> pure a -- we only want a single match
         (_ : _) -> throwError (ConflictingConstructors name)
         _ -> throwError (TypeConstructorNotInScope env name)
 

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -213,7 +213,7 @@ inferDataConstructor env name = do
   args <- findConstructorArgs constructors name
   (tyVars, tyArgs) <- inferArgTypes env tyVarNames args
   case args of
-    [] -> pure (mempty, MTData ty mempty)
+    [] -> pure (mempty, MTData ty tyVars)
     _ ->
       pure (mempty, foldr MTFunction (MTData ty tyVars) tyArgs)
 

--- a/src/Language/Mimsa/Typechecker/Patterns.hs
+++ b/src/Language/Mimsa/Typechecker/Patterns.hs
@@ -1,0 +1,29 @@
+module Language.Mimsa.Typechecker.Patterns where
+
+import Control.Monad.Except
+import Data.List (nub)
+import Data.Map (Map)
+import Language.Mimsa.Typechecker.Environment
+import Language.Mimsa.Typechecker.TcMonad
+import Language.Mimsa.Types
+
+checkCompleteness ::
+  Environment ->
+  [(Construct, Expr Variable)] ->
+  Maybe (Expr Variable) ->
+  TcMonad ()
+checkCompleteness _ _ (Just _) = pure ()
+checkCompleteness env opts Nothing = do
+  -- find data type for each match
+  items <- traverse (\(name, _) -> lookupConstructor env name) opts
+  -- check they are all the same one
+  dataType <- case nub items of
+    [a] -> pure a
+    _ -> throwError (MixedUpPatterns (fst <$> opts))
+  allPatternsExist (fst <$> opts) dataType
+  pure ()
+
+allPatternsExist :: [Construct] -> (Construct, ([Name], Map Construct [TypeName])) -> TcMonad ()
+allPatternsExist optNames (_, (_, dataTypes)) = do
+  -- check each one of optNames exists in dataTypes
+  pure ()

--- a/src/Language/Mimsa/Typechecker/Patterns.hs
+++ b/src/Language/Mimsa/Typechecker/Patterns.hs
@@ -29,7 +29,7 @@ allPatternsExist optNames' (_, (_, dataTypes)) = do
   -- check each one of optNames exists in dataTypes
   let dtNames = S.fromList (M.keys dataTypes)
       optNames = S.fromList optNames'
-  let (_matched, unmatched) = S.partition (\a -> S.member a optNames) dtNames
+  let (_matched, unmatched) = S.partition (`S.member` optNames) dtNames
   if S.size unmatched > 0
     then throwError (IncompletePatternMatch (S.toList unmatched))
     else pure ()

--- a/src/Language/Mimsa/Typechecker/Unify.hs
+++ b/src/Language/Mimsa/Typechecker/Unify.hs
@@ -25,7 +25,6 @@ freeTypeVars ty = case ty of
   MTRecord as -> foldr S.union mempty (freeTypeVars <$> as)
   MTList as -> freeTypeVars as
   MTData _ -> S.empty
-  MTFun a b -> freeTypeVars a <> freeTypeVars b
   MTString -> S.empty
   MTInt -> S.empty
   MTBool -> S.empty
@@ -60,8 +59,6 @@ unify tyA tyB =
       unifyPairs (l, r) (l', r')
     (MTPair a b, MTPair a' b') -> unifyPairs (a, b) (a', b')
     (MTSum a b, MTSum a' b') ->
-      unifyPairs (a, b) (a', b')
-    (MTFun a b, MTFun a' b') ->
       unifyPairs (a, b) (a', b')
     (MTList a, MTList a') -> unify a a'
     (MTRecord as, MTRecord bs) -> do

--- a/src/Language/Mimsa/Typechecker/Unify.hs
+++ b/src/Language/Mimsa/Typechecker/Unify.hs
@@ -24,6 +24,7 @@ freeTypeVars ty = case ty of
   MTSum l r -> S.union (freeTypeVars l) (freeTypeVars r)
   MTRecord as -> foldr S.union mempty (freeTypeVars <$> as)
   MTList as -> freeTypeVars as
+  MTConstructor _ -> S.empty
   MTString -> S.empty
   MTInt -> S.empty
   MTBool -> S.empty

--- a/src/Language/Mimsa/Typechecker/Unify.hs
+++ b/src/Language/Mimsa/Typechecker/Unify.hs
@@ -72,7 +72,7 @@ unify tyA tyB =
     (MTData a tyAs, MTData b tyBs)
       | a == b -> do
         let pairs = zip tyAs tyBs
-        s <- traverse (\(tyA', tyB') -> unify tyA' tyB') pairs
+        s <- traverse (uncurry unify) pairs
         pure (mconcat s)
     (MTVar u, t) -> varBind u t
     (t, MTVar u) -> varBind u t

--- a/src/Language/Mimsa/Typechecker/Unify.hs
+++ b/src/Language/Mimsa/Typechecker/Unify.hs
@@ -24,7 +24,7 @@ freeTypeVars ty = case ty of
   MTSum l r -> S.union (freeTypeVars l) (freeTypeVars r)
   MTRecord as -> foldr S.union mempty (freeTypeVars <$> as)
   MTList as -> freeTypeVars as
-  MTData _ -> S.empty
+  MTData _ _ -> S.empty
   MTString -> S.empty
   MTInt -> S.empty
   MTBool -> S.empty
@@ -69,7 +69,9 @@ unify tyA tyB =
             unify tyLeft tyRight
       s <- traverse getRecordTypes allKeys
       pure (foldl (<>) mempty s)
-    (MTData a, MTData b) | a == b -> pure mempty
+    (MTData a _, MTData b _)
+      | a == b ->
+        pure mempty
     (MTVar u, t) -> varBind u t
     (t, MTVar u) -> varBind u t
     (a, b) ->

--- a/src/Language/Mimsa/Types.hs
+++ b/src/Language/Mimsa/Types.hs
@@ -16,6 +16,7 @@ module Language.Mimsa.Types
     module Language.Mimsa.Types.ResolverError,
     module Language.Mimsa.Types.InterpreterError,
     module Language.Mimsa.Types.Variable,
+    module Language.Mimsa.Types.Construct,
     module Language.Mimsa.Types.Scope,
     module Language.Mimsa.Types.Swaps,
     module Language.Mimsa.Types.UniVar,
@@ -29,6 +30,7 @@ where
 
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Bindings
+import Language.Mimsa.Types.Construct
 import Language.Mimsa.Types.Environment
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.ExprHash

--- a/src/Language/Mimsa/Types.hs
+++ b/src/Language/Mimsa/Types.hs
@@ -25,6 +25,7 @@ module Language.Mimsa.Types
     module Language.Mimsa.Types.Bindings,
     module Language.Mimsa.Types.StoreExpression,
     module Language.Mimsa.Types.Project,
+    module Language.Mimsa.Types.TypeName,
   )
 where
 
@@ -51,6 +52,7 @@ import Language.Mimsa.Types.Substitutions
 import Language.Mimsa.Types.Swaps
 import Language.Mimsa.Types.Tui
 import Language.Mimsa.Types.TypeError
+import Language.Mimsa.Types.TypeName
 import Language.Mimsa.Types.UniVar
 import Language.Mimsa.Types.Usage
 import Language.Mimsa.Types.Variable

--- a/src/Language/Mimsa/Types/AST.hs
+++ b/src/Language/Mimsa/Types/AST.hs
@@ -78,7 +78,7 @@ data Expr a
   | MyList (NonEmpty (Expr a)) -- [a]
   | MyRecord (Map Name (Expr a)) -- { dog: MyLiteral (MyInt 1), cat: MyLiteral (MyInt 2) }
   | MyRecordAccess (Expr a) Name -- a.foo
-  | MyData Construct (NonEmpty (Construct, [Construct])) (Expr a) -- tyName, (consName, fields) body
+  | MyData Construct (Map Construct [Construct]) (Expr a) -- tyName, Map constructor args, body
   | MyConstructor Construct -- use a constructor by name - WIP
   | MyConsApp (Expr a) (Expr a) -- constructor, value
   deriving (Eq, Ord, Show, Generic, JSON.FromJSON, JSON.ToJSON)
@@ -165,7 +165,7 @@ instance (Printer a) => Printer (Expr a) where
           <$> M.toList map'
   prettyPrint (MyData tyName constructors expr) =
     "type " <> prettyPrint tyName
-      <> T.intercalate " | " (printCons <$> NE.toList constructors)
+      <> T.intercalate " | " (printCons <$> M.toList constructors)
       <> " in "
       <> printSubExpr expr
     where

--- a/src/Language/Mimsa/Types/AST.hs
+++ b/src/Language/Mimsa/Types/AST.hs
@@ -80,6 +80,7 @@ data Expr a
   | MyRecordAccess (Expr a) Name -- a.foo
   | MyData Construct (NonEmpty (Construct, [Construct])) (Expr a) -- tyName, (consName, fields) body
   | MyConstructor Construct -- use a constructor by name - WIP
+  | MyConsApp (Expr a) (Expr a) -- constructor, value
   deriving (Eq, Ord, Show, Generic, JSON.FromJSON, JSON.ToJSON)
 
 instance (Printer a) => Printer (Expr a) where
@@ -171,6 +172,7 @@ instance (Printer a) => Printer (Expr a) where
       printCons (consName, args) =
         prettyPrint consName <> " " <> T.intercalate " " (prettyPrint <$> args)
   prettyPrint (MyConstructor name) = prettyPrint name
+  prettyPrint (MyConsApp fn val) = prettyPrint fn <> " " <> prettyPrint val
 
 inParens :: (Printer a) => a -> Text
 inParens a = "(" <> prettyPrint a <> ")"

--- a/src/Language/Mimsa/Types/AST.hs
+++ b/src/Language/Mimsa/Types/AST.hs
@@ -181,7 +181,7 @@ instance (Printer a) => Printer (Expr a) where
     "case "
       <> printSubExpr sumExpr
       <> " of "
-      <> T.intercalate "| " (printMatch <$> matches)
+      <> T.intercalate " | " (printMatch <$> matches)
       <> maybe "" (\catchExpr -> " | otherwise " <> printSubExpr catchExpr) catchAll
     where
       printMatch (construct, expr') =

--- a/src/Language/Mimsa/Types/AST.hs
+++ b/src/Language/Mimsa/Types/AST.hs
@@ -24,6 +24,7 @@ import GHC.Generics
 import Language.Mimsa.Types.Construct
 import Language.Mimsa.Types.Name
 import Language.Mimsa.Types.Printer
+import Language.Mimsa.Types.TypeName
 
 ------------
 
@@ -78,8 +79,8 @@ data Expr a
   | MyList (NonEmpty (Expr a)) -- [a]
   | MyRecord (Map Name (Expr a)) -- { dog: MyLiteral (MyInt 1), cat: MyLiteral (MyInt 2) }
   | MyRecordAccess (Expr a) Name -- a.foo
-  | MyData Construct (Map Construct [Construct]) (Expr a) -- tyName, Map constructor args, body
-  | MyConstructor Construct -- use a constructor by name - WIP
+  | MyData Construct (Map Construct [TypeName]) (Expr a) -- tyName, Map constructor args, body
+  | MyConstructor Construct -- use a constructor by name
   | MyConsApp (Expr a) (Expr a) -- constructor, value
   deriving (Eq, Ord, Show, Generic, JSON.FromJSON, JSON.ToJSON)
 

--- a/src/Language/Mimsa/Types/AST.hs
+++ b/src/Language/Mimsa/Types/AST.hs
@@ -79,7 +79,7 @@ data Expr a
   | MyList (NonEmpty (Expr a)) -- [a]
   | MyRecord (Map Name (Expr a)) -- { dog: MyLiteral (MyInt 1), cat: MyLiteral (MyInt 2) }
   | MyRecordAccess (Expr a) Name -- a.foo
-  | MyData Construct (Map Construct [TypeName]) (Expr a) -- tyName, Map constructor args, body
+  | MyData Construct [Name] (Map Construct [TypeName]) (Expr a) -- tyName, tyArgs, Map constructor args, body
   | MyConstructor Construct -- use a constructor by name
   | MyConsApp (Expr a) (Expr a) -- constructor, value
   deriving (Eq, Ord, Show, Generic, JSON.FromJSON, JSON.ToJSON)
@@ -164,8 +164,10 @@ instance (Printer a) => Printer (Expr a) where
               <> printSubExpr val
         )
           <$> M.toList map'
-  prettyPrint (MyData tyName constructors expr) =
+  prettyPrint (MyData tyName tyArgs constructors expr) =
     "type " <> prettyPrint tyName
+      <> T.intercalate " " (prettyPrint <$> tyArgs)
+      <> " "
       <> T.intercalate " | " (printCons <$> M.toList constructors)
       <> " in "
       <> printSubExpr expr

--- a/src/Language/Mimsa/Types/AST.hs
+++ b/src/Language/Mimsa/Types/AST.hs
@@ -21,6 +21,7 @@ import qualified Data.Map as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import GHC.Generics
+import Language.Mimsa.Types.Construct
 import Language.Mimsa.Types.Name
 import Language.Mimsa.Types.Printer
 
@@ -77,6 +78,8 @@ data Expr a
   | MyList (NonEmpty (Expr a)) -- [a]
   | MyRecord (Map Name (Expr a)) -- { dog: MyLiteral (MyInt 1), cat: MyLiteral (MyInt 2) }
   | MyRecordAccess (Expr a) Name -- a.foo
+  | MyData Construct (NonEmpty (Construct, [Construct])) (Expr a) -- tyName, (consName, fields) body
+  | MyConstructor Construct -- use a constructor by name - WIP
   deriving (Eq, Ord, Show, Generic, JSON.FromJSON, JSON.ToJSON)
 
 instance (Printer a) => Printer (Expr a) where
@@ -159,6 +162,15 @@ instance (Printer a) => Printer (Expr a) where
               <> printSubExpr val
         )
           <$> M.toList map'
+  prettyPrint (MyData tyName constructors expr) =
+    "type " <> prettyPrint tyName
+      <> T.intercalate " | " (printCons <$> NE.toList constructors)
+      <> " in "
+      <> printSubExpr expr
+    where
+      printCons (consName, args) =
+        prettyPrint consName <> " " <> T.intercalate " " (prettyPrint <$> args)
+  prettyPrint (MyConstructor name) = prettyPrint name
 
 inParens :: (Printer a) => a -> Text
 inParens a = "(" <> prettyPrint a <> ")"

--- a/src/Language/Mimsa/Types/Construct.hs
+++ b/src/Language/Mimsa/Types/Construct.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Language.Mimsa.Types.Name where
+module Language.Mimsa.Types.Construct where
 
 import qualified Data.Aeson as JSON
 import qualified Data.Char as Ch
@@ -12,7 +12,7 @@ import qualified Data.Text as T
 import GHC.Generics
 import Language.Mimsa.Types.Printer
 
-newtype Name = Name {getName' :: Text}
+newtype Construct = Construct {getConstruct' :: Text}
   deriving stock (Eq, Ord, Generic)
   deriving newtype
     ( Show,
@@ -22,27 +22,27 @@ newtype Name = Name {getName' :: Text}
       JSON.ToJSONKey
     )
 
-instance Printer Name where
-  prettyPrint = getName
+instance Printer Construct where
+  prettyPrint = getConstruct
 
-getName :: Name -> Text
-getName (Name t) = t
+getConstruct :: Construct -> Text
+getConstruct (Construct t) = t
 
-validName :: Text -> Bool
-validName a =
+validConstruct :: Text -> Bool
+validConstruct a =
   T.length a > 0
     && T.filter Ch.isAlphaNum a == a
     && not (Ch.isDigit (T.head a))
-    && Ch.isLower (T.head a)
+    && Ch.isUpper (T.head a)
 
-mkName :: Text -> Name
-mkName a =
-  if validName a
-    then Name a
-    else error $ T.unpack $ "Name validation fail for '" <> a <> "'"
+mkConstruct :: Text -> Construct
+mkConstruct a =
+  if validConstruct a
+    then Construct a
+    else error $ T.unpack $ "Construct validation fail for '" <> a <> "'"
 
-safeMkName :: Text -> Maybe Name
-safeMkName a =
-  if validName a
-    then Just (Name a)
+safeMkConstruct :: Text -> Maybe Construct
+safeMkConstruct a =
+  if validConstruct a
+    then Just (Construct a)
     else Nothing

--- a/src/Language/Mimsa/Types/Environment.hs
+++ b/src/Language/Mimsa/Types/Environment.hs
@@ -8,6 +8,7 @@ import qualified Data.Text as T
 import Language.Mimsa.Types.Construct
 import Language.Mimsa.Types.Printer
 import Language.Mimsa.Types.Scheme
+import Language.Mimsa.Types.TypeName
 import Language.Mimsa.Types.Variable
 
 ---
@@ -16,7 +17,7 @@ import Language.Mimsa.Types.Variable
 data Environment
   = Environment
       { getSchemes :: Map Variable Scheme,
-        getDataTypes :: Map Construct (Map Construct [Construct])
+        getDataTypes :: Map Construct (Map Construct [TypeName])
       }
   deriving (Eq, Ord, Show)
 

--- a/src/Language/Mimsa/Types/Environment.hs
+++ b/src/Language/Mimsa/Types/Environment.hs
@@ -8,7 +8,6 @@ import Data.Map (Map)
 import qualified Data.Map as M
 import qualified Data.Text as T
 import Language.Mimsa.Types.Construct
-import Language.Mimsa.Types.Name
 import Language.Mimsa.Types.Printer
 import Language.Mimsa.Types.Scheme
 import Language.Mimsa.Types.Variable
@@ -19,7 +18,7 @@ import Language.Mimsa.Types.Variable
 data Environment
   = Environment
       { getSchemes :: Map Variable Scheme,
-        getDataTypes :: Map Name (Construct, NonEmpty (Construct, [Construct]))
+        getDataTypes :: Map Construct (NonEmpty (Construct, [Construct]))
       }
   deriving (Eq, Ord, Show)
 

--- a/src/Language/Mimsa/Types/Environment.hs
+++ b/src/Language/Mimsa/Types/Environment.hs
@@ -1,9 +1,7 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Language.Mimsa.Types.Environment where
 
-import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
 import qualified Data.Map as M
 import qualified Data.Text as T
@@ -18,7 +16,7 @@ import Language.Mimsa.Types.Variable
 data Environment
   = Environment
       { getSchemes :: Map Variable Scheme,
-        getDataTypes :: Map Construct (NonEmpty (Construct, [Construct]))
+        getDataTypes :: Map Construct (Map Construct [Construct])
       }
   deriving (Eq, Ord, Show)
 

--- a/src/Language/Mimsa/Types/Environment.hs
+++ b/src/Language/Mimsa/Types/Environment.hs
@@ -3,22 +3,36 @@
 
 module Language.Mimsa.Types.Environment where
 
+import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
 import qualified Data.Map as M
 import qualified Data.Text as T
+import Language.Mimsa.Types.Construct
+import Language.Mimsa.Types.Name
 import Language.Mimsa.Types.Printer
 import Language.Mimsa.Types.Scheme
 import Language.Mimsa.Types.Variable
 
 ---
 
-newtype Environment = Environment {getEnvironment :: Map Variable Scheme}
-  deriving (Eq, Ord, Show, Semigroup, Monoid)
+-- everything we need in typechecking environment
+data Environment
+  = Environment
+      { getSchemes :: Map Variable Scheme,
+        getDataTypes :: Map Name (Construct, NonEmpty (Construct, [Construct]))
+      }
+  deriving (Eq, Ord, Show)
+
+instance Semigroup Environment where
+  (Environment a b) <> (Environment a' b') = Environment (a <> a') (b <> b')
+
+instance Monoid Environment where
+  mempty = Environment mempty mempty
 
 instance Printer Environment where
-  prettyPrint (Environment items) =
+  prettyPrint (Environment typeSchemes _dataTypes) =
     "[\n"
-      <> T.intercalate ", \n" (printRow <$> M.toList items)
+      <> T.intercalate ", \n" (printRow <$> M.toList typeSchemes)
       <> "\n]"
     where
       printRow (var, scheme) =

--- a/src/Language/Mimsa/Types/Environment.hs
+++ b/src/Language/Mimsa/Types/Environment.hs
@@ -6,6 +6,7 @@ import Data.Map (Map)
 import qualified Data.Map as M
 import qualified Data.Text as T
 import Language.Mimsa.Types.Construct
+import Language.Mimsa.Types.Name
 import Language.Mimsa.Types.Printer
 import Language.Mimsa.Types.Scheme
 import Language.Mimsa.Types.TypeName
@@ -17,7 +18,7 @@ import Language.Mimsa.Types.Variable
 data Environment
   = Environment
       { getSchemes :: Map Variable Scheme,
-        getDataTypes :: Map Construct (Map Construct [TypeName])
+        getDataTypes :: Map Construct ([Name], Map Construct [TypeName])
       }
   deriving (Eq, Ord, Show)
 

--- a/src/Language/Mimsa/Types/InterpreterError.hs
+++ b/src/Language/Mimsa/Types/InterpreterError.hs
@@ -24,6 +24,7 @@ data InterpreterError
   | PredicateForIfMustBeABoolean (Expr Variable)
   | CouldNotUnwrapBuiltIn Variable
   | CouldNotMatchBuiltInId BiIds
+  | PatternMatchFailure (Expr Variable)
   deriving (Eq, Ord, Show)
 
 instance Printer InterpreterError where
@@ -40,6 +41,7 @@ instance Printer InterpreterError where
   prettyPrint (PredicateForIfMustBeABoolean expr) = "Expected a boolean as a predicate. Cannot use: " <> prettyPrint expr
   prettyPrint (CouldNotUnwrapBuiltIn name) = "Could unwrap built-in " <> prettyPrint name
   prettyPrint (CouldNotMatchBuiltInId ids) = "Could not match built in ids " <> prettyPrint ids
+  prettyPrint (PatternMatchFailure expr') = "Could not pattern match on value " <> prettyPrint expr'
   prettyPrint UnknownInterpreterError = "Unknown interpreter error"
 
 instance Semigroup InterpreterError where

--- a/src/Language/Mimsa/Types/MonoType.hs
+++ b/src/Language/Mimsa/Types/MonoType.hs
@@ -28,7 +28,6 @@ data MonoType
   | MTRecord (Map Name MonoType) -- { foo: a, bar: b }
   | MTVar Variable
   | MTData Construct
-  | MTFun MonoType MonoType
   deriving (Eq, Ord, Show)
 
 -----------
@@ -56,7 +55,6 @@ instance Printer MonoType where
               <> printSubType mt
         )
           <$> M.toList as
-  prettyPrint (MTFun a b) = printSubType a <> " -> " <> printSubType b
 
 -- simple things with no brackets, complex things in brackets
 printSubType :: MonoType -> Text

--- a/src/Language/Mimsa/Types/MonoType.hs
+++ b/src/Language/Mimsa/Types/MonoType.hs
@@ -27,7 +27,8 @@ data MonoType
   | MTList MonoType -- [a]
   | MTRecord (Map Name MonoType) -- { foo: a, bar: b }
   | MTVar Variable
-  | MTConstructor Construct
+  | MTData Construct
+  | MTFun MonoType MonoType
   deriving (Eq, Ord, Show)
 
 -----------
@@ -40,7 +41,7 @@ instance Printer MonoType where
   prettyPrint MTString = "String"
   prettyPrint MTBool = "Boolean"
   prettyPrint MTUnit = "Unit"
-  prettyPrint (MTConstructor consName) = prettyPrint consName
+  prettyPrint (MTData consName) = prettyPrint consName <> "'"
   prettyPrint (MTFunction a b) = printSubType a <> " -> " <> printSubType b
   prettyPrint (MTPair a b) = "(" <> printSubType a <> ", " <> printSubType b <> ")"
   prettyPrint (MTVar a) = prettyPrint a
@@ -55,6 +56,7 @@ instance Printer MonoType where
               <> printSubType mt
         )
           <$> M.toList as
+  prettyPrint (MTFun a b) = printSubType a <> " -> " <> printSubType b
 
 -- simple things with no brackets, complex things in brackets
 printSubType :: MonoType -> Text

--- a/src/Language/Mimsa/Types/MonoType.hs
+++ b/src/Language/Mimsa/Types/MonoType.hs
@@ -27,7 +27,7 @@ data MonoType
   | MTList MonoType -- [a]
   | MTRecord (Map Name MonoType) -- { foo: a, bar: b }
   | MTVar Variable
-  | MTData Construct
+  | MTData Construct [MonoType] -- name, typeVars
   deriving (Eq, Ord, Show)
 
 -----------
@@ -40,7 +40,9 @@ instance Printer MonoType where
   prettyPrint MTString = "String"
   prettyPrint MTBool = "Boolean"
   prettyPrint MTUnit = "Unit"
-  prettyPrint (MTData consName) = prettyPrint consName <> "'"
+  prettyPrint (MTData consName tyVars) =
+    prettyPrint consName <> " "
+      <> T.intercalate " " (prettyPrint <$> tyVars)
   prettyPrint (MTFunction a b) = printSubType a <> " -> " <> printSubType b
   prettyPrint (MTPair a b) = "(" <> printSubType a <> ", " <> printSubType b <> ")"
   prettyPrint (MTVar a) = prettyPrint a

--- a/src/Language/Mimsa/Types/MonoType.hs
+++ b/src/Language/Mimsa/Types/MonoType.hs
@@ -9,6 +9,7 @@ import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Text (Text)
 import qualified Data.Text as T
+import Language.Mimsa.Types.Construct
 import Language.Mimsa.Types.Name
 import Language.Mimsa.Types.Printer
 import Language.Mimsa.Types.Variable
@@ -26,6 +27,7 @@ data MonoType
   | MTList MonoType -- [a]
   | MTRecord (Map Name MonoType) -- { foo: a, bar: b }
   | MTVar Variable
+  | MTConstructor Construct
   deriving (Eq, Ord, Show)
 
 -----------
@@ -38,6 +40,7 @@ instance Printer MonoType where
   prettyPrint MTString = "String"
   prettyPrint MTBool = "Boolean"
   prettyPrint MTUnit = "Unit"
+  prettyPrint (MTConstructor consName) = prettyPrint consName
   prettyPrint (MTFunction a b) = printSubType a <> " -> " <> printSubType b
   prettyPrint (MTPair a b) = "(" <> printSubType a <> ", " <> printSubType b <> ")"
   prettyPrint (MTVar a) = prettyPrint a

--- a/src/Language/Mimsa/Types/Printer.hs
+++ b/src/Language/Mimsa/Types/Printer.hs
@@ -19,6 +19,9 @@ instance Printer Text where
 instance Printer Int where
   prettyPrint = T.pack . show
 
+instance (Printer a) => Printer [a] where
+  prettyPrint as = T.intercalate ", " (prettyPrint <$> as)
+
 instance (Printer a, Printer b) => Printer (a, b) where
   prettyPrint (a, b) = T.intercalate "\n" [prettyPrint a, prettyPrint b]
 

--- a/src/Language/Mimsa/Types/Printer.hs
+++ b/src/Language/Mimsa/Types/Printer.hs
@@ -23,19 +23,21 @@ instance (Printer a) => Printer [a] where
   prettyPrint as = T.intercalate ", " (prettyPrint <$> as)
 
 instance (Printer a, Printer b) => Printer (a, b) where
-  prettyPrint (a, b) = T.intercalate "\n" [prettyPrint a, prettyPrint b]
+  prettyPrint (a, b) = "\n " <> T.intercalate "\n " [prettyPrint a, prettyPrint b]
 
 instance (Printer a, Printer b, Printer c) => Printer (a, b, c) where
   prettyPrint (a, b, c) =
-    T.intercalate
-      "\n"
-      [prettyPrint a, prettyPrint b, prettyPrint c]
+    "\n "
+      <> T.intercalate
+        "\n "
+        [prettyPrint a, prettyPrint b, prettyPrint c]
 
 instance (Printer a, Printer b, Printer c, Printer d) => Printer (a, b, c, d) where
   prettyPrint (a, b, c, d) =
-    T.intercalate
-      "\n"
-      [prettyPrint a, prettyPrint b, prettyPrint c, prettyPrint d]
+    "\n "
+      <> T.intercalate
+        "\n "
+        [prettyPrint a, prettyPrint b, prettyPrint c, prettyPrint d]
 
 instance (Printer a) => Printer (Set a) where
   prettyPrint as = "[" <> T.intercalate ", " (prettyPrint <$> S.toList as) <> "]"

--- a/src/Language/Mimsa/Types/Substitutions.hs
+++ b/src/Language/Mimsa/Types/Substitutions.hs
@@ -1,9 +1,13 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Language.Mimsa.Types.Substitutions where
 
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
 import Language.Mimsa.Types.MonoType
+import Language.Mimsa.Types.Printer
 import Language.Mimsa.Types.Variable
 
 ---
@@ -17,6 +21,11 @@ instance Semigroup Substitutions where
 
 instance Monoid Substitutions where
   mempty = Substitutions mempty
+
+instance Printer Substitutions where
+  prettyPrint (Substitutions s1) = "\n  " <> T.intercalate "\n  " (printRow <$> M.toList s1)
+    where
+      printRow (var, mt) = prettyPrint var <> ": " <> prettyPrint mt
 
 ---
 

--- a/src/Language/Mimsa/Types/Substitutions.hs
+++ b/src/Language/Mimsa/Types/Substitutions.hs
@@ -25,10 +25,10 @@ substLookup subst i = M.lookup i (getSubstitutions subst)
 
 applySubst :: Substitutions -> MonoType -> MonoType
 applySubst subst ty = case ty of
-  MTVar i ->
+  MTVar var ->
     fromMaybe
-      (MTVar i)
-      (substLookup subst i)
+      (MTVar var)
+      (substLookup subst var)
   MTFunction arg res ->
     MTFunction (applySubst subst arg) (applySubst subst res)
   MTPair a b ->
@@ -38,7 +38,8 @@ applySubst subst ty = case ty of
   MTList a -> MTList (applySubst subst a)
   MTRecord a -> MTRecord (applySubst subst <$> a)
   MTSum a b -> MTSum (applySubst subst a) (applySubst subst b)
-  MTConstructor a -> MTConstructor a
+  MTData a -> MTData a
+  MTFun a b -> MTFun (applySubst subst a) (applySubst subst b)
   MTInt -> MTInt
   MTString -> MTString
   MTBool -> MTBool

--- a/src/Language/Mimsa/Types/Substitutions.hs
+++ b/src/Language/Mimsa/Types/Substitutions.hs
@@ -38,7 +38,7 @@ applySubst subst ty = case ty of
   MTList a -> MTList (applySubst subst a)
   MTRecord a -> MTRecord (applySubst subst <$> a)
   MTSum a b -> MTSum (applySubst subst a) (applySubst subst b)
-  MTData a ty' -> MTData a ty'
+  MTData a ty' -> MTData a (applySubst subst <$> ty')
   MTInt -> MTInt
   MTString -> MTString
   MTBool -> MTBool

--- a/src/Language/Mimsa/Types/Substitutions.hs
+++ b/src/Language/Mimsa/Types/Substitutions.hs
@@ -38,7 +38,7 @@ applySubst subst ty = case ty of
   MTList a -> MTList (applySubst subst a)
   MTRecord a -> MTRecord (applySubst subst <$> a)
   MTSum a b -> MTSum (applySubst subst a) (applySubst subst b)
-  MTData a -> MTData a
+  MTData a ty' -> MTData a ty'
   MTInt -> MTInt
   MTString -> MTString
   MTBool -> MTBool

--- a/src/Language/Mimsa/Types/Substitutions.hs
+++ b/src/Language/Mimsa/Types/Substitutions.hs
@@ -38,6 +38,7 @@ applySubst subst ty = case ty of
   MTList a -> MTList (applySubst subst a)
   MTRecord a -> MTRecord (applySubst subst <$> a)
   MTSum a b -> MTSum (applySubst subst a) (applySubst subst b)
+  MTConstructor a -> MTConstructor a
   MTInt -> MTInt
   MTString -> MTString
   MTBool -> MTBool

--- a/src/Language/Mimsa/Types/Substitutions.hs
+++ b/src/Language/Mimsa/Types/Substitutions.hs
@@ -39,7 +39,6 @@ applySubst subst ty = case ty of
   MTRecord a -> MTRecord (applySubst subst <$> a)
   MTSum a b -> MTSum (applySubst subst a) (applySubst subst b)
   MTData a -> MTData a
-  MTFun a b -> MTFun (applySubst subst a) (applySubst subst b)
   MTInt -> MTInt
   MTString -> MTString
   MTBool -> MTBool

--- a/src/Language/Mimsa/Types/TypeError.hs
+++ b/src/Language/Mimsa/Types/TypeError.hs
@@ -36,6 +36,7 @@ data TypeError
   | CaseMatchExpectedLambda (Expr Variable) (Expr Variable)
   | TypeConstructorNotInScope Environment Construct
   | TypeIsNotConstructor (Expr Variable)
+  | TypeVariableNotInDataType Name [Name]
   | ConflictingConstructors Construct
   | CannotApplyToType Construct
   | DuplicateTypeDeclaration Construct
@@ -89,14 +90,19 @@ instance Printer TypeError where
     "Cannot apply value to " <> prettyPrint name
   prettyPrint (DuplicateTypeDeclaration name) =
     "Cannot redeclare existing type name " <> prettyPrint name
+  prettyPrint (TypeVariableNotInDataType a as) =
+    "Type variable " <> prettyPrint a <> " could not be in found in type vars for datatype: ["
+      <> T.intercalate ", " (prettyPrint <$> as)
+      <> "]"
 
 printDataTypes :: Environment -> Text
 printDataTypes env = T.intercalate "\n" (printDt <$> M.toList (getDataTypes env))
   where
-    printDt (tyName, constructors) =
-      prettyPrint tyName
+    printDt (tyName, (tyVars, constructors)) =
+      prettyPrint tyName <> printTyVars tyVars
         <> ": "
         <> T.intercalate " | " (printCons <$> M.toList constructors)
+    printTyVars as = T.intercalate " " (prettyPrint <$> as)
     printCons (consName, args) =
       prettyPrint consName
         <> " "

--- a/src/Language/Mimsa/Types/TypeError.hs
+++ b/src/Language/Mimsa/Types/TypeError.hs
@@ -36,7 +36,7 @@ data TypeError
   | CaseMatchExpectedLambda (Expr Variable) (Expr Variable)
   | TypeConstructorNotInScope Environment Construct
   | TypeIsNotConstructor (Expr Variable)
-  | TypeVariableNotInDataType Name [Name]
+  | TypeVariableNotInDataType Construct Name [Name]
   | ConflictingConstructors Construct
   | CannotApplyToType Construct
   | DuplicateTypeDeclaration Construct
@@ -92,8 +92,9 @@ instance Printer TypeError where
     "Cannot apply value to " <> prettyPrint name
   prettyPrint (DuplicateTypeDeclaration name) =
     "Cannot redeclare existing type name " <> prettyPrint name
-  prettyPrint (TypeVariableNotInDataType a as) =
-    "Type variable " <> prettyPrint a <> " could not be in found in type vars for datatype: ["
+  prettyPrint (TypeVariableNotInDataType ty a as) =
+    "Type variable " <> prettyPrint a <> " could not be in found in type vars for " <> prettyPrint ty
+      <> ". The following type variables were found: ["
       <> T.intercalate ", " (prettyPrint <$> as)
       <> "]"
   prettyPrint (IncompletePatternMatch names) =

--- a/src/Language/Mimsa/Types/TypeError.hs
+++ b/src/Language/Mimsa/Types/TypeError.hs
@@ -12,6 +12,7 @@ import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Construct
 import Language.Mimsa.Types.Environment
 import Language.Mimsa.Types.MonoType
 import Language.Mimsa.Types.Name
@@ -33,6 +34,7 @@ data TypeError
   | CaseMatchExpectedPair MonoType
   | CaseMatchExpectedList MonoType
   | CaseMatchExpectedLambda (Expr Variable) (Expr Variable)
+  | TypeConstructorNotInScope Environment Construct
   deriving (Eq, Ord, Show)
 
 showKeys :: (Printer p) => Map p a -> Text
@@ -70,6 +72,7 @@ instance Printer TypeError where
     "Expected list but got " <> prettyPrint mt
   prettyPrint (CaseMatchExpectedLambda l r) =
     "Expected lambdas but got " <> prettyPrint l <> " and " <> prettyPrint r
+  prettyPrint (TypeConstructorNotInScope name env) = "Type constructor for " <> prettyPrint name <> " not found in scope { " <> prettyPrint env <> " }"
 
 instance Semigroup TypeError where
   a <> _ = a

--- a/src/Language/Mimsa/Types/TypeError.hs
+++ b/src/Language/Mimsa/Types/TypeError.hs
@@ -40,6 +40,8 @@ data TypeError
   | ConflictingConstructors Construct
   | CannotApplyToType Construct
   | DuplicateTypeDeclaration Construct
+  | IncompletePatternMatch [Construct]
+  | MixedUpPatterns [Construct]
   deriving (Eq, Ord, Show)
 
 showKeys :: (Printer p) => Map p a -> Text
@@ -93,6 +95,14 @@ instance Printer TypeError where
   prettyPrint (TypeVariableNotInDataType a as) =
     "Type variable " <> prettyPrint a <> " could not be in found in type vars for datatype: ["
       <> T.intercalate ", " (prettyPrint <$> as)
+      <> "]"
+  prettyPrint (IncompletePatternMatch names) =
+    "Incomplete pattern match. Missing constructors: ["
+      <> T.intercalate ", " (prettyPrint <$> names)
+      <> "]"
+  prettyPrint (MixedUpPatterns names) =
+    "Mixed up patterns in same match. Constructors: ["
+      <> T.intercalate ", " (prettyPrint <$> names)
       <> "]"
 
 printDataTypes :: Environment -> Text

--- a/src/Language/Mimsa/Types/TypeName.hs
+++ b/src/Language/Mimsa/Types/TypeName.hs
@@ -1,17 +1,23 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Language.Mimsa.Types.TypeName where
 
 import qualified Data.Aeson as JSON
+import qualified Data.Text as T
 import GHC.Generics
 import Language.Mimsa.Types.Construct
 import Language.Mimsa.Types.Name
 import Language.Mimsa.Types.Printer
 
-data TypeName = ConsName Construct | VarName Name
+data TypeName = ConsName Construct [TypeName] | VarName Name
   deriving (Eq, Ord, Show, Generic, JSON.ToJSON, JSON.FromJSON)
 
 instance Printer TypeName where
-  prettyPrint (ConsName c) = prettyPrint c
+  prettyPrint (ConsName c tys) = prettyPrint c <> vars tys
+    where
+      vars ty = case ty of
+        [] -> ""
+        as -> T.intercalate " " (prettyPrint <$> as)
   prettyPrint (VarName v) = prettyPrint v

--- a/src/Language/Mimsa/Types/TypeName.hs
+++ b/src/Language/Mimsa/Types/TypeName.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Language.Mimsa.Types.TypeName where
+
+import qualified Data.Aeson as JSON
+import GHC.Generics
+import Language.Mimsa.Types.Construct
+import Language.Mimsa.Types.Name
+import Language.Mimsa.Types.Printer
+
+data TypeName = ConsName Construct | VarName Name
+  deriving (Eq, Ord, Show, Generic, JSON.ToJSON, JSON.FromJSON)
+
+instance Printer TypeName where
+  prettyPrint (ConsName c) = prettyPrint c
+  prettyPrint (VarName v) = prettyPrint v

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -243,21 +243,21 @@ spec =
         result <- eval stdLib "type LeBool = Vrai | Faux in Vrai"
         result
           `shouldBe` Right
-            ( MTData (mkConstruct "LeBool"),
+            ( MTData (mkConstruct "LeBool") [],
               MyConstructor (mkConstruct "Vrai")
             )
       it "type Nat = Zero | Suc Nat in Suc Zero" $ do
         result <- eval stdLib "type Nat = Zero | Suc Nat in Suc Zero"
         result
           `shouldBe` Right
-            ( MTData (mkConstruct "Nat"),
+            ( MTData (mkConstruct "Nat") [],
               MyConsApp (MyConstructor (mkConstruct "Suc")) (MyConstructor (mkConstruct "Zero"))
             )
       it "type Nat = Zero | Suc Nat in Suc Suc Zero" $ do
         result <- eval stdLib "type Nat = Zero | Suc Nat in Suc Suc Zero"
         result
           `shouldBe` Right
-            ( MTData (mkConstruct "Nat"),
+            ( MTData (mkConstruct "Nat") [],
               MyConsApp
                 (MyConstructor (mkConstruct "Suc"))
                 ( MyConsApp (MyConstructor (mkConstruct "Suc")) (MyConstructor (mkConstruct "Zero"))
@@ -276,8 +276,8 @@ spec =
         result
           `shouldBe` Right
             ( MTFunction
-                (MTData (mkConstruct "Nat"))
-                (MTData (mkConstruct "Nat")),
+                (MTData (mkConstruct "Nat") [])
+                (MTData (mkConstruct "Nat") []),
               MyConstructor (mkConstruct "Suc")
             )
       it "type OhNat = Zero | Suc OhNat String in Suc" $ do
@@ -285,10 +285,10 @@ spec =
         result
           `shouldBe` Right
             ( MTFunction
-                (MTData (mkConstruct "OhNat"))
+                (MTData (mkConstruct "OhNat") [])
                 ( MTFunction
                     MTString
-                    (MTData (mkConstruct "OhNat"))
+                    (MTData (mkConstruct "OhNat") [])
                 ),
               MyConstructor (mkConstruct "Suc")
             )
@@ -296,7 +296,7 @@ spec =
         result <- eval stdLib "type Pet = Cat String | Dog String in Cat \"mimsa\""
         result
           `shouldBe` Right
-            ( MTData (mkConstruct "Pet"),
+            ( MTData (mkConstruct "Pet") [],
               MyConsApp (MyConstructor (mkConstruct "Cat")) (str' "mimsa")
             )
       it "type Void in 1" $ do
@@ -313,7 +313,7 @@ spec =
                 MTInt
                 ( MTFunction
                     MTString
-                    (MTData (mkConstruct "LongBoy"))
+                    (MTData (mkConstruct "LongBoy") [])
                 ),
               MyConsApp
                 (MyConstructor (mkConstruct "Stuff"))
@@ -323,11 +323,18 @@ spec =
         result <- eval stdLib "type Tree = Leaf Int | Branch Tree Tree in Branch (Leaf 1) (Leaf 2)"
         result
           `shouldBe` Right
-            ( MTData (mkConstruct "Tree"),
+            ( MTData (mkConstruct "Tree") [],
               MyConsApp
                 ( MyConsApp
                     (MyConstructor $ mkConstruct "Branch")
                     (MyConsApp (MyConstructor $ mkConstruct "Leaf") (int 1))
                 )
                 (MyConsApp (MyConstructor $ mkConstruct "Leaf") (int 2))
+            )
+      it "type Maybe a = Just a | Nothing in Just 1" $ do
+        result <- eval stdLib "type Maybe a = Just a | Nothing in Just 1"
+        result
+          `shouldBe` Right
+            ( MTData (mkConstruct "Maybe") [MTInt],
+              MyConsApp (MyConstructor $ mkConstruct "Just") (int 1)
             )

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -354,3 +354,35 @@ spec =
             ( MTData (mkConstruct "Maybe") [MTInt],
               MyConsApp (MyConstructor $ mkConstruct "Just") (int 1)
             )
+      it "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | Nothing False" $ do
+        result <- eval stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | Nothing False"
+        result
+          `shouldBe` Right
+            (MTBool, bool False)
+      it "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> True | Nothing 1" $ do
+        result <- eval stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> True | Nothing 1"
+        result `shouldSatisfy` isLeft
+      it "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | otherwise False" $ do
+        result <- eval stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | otherwise False"
+        result
+          `shouldBe` Right
+            (MTBool, bool False)
+      it "type Stuff = Thing String Int in case Thing \"Hello\" 1 of Thing \\name -> \\num -> name" $ do
+        result <- eval stdLib "type Stuff = Thing String Int in case Thing \"Hello\" 1 of Thing \\name -> \\num -> name"
+        result
+          `shouldBe` Right
+            (MTString, str' "Hello")
+      it "type Result e a = Failure e | Success a in case Failure \"oh no\" of Success \\a -> \"oh yes\" | Failure \\e -> e" $ do
+        result <- eval stdLib "type Result e a = Failure e | Success a in case Failure \"oh no\" of Success \\a -> \"oh yes\" | Failure \\e -> e"
+        result
+          `shouldBe` Right
+            (MTString, str' "oh no")
+      it "type Blap a = Boop a Int in case Boop True 100 of Boop \\a -> \\b -> a" $ do
+        result <- eval stdLib "type Blap a = Boop a Int in case Boop True 100 of Boop \\a -> \\b -> a"
+        result `shouldBe` Right (MTBool, bool True)
+      it "type Maybe a = Just a | Nothing in case Nothing of Nothing False" $ do
+        result <- eval stdLib "type Maybe a = Just a | Nothing in case Nothing of Nothing False"
+        result `shouldSatisfy` isLeft
+      it "type Maybe a = Just a | Nothing in case Nothing of otherwise False" $ do
+        result <- eval stdLib "type Maybe a = Just a | Nothing in case Nothing of otherwise False"
+        result `shouldBe` Right (MTBool, bool False)

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -401,3 +401,28 @@ spec =
             ( MTData (mkConstruct "Tree") [MTInt],
               MyConsApp (MyConstructor $ mkConstruct "Leaf") (int 1)
             )
+      {-
+      it "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Leaf 1" $ do
+        result <- eval stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Leaf 1"
+        result
+          `shouldSatisfy` isLeft
+      -}
+      it "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Branch (Leaf 1) (Leaf True)" $ do
+        result <- eval stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Branch (Leaf 1) (Leaf True)"
+        result
+          `shouldSatisfy` isLeft
+      it "type Tree a = Empty | Branch (Tree a) a (Tree a) in Branch (Empty) 1 (Empty)" $ do
+        result <- eval stdLib "type Tree a = Empty | Branch (Tree a) a (Tree a) in Branch (Empty) 1 (Empty)"
+        result
+          `shouldBe` Right
+            ( MTData (mkConstruct "Tree") [MTInt],
+              MyConsApp
+                ( MyConsApp
+                    ( MyConsApp
+                        (MyConstructor $ mkConstruct "Branch")
+                        (MyConstructor $ mkConstruct "Empty")
+                    )
+                    (int 1)
+                )
+                (MyConstructor $ mkConstruct "Empty")
+            )

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -377,12 +377,20 @@ spec =
         result
           `shouldBe` Right
             (MTString, str' "oh no")
-      it "type Blap a = Boop a Int in case Boop True 100 of Boop \\a -> \\b -> a" $ do
-        result <- eval stdLib "type Blap a = Boop a Int in case Boop True 100 of Boop \\a -> \\b -> a"
-        result `shouldBe` Right (MTBool, bool True)
+      {-
+            it "type Blap a = Boop a Int in case Boop True 100 of Boop \\a -> \\b -> a" $ do
+              result <- eval stdLib "type Blap a = Boop a Int in case Boop True 100 of Boop \\a -> \\b -> a"
+              result `shouldBe` Right (MTBool, bool True)
+      -}
       it "type Maybe a = Just a | Nothing in case Nothing of Nothing False" $ do
         result <- eval stdLib "type Maybe a = Just a | Nothing in case Nothing of Nothing False"
         result `shouldSatisfy` isLeft
       it "type Maybe a = Just a | Nothing in case Nothing of otherwise False" $ do
         result <- eval stdLib "type Maybe a = Just a | Nothing in case Nothing of otherwise False"
         result `shouldBe` Right (MTBool, bool False)
+      it "type Thing = Thing String in let a = \"string\" in case a of Thing \\s -> s" $ do
+        result <- eval stdLib "type Thing = Thing String in let a = \"string\" in case a of Thing \\s -> s"
+        result `shouldBe` Right (MTString, str' "string")
+      it "type Pair a b = Pair a b in case Pair \"dog\" 1 of Pair \a -> a" $ do
+        result <- eval stdLib "type Pair a b = Pair a b in case Pair \"dog\" 1 of Pair \a -> a"
+        result `shouldSatisfy` isLeft

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -331,6 +331,15 @@ spec =
                 )
                 (MyConsApp (MyConstructor $ mkConstruct "Leaf") (int 2))
             )
+      it "type Maybe a = Just a | Nothing in Just" $ do
+        result <- eval stdLib "type Maybe a = Just a | Nothing in Just"
+        result
+          `shouldBe` Right
+            ( MTFunction
+                (MTVar (NumberedVar 1))
+                (MTData (mkConstruct "Maybe") [MTVar (NumberedVar 1)]),
+              MyConstructor $ mkConstruct "Just"
+            )
       it "type Maybe a = Just a | Nothing in Just 1" $ do
         result <- eval stdLib "type Maybe a = Just a | Nothing in Just 1"
         result

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -239,3 +239,10 @@ spec =
         result
           `shouldBe` Right
             (MTList MTInt, MyList $ NE.fromList [int 1, int 2, int 3, int 4])
+      it "type LeBool = Vrai | Faux in Vrai" $ do
+        result <- eval stdLib "type LeBool = Vrai | Faux in Vrai"
+        result
+          `shouldBe` Right
+            ( MTConstructor (mkConstruct "LeBool"),
+              MyConstructor (mkConstruct "Vrai")
+            )

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -388,8 +388,8 @@ spec =
       it "type Maybe a = Just a | Nothing in case Nothing of otherwise False" $ do
         result <- eval stdLib "type Maybe a = Just a | Nothing in case Nothing of otherwise False"
         result `shouldBe` Right (MTBool, bool False)
-      it "type Thing = Thing String in let a = \"string\" in case a of Thing \\s -> s" $ do
-        result <- eval stdLib "type Thing = Thing String in let a = \"string\" in case a of Thing \\s -> s"
+      it "type Thing = Thing String in let a = Thing \"string\" in case a of Thing \\s -> s" $ do
+        result <- eval stdLib "type Thing = Thing String in let a = Thing \"string\" in case a of Thing \\s -> s"
         result `shouldBe` Right (MTString, str' "string")
       it "type Pair a b = Pair a b in case Pair \"dog\" 1 of Pair \a -> a" $ do
         result <- eval stdLib "type Pair a b = Pair a b in case Pair \"dog\" 1 of Pair \a -> a"

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -275,7 +275,7 @@ spec =
         result <- eval stdLib "type Nat = Zero | Suc Nat in Suc"
         result
           `shouldBe` Right
-            ( MTFun
+            ( MTFunction
                 (MTData (mkConstruct "Nat"))
                 (MTData (mkConstruct "Nat")),
               MyConstructor (mkConstruct "Suc")
@@ -284,9 +284,9 @@ spec =
         result <- eval stdLib "type OhNat = Zero | Suc OhNat String in Suc"
         result
           `shouldBe` Right
-            ( MTFun
+            ( MTFunction
                 (MTData (mkConstruct "OhNat"))
-                ( MTFun
+                ( MTFunction
                     MTString
                     (MTData (mkConstruct "OhNat"))
                 ),
@@ -309,9 +309,9 @@ spec =
         result <- eval stdLib "type LongBoy = Stuff String Int String in Stuff \"yes\""
         result
           `shouldBe` Right
-            ( MTFun
+            ( MTFunction
                 MTInt
-                ( MTFun
+                ( MTFunction
                     MTString
                     (MTData (mkConstruct "LongBoy"))
                 ),

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -278,3 +278,9 @@ spec =
             ( MTConstructor (mkConstruct "Pet"),
               MyConsApp (MyConstructor (mkConstruct "Cat")) (str' "mimsa")
             )
+      it "type Void in 1" $ do
+        result <- eval stdLib "type Void in 1"
+        result `shouldBe` Right (MTInt, int 1)
+      it "type String = Should | Error in Error" $ do
+        result <- eval stdLib "type String = Should | Error in Error"
+        result `shouldSatisfy` isLeft

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -340,6 +340,13 @@ spec =
                 (MTData (mkConstruct "Maybe") [MTVar (NumberedVar 1)]),
               MyConstructor $ mkConstruct "Just"
             )
+      it "type Maybe a = Just a | Nothing in Nothing" $ do
+        result <- eval stdLib "type Maybe a = Just a | Nothing in Nothing"
+        result
+          `shouldBe` Right
+            ( MTData (mkConstruct "Maybe") [MTVar (NumberedVar 1)],
+              MyConstructor $ mkConstruct "Nothing"
+            )
       it "type Maybe a = Just a | Nothing in Just 1" $ do
         result <- eval stdLib "type Maybe a = Just a | Nothing in Just 1"
         result

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -6,7 +6,7 @@ module Test.Repl
   )
 where
 
-import Data.Either (isRight)
+import Data.Either (isLeft, isRight)
 import qualified Data.List.NonEmpty as NE
 import Data.Text (Text)
 import Language.Mimsa.Interpreter
@@ -245,4 +245,36 @@ spec =
           `shouldBe` Right
             ( MTConstructor (mkConstruct "LeBool"),
               MyConstructor (mkConstruct "Vrai")
+            )
+      it "type Nat = Zero | Suc Nat in Suc Zero" $ do
+        result <- eval stdLib "type Nat = Zero | Suc Nat in Suc Zero"
+        result
+          `shouldBe` Right
+            ( MTConstructor (mkConstruct "Nat"),
+              MyConsApp (MyConstructor (mkConstruct "Suc")) (MyConstructor (mkConstruct "Zero"))
+            )
+      it "type Nat = Zero | Suc Nat in Suc Suc Zero" $ do
+        result <- eval stdLib "type Nat = Zero | Suc Nat in Suc Suc Zero"
+        result
+          `shouldBe` Right
+            ( MTConstructor (mkConstruct "Nat"),
+              MyConsApp
+                (MyConstructor (mkConstruct "Suc"))
+                ( MyConsApp (MyConstructor (mkConstruct "Suc")) (MyConstructor (mkConstruct "Zero"))
+                )
+            )
+      it "type Nat = Zero | Suc Nat in Suc 1" $ do
+        result <- eval stdLib "type Nat = Zero | Suc Nat in Suc 1"
+        result
+          `shouldSatisfy` isLeft
+      it "type Nat = Zero | Suc Nat in Suc Dog" $ do
+        result <- eval stdLib "type Nat = Zero | Suc Nat in Suc Dog"
+        result
+          `shouldSatisfy` isLeft
+      it "type Pet = Cat String | Dog String in Cat \"mimsa\"" $ do
+        result <- eval stdLib "type Pet = Cat String | Dog String in Cat \"mimsa\""
+        result
+          `shouldBe` Right
+            ( MTConstructor (mkConstruct "Pet"),
+              MyConsApp (MyConstructor (mkConstruct "Cat")) (str' "mimsa")
             )

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -394,3 +394,10 @@ spec =
       it "type Pair a b = Pair a b in case Pair \"dog\" 1 of Pair \a -> a" $ do
         result <- eval stdLib "type Pair a b = Pair a b in case Pair \"dog\" 1 of Pair \a -> a"
         result `shouldSatisfy` isLeft
+      it "type Tree a = Leaf a | Branch (Tree a) (Tree a) in Leaf 1" $ do
+        result <- eval stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree a) in Leaf 1"
+        result
+          `shouldBe` Right
+            ( MTData (mkConstruct "Tree") [MTInt],
+              MyConsApp (MyConstructor $ mkConstruct "Leaf") (int 1)
+            )

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -319,3 +319,15 @@ spec =
                 (MyConstructor (mkConstruct "Stuff"))
                 (str' "yes")
             )
+      it "type Tree = Leaf Int | Branch Tree Tree in Branch (Leaf 1) (Leaf 2)" $ do
+        result <- eval stdLib "type Tree = Leaf Int | Branch Tree Tree in Branch (Leaf 1) (Leaf 2)"
+        result
+          `shouldBe` Right
+            ( MTData (mkConstruct "Tree"),
+              MyConsApp
+                ( MyConsApp
+                    (MyConstructor $ mkConstruct "Branch")
+                    (MyConsApp (MyConstructor $ mkConstruct "Leaf") (int 1))
+                )
+                (MyConsApp (MyConstructor $ mkConstruct "Leaf") (int 2))
+            )

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -243,21 +243,21 @@ spec =
         result <- eval stdLib "type LeBool = Vrai | Faux in Vrai"
         result
           `shouldBe` Right
-            ( MTConstructor (mkConstruct "LeBool"),
+            ( MTData (mkConstruct "LeBool"),
               MyConstructor (mkConstruct "Vrai")
             )
       it "type Nat = Zero | Suc Nat in Suc Zero" $ do
         result <- eval stdLib "type Nat = Zero | Suc Nat in Suc Zero"
         result
           `shouldBe` Right
-            ( MTConstructor (mkConstruct "Nat"),
+            ( MTData (mkConstruct "Nat"),
               MyConsApp (MyConstructor (mkConstruct "Suc")) (MyConstructor (mkConstruct "Zero"))
             )
       it "type Nat = Zero | Suc Nat in Suc Suc Zero" $ do
         result <- eval stdLib "type Nat = Zero | Suc Nat in Suc Suc Zero"
         result
           `shouldBe` Right
-            ( MTConstructor (mkConstruct "Nat"),
+            ( MTData (mkConstruct "Nat"),
               MyConsApp
                 (MyConstructor (mkConstruct "Suc"))
                 ( MyConsApp (MyConstructor (mkConstruct "Suc")) (MyConstructor (mkConstruct "Zero"))
@@ -271,11 +271,32 @@ spec =
         result <- eval stdLib "type Nat = Zero | Suc Nat in Suc Dog"
         result
           `shouldSatisfy` isLeft
+      it "type Nat = Zero | Suc Nat in Suc" $ do
+        result <- eval stdLib "type Nat = Zero | Suc Nat in Suc"
+        result
+          `shouldBe` Right
+            ( MTFun
+                (MTData (mkConstruct "Nat"))
+                (MTData (mkConstruct "Nat")),
+              MyConstructor (mkConstruct "Suc")
+            )
+      it "type OhNat = Zero | Suc OhNat String in Suc" $ do
+        result <- eval stdLib "type OhNat = Zero | Suc OhNat String in Suc"
+        result
+          `shouldBe` Right
+            ( MTFun
+                (MTData (mkConstruct "OhNat"))
+                ( MTFun
+                    MTString
+                    (MTData (mkConstruct "OhNat"))
+                ),
+              MyConstructor (mkConstruct "Suc")
+            )
       it "type Pet = Cat String | Dog String in Cat \"mimsa\"" $ do
         result <- eval stdLib "type Pet = Cat String | Dog String in Cat \"mimsa\""
         result
           `shouldBe` Right
-            ( MTConstructor (mkConstruct "Pet"),
+            ( MTData (mkConstruct "Pet"),
               MyConsApp (MyConstructor (mkConstruct "Cat")) (str' "mimsa")
             )
       it "type Void in 1" $ do
@@ -284,3 +305,17 @@ spec =
       it "type String = Should | Error in Error" $ do
         result <- eval stdLib "type String = Should | Error in Error"
         result `shouldSatisfy` isLeft
+      it "type LongBoy = Stuff String Int String in Stuff \"yes\"" $ do
+        result <- eval stdLib "type LongBoy = Stuff String Int String in Stuff \"yes\""
+        result
+          `shouldBe` Right
+            ( MTFun
+                MTInt
+                ( MTFun
+                    MTString
+                    (MTData (mkConstruct "LongBoy"))
+                ),
+              MyConsApp
+                (MyConstructor (mkConstruct "Stuff"))
+                (str' "yes")
+            )

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -218,7 +218,7 @@ spec = do
               (mkConstruct "Dog")
               ( M.singleton
                   (mkConstruct "Dog")
-                  [mkConstruct "String"]
+                  [ConsName $ mkConstruct "String"]
               )
               (int 1)
           )
@@ -241,7 +241,7 @@ spec = do
               (mkConstruct "Nat")
               ( M.fromList
                   [ (mkConstruct "Zero", []),
-                    (mkConstruct "Succ", [mkConstruct "Nat"])
+                    (mkConstruct "Succ", [ConsName $ mkConstruct "Nat"])
                   ]
               )
               (int 1)

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -246,5 +246,15 @@ spec = do
               )
               (int 1)
           )
+    it "Parses a multiple argument constructor" $
+      parseExpr "Dog \"hi\" \"dog\""
+        `shouldBe` Right
+          ( MyConsApp
+              ( MyConsApp
+                  (MyConstructor $ mkConstruct "Dog")
+                  (str' "hi")
+              )
+              (str' "dog")
+          )
     it "Uses a constructor" $
       parseExpr "Vrai" `shouldBe` Right (MyConstructor (mkConstruct "Vrai"))

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -208,6 +208,7 @@ spec = do
         `shouldBe` Right
           ( MyData
               (mkConstruct "AbsoluteUnit")
+              mempty
               (M.singleton (mkConstruct "AbsoluteUnit") mempty)
               (int 1)
           )
@@ -216,6 +217,7 @@ spec = do
         `shouldBe` Right
           ( MyData
               (mkConstruct "Dog")
+              mempty
               ( M.singleton
                   (mkConstruct "Dog")
                   [ConsName $ mkConstruct "String"]
@@ -227,6 +229,7 @@ spec = do
         `shouldBe` Right
           ( MyData
               (mkConstruct "LeBool")
+              mempty
               ( M.fromList
                   [ (mkConstruct "Vrai", []),
                     (mkConstruct "Faux", [])
@@ -239,6 +242,7 @@ spec = do
         `shouldBe` Right
           ( MyData
               (mkConstruct "Nat")
+              mempty
               ( M.fromList
                   [ (mkConstruct "Zero", []),
                     (mkConstruct "Succ", [ConsName $ mkConstruct "Nat"])
@@ -255,6 +259,19 @@ spec = do
                   (str' "hi")
               )
               (str' "dog")
+          )
+    it "Parses a type declaration with variable" $
+      parseExpr "type Maybe a = Just a | Nothing in Nothing"
+        `shouldBe` Right
+          ( MyData
+              (mkConstruct "Maybe")
+              [mkName "a"]
+              ( M.fromList
+                  [ (mkConstruct "Just", [VarName $ mkName "a"]),
+                    (mkConstruct "Nothing", [])
+                  ]
+              )
+              (MyConstructor $ mkConstruct "Nothing")
           )
     it "Uses a constructor" $
       parseExpr "Vrai" `shouldBe` Right (MyConstructor (mkConstruct "Vrai"))

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -8,9 +8,9 @@ where
 import Data.Either (isLeft)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
-import Language.Mimsa
 import Language.Mimsa.Syntax
 import qualified Language.Mimsa.Syntax as P
+import Language.Mimsa.Types
 import Test.Helpers
 import Test.Hspec
 
@@ -203,3 +203,41 @@ spec = do
               (MyLambda (mkName "r") (str' "It's not ten"))
               (MyLambda (mkName "l") (str' "It's ten!"))
           )
+    it "Parses an absolute unit" $
+      parseExpr "type AbsoluteUnit = AbsoluteUnit in 1"
+        `shouldBe` Right
+          ( MyData
+              (mkConstruct "AbsoluteUnit")
+              (pure (mkConstruct "AbsoluteUnit", mempty))
+              (int 1)
+          )
+    it "Parses a single constructor with one arg" $
+      parseExpr "type Dog = Dog String in 1"
+        `shouldBe` Right
+          ( MyData
+              (mkConstruct "Dog")
+              (pure (mkConstruct "Dog", [mkConstruct "String"]))
+              (int 1)
+          )
+    it "Parses a french boolean" $
+      parseExpr "type LeBool = Vrai | Faux in 1"
+        `shouldBe` Right
+          ( MyData
+              (mkConstruct "LeBool")
+              (NE.fromList [(mkConstruct "Vrai", []), (mkConstruct "Faux", [])])
+              (int 1)
+          )
+    it "Parses a peano number data declaration" $
+      parseExpr "type Nat = Zero | Succ Nat in 1"
+        `shouldBe` Right
+          ( MyData
+              (mkConstruct "Nat")
+              ( NE.fromList
+                  [ (mkConstruct "Zero", []),
+                    (mkConstruct "Succ", [mkConstruct "Nat"])
+                  ]
+              )
+              (int 1)
+          )
+    it "Uses a constructor" $
+      parseExpr "Vrai" `shouldBe` Right (MyConstructor (mkConstruct "Vrai"))

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -275,3 +275,30 @@ spec = do
           )
     it "Uses a constructor" $
       parseExpr "Vrai" `shouldBe` Right (MyConstructor (mkConstruct "Vrai"))
+    it "Parses a custom case match" $
+      parseExpr "case Just 1 of Just \\a -> a | Nothing 0"
+        `shouldBe` Right
+          ( MyCaseMatch
+              (MyConsApp (MyConstructor $ mkConstruct "Just") (int 1))
+              [ (mkConstruct "Just", MyLambda (mkName "a") (MyVar (mkName "a"))),
+                (mkConstruct "Nothing", int 0)
+              ]
+              Nothing
+          )
+    it "Parses a custom case match with fall through case" $
+      parseExpr "case Just 1 of Just \\a -> a | otherwise 0"
+        `shouldBe` Right
+          ( MyCaseMatch
+              (MyConsApp (MyConstructor $ mkConstruct "Just") (int 1))
+              [ (mkConstruct "Just", MyLambda (mkName "a") (MyVar (mkName "a")))
+              ]
+              (Just $ int 0)
+          )
+    it "Parses a custom case match with only a fall through case" $
+      parseExpr "case Just 1 of otherwise 0"
+        `shouldBe` Right
+          ( MyCaseMatch
+              (MyConsApp (MyConstructor $ mkConstruct "Just") (int 1))
+              mempty
+              (Just $ int 0)
+          )

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -208,7 +208,7 @@ spec = do
         `shouldBe` Right
           ( MyData
               (mkConstruct "AbsoluteUnit")
-              (pure (mkConstruct "AbsoluteUnit", mempty))
+              (M.singleton (mkConstruct "AbsoluteUnit") mempty)
               (int 1)
           )
     it "Parses a single constructor with one arg" $
@@ -216,7 +216,10 @@ spec = do
         `shouldBe` Right
           ( MyData
               (mkConstruct "Dog")
-              (pure (mkConstruct "Dog", [mkConstruct "String"]))
+              ( M.singleton
+                  (mkConstruct "Dog")
+                  [mkConstruct "String"]
+              )
               (int 1)
           )
     it "Parses a french boolean" $
@@ -224,7 +227,11 @@ spec = do
         `shouldBe` Right
           ( MyData
               (mkConstruct "LeBool")
-              (NE.fromList [(mkConstruct "Vrai", []), (mkConstruct "Faux", [])])
+              ( M.fromList
+                  [ (mkConstruct "Vrai", []),
+                    (mkConstruct "Faux", [])
+                  ]
+              )
               (int 1)
           )
     it "Parses a peano number data declaration" $
@@ -232,7 +239,7 @@ spec = do
         `shouldBe` Right
           ( MyData
               (mkConstruct "Nat")
-              ( NE.fromList
+              ( M.fromList
                   [ (mkConstruct "Zero", []),
                     (mkConstruct "Succ", [mkConstruct "Nat"])
                   ]

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -220,7 +220,7 @@ spec = do
               mempty
               ( M.singleton
                   (mkConstruct "Dog")
-                  [ConsName $ mkConstruct "String"]
+                  [ConsName (mkConstruct "String") mempty]
               )
               (int 1)
           )
@@ -245,7 +245,7 @@ spec = do
               mempty
               ( M.fromList
                   [ (mkConstruct "Zero", []),
-                    (mkConstruct "Succ", [ConsName $ mkConstruct "Nat"])
+                    (mkConstruct "Succ", [ConsName (mkConstruct "Nat") mempty])
                   ]
               )
               (int 1)


### PR DESCRIPTION
This WIP PR adds datatype declarations as follows:

```haskell
type Result e a = Reaping e | Sowing a in .....
```

and destructuring like:

```haskell
case Reaping True of Sowing \a -> "Haha fuck yeah!!! Yes!!" | Reaping \e -> "Well this fucking sucks. What the fuck."
```

Currently some questions about how to share these types around. Currently we put functions into global scope and then pull them into `StoreExpression` scope when we use them. Should these be a second set of items in the `StoreExpression`? Or just pulled in in the same manner?