### PR TITLE
Allow recursive let definitions

### DIFF
--- a/src/Language/Mimsa/Actions.hs
+++ b/src/Language/Mimsa/Actions.hs
@@ -13,6 +13,7 @@ import Control.Monad (join)
 import Data.Bifunctor (first)
 import qualified Data.Map as M
 import Data.Text (Text)
+import Language.Mimsa.Interpreter (scopeFromSwaps)
 import Language.Mimsa.Project (getCurrentBindings)
 import Language.Mimsa.Store (createStoreExpression, substitute)
 import Language.Mimsa.Syntax (parseExpr)
@@ -59,7 +60,8 @@ evaluateStoreExpression ::
 evaluateStoreExpression store' storeExpr = do
   let (swaps, newExpr, scope) = substitute store' storeExpr
   exprType <- getType swaps scope newExpr
-  pure (exprType, storeExpr, newExpr, scope)
+  let scopeWithSwaps = scope <> scopeFromSwaps swaps
+  pure (exprType, storeExpr, newExpr, scopeWithSwaps)
 
 getTypecheckedStoreExpression ::
   Project ->

--- a/src/Language/Mimsa/Interpreter.hs
+++ b/src/Language/Mimsa/Interpreter.hs
@@ -10,7 +10,6 @@ import Control.Monad.Reader
 import Control.Monad.Trans.State.Lazy
 import qualified Data.Map as M
 import Language.Mimsa.Interpreter.Interpret
-import Language.Mimsa.Logging
 import Language.Mimsa.Types
 
 interpret :: Scope -> Swaps -> Expr Variable -> IO (Either InterpreterError (Expr Variable))
@@ -24,7 +23,4 @@ interpret scope' swaps expr = fmap fst <$> either'
               (interpretWithScope expr)
               (scopeSize scope', scope')
           )
-          ( debugPretty
-              "swaps"
-              swaps
-          )
+          swaps

--- a/src/Language/Mimsa/Interpreter.hs
+++ b/src/Language/Mimsa/Interpreter.hs
@@ -1,5 +1,6 @@
 module Language.Mimsa.Interpreter
   ( interpret,
+    scopeFromSwaps,
   )
 where
 
@@ -20,3 +21,8 @@ interpret scope' expr = fmap fst <$> either'
         runStateT
           (interpretWithScope expr)
           (scopeSize scope', scope')
+
+-- to allow let recursion we need to tell the interpreter about any
+-- swaps we made to put them in scope
+scopeFromSwaps :: Swaps -> Scope
+scopeFromSwaps swaps = Scope $ MyVar . NamedVar <$> swaps

--- a/src/Language/Mimsa/Interpreter.hs
+++ b/src/Language/Mimsa/Interpreter.hs
@@ -1,28 +1,26 @@
 module Language.Mimsa.Interpreter
   ( interpret,
-    scopeFromSwaps,
   )
 where
 
 -- let's run our code, at least for the repl
 -- run == simplify, essentially
 import Control.Monad.Except
+import Control.Monad.Reader
 import Control.Monad.Trans.State.Lazy
 import qualified Data.Map as M
 import Language.Mimsa.Interpreter.Interpret
 import Language.Mimsa.Types
 
-interpret :: Scope -> Expr Variable -> IO (Either InterpreterError (Expr Variable))
-interpret scope' expr = fmap fst <$> either'
+interpret :: Scope -> Swaps -> Expr Variable -> IO (Either InterpreterError (Expr Variable))
+interpret scope' swaps expr = fmap fst <$> either'
   where
     scopeSize = M.size . getScope
     either' =
       runExceptT $
-        runStateT
-          (interpretWithScope expr)
-          (scopeSize scope', scope')
-
--- to allow let recursion we need to tell the interpreter about any
--- swaps we made to put them in scope
-scopeFromSwaps :: Swaps -> Scope
-scopeFromSwaps swaps = Scope $ MyVar . NamedVar <$> swaps
+        runReaderT
+          ( runStateT
+              (interpretWithScope expr)
+              (scopeSize scope', scope')
+          )
+          swaps

--- a/src/Language/Mimsa/Interpreter.hs
+++ b/src/Language/Mimsa/Interpreter.hs
@@ -10,6 +10,7 @@ import Control.Monad.Reader
 import Control.Monad.Trans.State.Lazy
 import qualified Data.Map as M
 import Language.Mimsa.Interpreter.Interpret
+import Language.Mimsa.Logging
 import Language.Mimsa.Types
 
 interpret :: Scope -> Swaps -> Expr Variable -> IO (Either InterpreterError (Expr Variable))
@@ -23,4 +24,7 @@ interpret scope' swaps expr = fmap fst <$> either'
               (interpretWithScope expr)
               (scopeSize scope', scope')
           )
-          swaps
+          ( debugPretty
+              "swaps"
+              swaps
+          )

--- a/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -126,7 +126,7 @@ unwrapBuiltIn name (ThreeArgs _ _) = do
 newLambdaCopy :: Variable -> Expr Variable -> App (Variable, Expr Variable)
 newLambdaCopy name expr = do
   newName' <- nextVariable
-  newExpr <- swapName name newName' expr
+  newExpr <- swapName (debugPretty "name" name) (debugPretty "newName" newName') expr
   pure (newName', newExpr)
 
 interpretWithScope :: Expr Variable -> App (Expr Variable)

--- a/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -13,6 +13,7 @@ import Language.Mimsa.Interpreter.PatternMatch
 import Language.Mimsa.Interpreter.SwapName
 import Language.Mimsa.Interpreter.Types
 import Language.Mimsa.Library
+import Language.Mimsa.Logging
 import Language.Mimsa.Types
 
 -- when we come to do let recursive the name of our binder
@@ -130,7 +131,7 @@ newLambdaCopy name expr = do
 
 interpretWithScope :: Expr Variable -> App (Expr Variable)
 interpretWithScope interpretExpr =
-  case interpretExpr of
+  case debugPretty "interpretExpr" interpretExpr of
     (MyLiteral a) -> pure (MyLiteral a)
     (MyPair a b) -> do
       exprA <- interpretWithScope a
@@ -154,7 +155,8 @@ interpretWithScope interpretExpr =
       expr <- interpretWithScope (MyVar f)
       interpretWithScope (MyApp expr value)
     (MyApp (MyLambda binder expr) value) -> do
-      addToScope (Scope $ M.singleton binder value)
+      value' <- interpretWithScope value
+      addToScope (Scope $ M.singleton binder value')
       interpretWithScope expr
     (MyApp (MyLiteral a) _) ->
       throwError $ CannotApplyToNonFunction (MyLiteral a)

--- a/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -8,7 +8,6 @@ where
 -- let's run our code, at least for the repl
 -- run == simplify, essentially
 import Control.Monad.Except
-import Control.Monad.Reader
 import qualified Data.Map as M
 import Language.Mimsa.Interpreter.PatternMatch
 import Language.Mimsa.Interpreter.SwapName
@@ -22,7 +21,7 @@ import Language.Mimsa.Types
 -- so we look it up to make sure we bind the right thing
 findActualBindingInSwaps :: Int -> App Variable
 findActualBindingInSwaps int = do
-  swaps <- ask
+  swaps <- askForSwaps
   scope' <- readScope
   case M.lookup (NumberedVar int) swaps of
     Just i' -> pure (NamedVar i')
@@ -139,7 +138,7 @@ interpretWithScope interpretExpr =
       exprB <- interpretWithScope b
       pure (MyPair exprA exprB)
     (MyLet binder expr body) -> do
-      addToScope (Scope $ M.singleton binder expr)
+      addToScope (Scope $ M.singleton (debugPretty "binder" binder) expr)
       interpretWithScope body
     (MyLetPair binderA binderB (MyPair a b) body) -> do
       let newScopes = Scope $ M.fromList [(binderA, a), (binderB, b)]

--- a/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -13,7 +13,6 @@ import Language.Mimsa.Interpreter.PatternMatch
 import Language.Mimsa.Interpreter.SwapName
 import Language.Mimsa.Interpreter.Types
 import Language.Mimsa.Library
-import Language.Mimsa.Logging
 import Language.Mimsa.Types
 
 -- when we come to do let recursive the name of our binder
@@ -126,12 +125,12 @@ unwrapBuiltIn name (ThreeArgs _ _) = do
 newLambdaCopy :: Variable -> Expr Variable -> App (Variable, Expr Variable)
 newLambdaCopy name expr = do
   newName' <- nextVariable
-  newExpr <- swapName (debugPretty "name" name) (debugPretty "newName" newName') expr
+  newExpr <- swapName name newName' expr
   pure (newName', newExpr)
 
 interpretWithScope :: Expr Variable -> App (Expr Variable)
 interpretWithScope interpretExpr =
-  case debugPretty "interpretExpr" interpretExpr of
+  case interpretExpr of
     (MyLiteral a) -> pure (MyLiteral a)
     (MyPair a b) -> do
       exprA <- interpretWithScope a

--- a/src/Language/Mimsa/Interpreter/SwapName.hs
+++ b/src/Language/Mimsa/Interpreter/SwapName.hs
@@ -46,7 +46,11 @@ swapName _ _ (MyLiteral a) = pure (MyLiteral a)
 swapName from to (MyData dataType expr) =
   MyData dataType <$> swapName from to expr
 swapName _ _ (MyConstructor n) = pure (MyConstructor n)
-swapName _ _ (MyConsApp a b) = pure (MyConsApp a b)
-swapName from to (MyCaseMatch expr b c) =
-  MyCaseMatch
-    <$> swapName from to expr <*> pure b <*> pure c
+swapName from to (MyConsApp a b) =
+  MyConsApp <$> swapName from to a
+    <*> swapName from to b
+swapName from to (MyCaseMatch expr matches catchAll) = do
+  expr' <- swapName from to expr
+  matches' <- traverse (\(k, v) -> (,) <$> pure k <*> swapName from to v) matches
+  catchAll' <- traverse (swapName from to) catchAll
+  pure (MyCaseMatch expr' matches' catchAll')

--- a/src/Language/Mimsa/Interpreter/SwapName.hs
+++ b/src/Language/Mimsa/Interpreter/SwapName.hs
@@ -47,4 +47,6 @@ swapName from to (MyData dataType expr) =
   MyData dataType <$> swapName from to expr
 swapName _ _ (MyConstructor n) = pure (MyConstructor n)
 swapName _ _ (MyConsApp a b) = pure (MyConsApp a b)
-swapName _ _ (MyCaseMatch a b c) = pure (MyCaseMatch a b c)
+swapName from to (MyCaseMatch expr b c) =
+  MyCaseMatch
+    <$> swapName from to expr <*> pure b <*> pure c

--- a/src/Language/Mimsa/Interpreter/Types.hs
+++ b/src/Language/Mimsa/Interpreter/Types.hs
@@ -1,4 +1,4 @@
-module Language.Mimsa.Interpreter.Types (App, readScope, nextVariable, addToScope) where
+module Language.Mimsa.Interpreter.Types (App, readScope, nextVariable, addToScope, askForSwaps) where
 
 import Control.Monad.Except
 import Control.Monad.Reader
@@ -22,3 +22,6 @@ nextVariable = NumberedVar <$> nextInt
 
 addToScope :: Scope -> App ()
 addToScope scope' = modify $ bimap (1 +) (scope' <>)
+
+askForSwaps :: App Swaps
+askForSwaps = ask

--- a/src/Language/Mimsa/Interpreter/Types.hs
+++ b/src/Language/Mimsa/Interpreter/Types.hs
@@ -6,7 +6,6 @@ import Control.Monad.Trans.State.Lazy
 import Data.Bifunctor (bimap, first)
 import qualified Data.Map as M
 import Data.Maybe (listToMaybe)
-import Language.Mimsa.Logging
 import Language.Mimsa.Types
 
 type App = StateT (Int, Scope) (ReaderT Swaps (ExceptT InterpreterError IO))
@@ -25,7 +24,7 @@ nextVariable = NumberedVar <$> nextInt
 
 addToScope :: Scope -> App ()
 addToScope scope' =
-  case foundALoop (debugPretty "new scope" scope') of
+  case foundALoop scope' of
     Nothing -> modify $ bimap (1 +) (scope' <>)
     Just k -> throwError $ SelfReferencingBinding k
   where

--- a/src/Language/Mimsa/Interpreter/Types.hs
+++ b/src/Language/Mimsa/Interpreter/Types.hs
@@ -1,11 +1,12 @@
 module Language.Mimsa.Interpreter.Types (App, readScope, nextVariable, addToScope) where
 
 import Control.Monad.Except
+import Control.Monad.Reader
 import Control.Monad.Trans.State.Lazy
 import Data.Bifunctor (bimap, first)
 import Language.Mimsa.Types
 
-type App = StateT (Int, Scope) (ExceptT InterpreterError IO)
+type App = StateT (Int, Scope) (ReaderT Swaps (ExceptT InterpreterError IO))
 
 readScope :: App Scope
 readScope = gets snd

--- a/src/Language/Mimsa/Interpreter/Types.hs
+++ b/src/Language/Mimsa/Interpreter/Types.hs
@@ -6,6 +6,7 @@ import Control.Monad.Trans.State.Lazy
 import Data.Bifunctor (bimap, first)
 import qualified Data.Map as M
 import Data.Maybe (listToMaybe)
+import Language.Mimsa.Logging
 import Language.Mimsa.Types
 
 type App = StateT (Int, Scope) (ReaderT Swaps (ExceptT InterpreterError IO))
@@ -24,7 +25,7 @@ nextVariable = NumberedVar <$> nextInt
 
 addToScope :: Scope -> App ()
 addToScope scope' =
-  case foundALoop scope' of
+  case foundALoop (debugPretty "new scope" scope') of
     Nothing -> modify $ bimap (1 +) (scope' <>)
     Just k -> throwError $ SelfReferencingBinding k
   where

--- a/src/Language/Mimsa/Library.hs
+++ b/src/Language/Mimsa/Library.hs
@@ -20,7 +20,6 @@ libraryFunctions =
     M.fromList
       [ (FuncName "randomInt", randomInt),
         (FuncName "randomIntFrom", randomIntFrom),
-        (FuncName "incrementInt", incrementInt),
         (FuncName "eq", eq),
         (FuncName "log", logFn),
         (FuncName "addInt", addInt)
@@ -62,12 +61,6 @@ randomIntFrom =
         val <- randomIO
         pure (MyLiteral (MyInt (max val i)))
     )
-
-incrementInt :: ForeignFunc
-incrementInt =
-  OneArg
-    (MTInt, MTInt)
-    (\(MyLiteral (MyInt i)) -> pure (MyLiteral (MyInt (i + 1))))
 
 eq :: ForeignFunc
 eq =

--- a/src/Language/Mimsa/Library.hs
+++ b/src/Language/Mimsa/Library.hs
@@ -22,7 +22,7 @@ libraryFunctions =
         (FuncName "randomIntFrom", randomIntFrom),
         (FuncName "eq", eq),
         (FuncName "log", logFn),
-        (FuncName "addInt", addInt)
+        (FuncName "addIntPair", addIntPair)
       ]
 
 isLibraryName :: Name -> Bool
@@ -72,12 +72,14 @@ eq =
 equality :: (Monad m, Eq a) => Expr a -> Expr a -> m (Expr a)
 equality x y = pure $ MyLiteral (MyBool (x == y))
 
-addInt :: ForeignFunc
-addInt =
-  TwoArgs
-    (MTInt, MTInt, MTInt)
-    ( \(MyLiteral (MyInt a))
-       (MyLiteral (MyInt b)) -> pure (MyLiteral (MyInt (a + b)))
+addIntPair :: ForeignFunc
+addIntPair =
+  OneArg
+    (MTPair MTInt MTInt, MTInt)
+    ( \( MyPair
+           (MyLiteral (MyInt a))
+           (MyLiteral (MyInt b))
+         ) -> pure (MyLiteral (MyInt (a + b)))
     )
 
 getFFType :: ForeignFunc -> MonoType

--- a/src/Language/Mimsa/Project/Versions.hs
+++ b/src/Language/Mimsa/Project/Versions.hs
@@ -53,5 +53,5 @@ getExprDetails ::
 getExprDetails project exprHash = do
   usages <- first UsageErr (findUsages project exprHash)
   storeExpr <- first UsageErr (getStoreExpression project exprHash)
-  (mt, _, expr', _) <- evaluateStoreExpression (store project) storeExpr
+  (mt, _, expr', _, _) <- evaluateStoreExpression (store project) storeExpr
   pure (expr', mt, usages)

--- a/src/Language/Mimsa/Tui/Evaluate.hs
+++ b/src/Language/Mimsa/Tui/Evaluate.hs
@@ -12,7 +12,7 @@ evaluateStoreExprToInfo ::
   Maybe (MonoType, Expr Name)
 evaluateStoreExprToInfo store' storeExpr =
   case evaluateStoreExpression store' storeExpr of
-    Right (mt, _, _, _) -> Just (mt, storeExpression storeExpr)
+    Right (mt, _, _, _, _) -> Just (mt, storeExpression storeExpr)
     _ -> Nothing
 
 hush :: Either e a -> Maybe a

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -132,7 +132,8 @@ inferLetBinding env binder expr body = do
   (s1, tyExpr) <- infer newEnv1 expr
   let newEnv2 = createEnv binder (generalise s1 tyExpr) <> newEnv1
   (s2, tyBody) <- infer (applySubstCtx s1 newEnv2) body
-  pure (s2 <> s1, tyBody)
+  s3 <- unify tyUnknown tyExpr
+  pure (s3 <> s2 <> s1, applySubst s3 tyBody)
 
 inferLetPairBinding ::
   Environment ->

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -10,6 +10,7 @@ where
 
 import Control.Applicative
 import Control.Monad.Except
+import Control.Monad.Reader
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import Data.Map (Map)
@@ -79,9 +80,11 @@ inferVarFromScope env name =
    in case lookup' name env of
         Just mt ->
           instantiate mt
-        _ ->
+        _ -> do
+          swaps <- ask
           throwError $
             VariableNotInEnv
+              swaps
               name
               (S.fromList (M.keys (getSchemes env)))
 

--- a/src/Language/Mimsa/Types/InterpreterError.hs
+++ b/src/Language/Mimsa/Types/InterpreterError.hs
@@ -25,6 +25,7 @@ data InterpreterError
   | CouldNotUnwrapBuiltIn Variable
   | CouldNotMatchBuiltInId BiIds
   | PatternMatchFailure (Expr Variable)
+  | SelfReferencingBinding Variable
   deriving (Eq, Ord, Show)
 
 instance Printer InterpreterError where
@@ -42,6 +43,7 @@ instance Printer InterpreterError where
   prettyPrint (CouldNotUnwrapBuiltIn name) = "Could unwrap built-in " <> prettyPrint name
   prettyPrint (CouldNotMatchBuiltInId ids) = "Could not match built in ids " <> prettyPrint ids
   prettyPrint (PatternMatchFailure expr') = "Could not pattern match on value " <> prettyPrint expr'
+  prettyPrint (SelfReferencingBinding b) = "Could not bind variable " <> prettyPrint b <> " to itself."
   prettyPrint UnknownInterpreterError = "Unknown interpreter error"
 
 instance Semigroup InterpreterError where

--- a/src/Language/Mimsa/Types/Printer.hs
+++ b/src/Language/Mimsa/Types/Printer.hs
@@ -33,6 +33,11 @@ instance (Printer k, Printer v) => Printer (Map k v) where
 instance (Printer a, Printer b) => Printer (a, b) where
   prettyPrint (a, b) = "\n " <> T.intercalate "\n " [prettyPrint a, prettyPrint b]
 
+instance (Printer k, Printer v) => Printer (Map k v) where
+  prettyPrint map' =
+    let printRow (k, v) = prettyPrint k <> ": " <> prettyPrint v
+     in T.intercalate ", " (printRow <$> M.toList map')
+
 instance (Printer a, Printer b, Printer c) => Printer (a, b, c) where
   prettyPrint (a, b, c) =
     "\n "

--- a/src/Language/Mimsa/Types/Printer.hs
+++ b/src/Language/Mimsa/Types/Printer.hs
@@ -24,12 +24,6 @@ instance Printer Int where
 instance (Printer a) => Printer [a] where
   prettyPrint as = T.intercalate ", " (prettyPrint <$> as)
 
-instance (Printer k, Printer v) => Printer (Map k v) where
-  prettyPrint a =
-    T.intercalate
-      ", "
-      ((\(k, v) -> prettyPrint k <> ": " <> prettyPrint v) <$> M.toList a)
-
 instance (Printer a, Printer b) => Printer (a, b) where
   prettyPrint (a, b) = "\n " <> T.intercalate "\n " [prettyPrint a, prettyPrint b]
 

--- a/src/Language/Mimsa/Types/Swaps.hs
+++ b/src/Language/Mimsa/Types/Swaps.hs
@@ -5,4 +5,6 @@ import Language.Mimsa.Types.Name
 import Language.Mimsa.Types.Variable
 
 -- the names that get changed in substitution
+-- Name is the original name
+-- Variable is the new variable
 type Swaps = Map Variable Name

--- a/src/Language/Mimsa/Types/Variable.hs
+++ b/src/Language/Mimsa/Types/Variable.hs
@@ -30,6 +30,6 @@ data Variable
 
 instance Printer Variable where
   prettyPrint (NamedVar n) = prettyPrint n
-  prettyPrint (NumberedVar i) = T.pack (show i)
+  prettyPrint (NumberedVar i) = "U" <> T.pack (show i)
   prettyPrint (BuiltIn n) = prettyPrint n
   prettyPrint (BuiltInActual n _) = prettyPrint n

--- a/test/Test/Interpreter.hs
+++ b/test/Test/Interpreter.hs
@@ -15,12 +15,12 @@ import Test.Hspec
 
 testInterpret :: Scope -> Expr Variable -> Expr Variable -> Expectation
 testInterpret scope' expr' expected = do
-  result <- interpret scope' expr'
+  result <- interpret scope' mempty expr'
   result `shouldBe` Right expected
 
 testInterpretFail :: Scope -> Expr Variable -> InterpreterError -> Expectation
 testInterpretFail scope' expr' expected = do
-  result <- interpret scope' expr'
+  result <- interpret scope' mempty expr'
   result `shouldBe` Left expected
 
 spec :: Spec
@@ -91,18 +91,18 @@ spec =
     describe "BuiltIns" $ do
       it "Can't find stupidMadeUpFunction" $ do
         let f = MyVar (named "stupidMadeUpFunction")
-        result <- interpret mempty f
+        result <- interpret mempty mempty f
         result `shouldSatisfy` isLeft
       it "Finds and uses randomInt" $ do
         let f = MyVar (builtIn "randomInt")
             scope' = mempty
-        result <- interpret scope' f
+        result <- interpret scope' mempty f
         print result
         result `shouldSatisfy` \(Right (MyLiteral (MyInt _))) -> True
       it "Finds and uses randomIntFrom" $ do
         let f = MyApp (MyVar (builtIn "randomIntFrom")) (int 10)
             scope' = mempty
-        result <- interpret scope' f
+        result <- interpret scope' mempty f
         print result
         result `shouldSatisfy` (\(Right (MyLiteral (MyInt i))) -> i > 9)
       it "Uses a two arg function inside an If" $ do
@@ -115,7 +115,7 @@ spec =
                 (int 1)
                 (int 0)
             scope' = mempty
-        result <- interpret scope' f
+        result <- interpret scope' mempty f
         result `shouldBe` Right (int 0)
       it "Destructures a pair" $ do
         let f =
@@ -135,7 +135,7 @@ spec =
                     (MyPair (int 1) (int 2))
                     (MyApp (MyVar (named "fst")) (MyVar (named "x")))
                 )
-        result <- interpret mempty f
+        result <- interpret mempty mempty f
         result `shouldBe` Right (int 1)
       it "Uses a higher order function twice without screwing the pooch" $ do
         let f =
@@ -164,7 +164,7 @@ spec =
                         (MyLiteral (MyInt 100))
                     )
                 )
-        result <- interpret mempty f
+        result <- interpret mempty mempty f
         result `shouldBe` Right (int 1)
       it "Uses var names in lambdas that conflict with the ones inside our built-in function without breaking" $ do
         let ifFunc =
@@ -186,7 +186,7 @@ spec =
                 )
             f = MyApp (MyApp ifFunc (int 1)) (int 2)
             scope' = mempty
-        result <- interpret scope' f
+        result <- interpret scope' mempty f
         result `shouldBe` Right (int 0)
       it "Runs the internals of reduce function" $ do
         let reduceFunc =
@@ -201,5 +201,5 @@ spec =
                     (MyLiteral (MyInt 1))
                 )
             scope' = mempty
-        result <- interpret scope' reduceFunc
+        result <- interpret scope' mempty reduceFunc
         result `shouldBe` Right (str' "Horse")

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -310,18 +310,14 @@ spec =
       it "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> incrementInt(loop(as2)(b))) in loop(Suc Suc Suc Zero)(10)" $ do
         result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> incrementInt(loop(as2)(b))) in loop(Suc Suc Suc Zero)(10)"
         result `shouldBe` Right (MTInt, int 13)
-      it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)" $ do
-        result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)"
-        result `shouldBe` Right (MTInt, int 3)
+      {-
+            it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)" $ do
+              result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)"
+              result `shouldBe` Right (MTInt, int 3)
+      -}
       it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty)" $ do
         result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty)"
         result `shouldBe` Right (MTInt, int 0)
       it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Item 3 Empty)" $ do
         result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Item 3 Empty)"
         result `shouldBe` Right (MTInt, int 3)
-{-
--- this (and any loop with multiple arity function) loops forever
-      it "let myReduce = (\\f -> \\b -> \\as -> let [head, tail] = as in case tail of Left \\l -> f(head)(b) | Right \\rest -> myReduce(f)(f(head)(b))(rest)) in myReduce(addInt)(0)([1,2,3])" $ do
-        result <- eval stdLib "let myReduce = (\\f -> \\b -> \\as -> let [head, tail] = as in case tail of Left \\l -> f(head)(b) | Right \\rest -> myReduce(f)(f(head)(b))(rest)) in myReduce(addInt)(0)([1,2,3])"
-        result `shouldBe` Right (MTInt, int 6)
--}

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -287,9 +287,6 @@ spec =
                   )
       
       -}
-      it "let reduce = (\\b -> \\a -> case a of Left \\l -> b | Right \\as -> let [head,tail] = as in reduce(addInt(b)(head))(tail)) in reduce(0)(Right [1,2,3])" $ do
-        result <- eval stdLib "let reduce = (\\b -> \\a -> case a of Left \\l -> b | Right \\as -> let [head,tail] = as in reduce(addInt(b)(head))(tail)) in reduce(0)(Right [1,2,3])"
-        result `shouldBe` Right (MTInt, int 6)
       it "type Arr a = Empty | Item a (Arr a) in case (Item 1 (Item 2 Empty)) of Empty Empty | Item \\a -> \\rest -> rest" $ do
         result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in case (Item 1 (Item 2 Empty)) of Empty Empty | Item \\a -> \\rest -> rest"
         result

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -296,6 +296,12 @@ spec =
       it "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Suc Suc Zero)" $ do
         result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Suc Suc Zero)"
         result `shouldBe` Right (MTInt, int 3)
+      it "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> incrementInt(loop(as2)(b))) in loop(Suc Suc Suc Zero)(10)" $ do
+        result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> incrementInt(loop(as2)(b))) in loop(Suc Suc Suc Zero)(10)"
+        result `shouldBe` Right (MTInt, int 13)
+      it "type Arr a = Empty | Item a (Arr a) in (let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \a -> \rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty))" $ do
+        result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in (let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \a -> \rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty))"
+        result `shouldBe` Right (MTInt, int 0)
 {-
 -- this (and any loop with multiple arity function) loops forever
       it "let myReduce = (\\f -> \\b -> \\as -> let [head, tail] = as in case tail of Left \\l -> f(head)(b) | Right \\rest -> myReduce(f)(f(head)(b))(rest)) in myReduce(addInt)(0)([1,2,3])" $ do

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -60,7 +60,7 @@ spec =
               int 1
             )
       it "let compose = (\\f -> \\g -> \\a -> f(g(a))) in compose(incrementInt)(incrementInt)(67)" $ do
-        result <- eval mempty "let compose = (\\f -> \\g -> \\a -> f(g(a))) in compose(incrementInt)(incrementInt)(67)"
+        result <- eval stdLib "let compose = (\\f -> \\g -> \\a -> f(g(a))) in compose(incrementInt)(incrementInt)(67)"
         result `shouldBe` Right (MTInt, int 69)
       it "let reuse = ({ first: id(1), second: id(2) }) in reuse.first" $ do
         result <- eval stdLib "let reuse = ({ first: id(1), second: id(2) }) in reuse.first"

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -42,7 +42,7 @@ spec =
         result <- eval stdLib "let prelude = ({ id: (\\i -> i) }) in prelude.id"
         result
           `shouldBe` Right
-            ( MTFunction (unknown 3) (unknown 3),
+            ( MTFunction (unknown 4) (unknown 4),
               MyLambda (named "i") (MyVar (named "i"))
             )
       it "let prelude = ({ id: (\\i -> i) }) in prelude.id(1)" $ do
@@ -290,3 +290,6 @@ spec =
       it "let reduce = (\\b -> \\a -> case a of Left \\l -> b | Right \\as -> let [head,tail] = as in reduce(addInt(b)(head))(tail)) in reduce(0)(Right [1,2,3])" $ do
         result <- eval stdLib "let reduce = (\\b -> \\a -> case a of Left \\l -> b | Right \\as -> let [head,tail] = as in reduce(addInt(b)(head))(tail)) in reduce(0)(Right [1,2,3])"
         result `shouldBe` Right (MTInt, int 6)
+      it "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)" $ do
+        result <- eval stdLib "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)"
+        result `shouldBe` Right (MTInt, int 10)

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -290,6 +290,20 @@ spec =
       it "let reduce = (\\b -> \\a -> case a of Left \\l -> b | Right \\as -> let [head,tail] = as in reduce(addInt(b)(head))(tail)) in reduce(0)(Right [1,2,3])" $ do
         result <- eval stdLib "let reduce = (\\b -> \\a -> case a of Left \\l -> b | Right \\as -> let [head,tail] = as in reduce(addInt(b)(head))(tail)) in reduce(0)(Right [1,2,3])"
         result `shouldBe` Right (MTInt, int 6)
+      it "type Arr a = Empty | Item a (Arr a) in case (Item 1 (Item 2 Empty)) of Empty Empty | Item \\a -> \\rest -> rest" $ do
+        result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in case (Item 1 (Item 2 Empty)) of Empty Empty | Item \\a -> \\rest -> rest"
+        result
+          `shouldBe` Right
+            ( MTData (mkConstruct "Arr") [MTInt],
+              MyConsApp
+                ( MyConsApp
+                    ( MyConstructor
+                        (mkConstruct "Item")
+                    )
+                    (int 2)
+                )
+                (MyConstructor $ mkConstruct "Empty")
+            )
       it "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)" $ do
         result <- eval stdLib "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)"
         result `shouldBe` Right (MTInt, int 10)

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -278,12 +278,15 @@ spec =
       it "type Either e a = Left e | Right a in \\f -> \\g -> \\either -> case either of Left \\e -> g(e) | Right \\a -> f(a)" $ do
         result <- eval stdLib "type Either e a = Left e | Right a in \\f -> \\g -> \\either -> case either of Left \\e -> g(e) | Right \\a -> f(a)"
         result `shouldSatisfy` isRight
-{-
-      it "type Maybe a = Just a | Nothing in \\maybe -> case maybe of Just \\a -> a | Nothing \"poo\"" $ do
-        result <- eval stdLib "type Maybe a = Just a | Nothing in \\maybe -> case maybe of Just \\a -> a | Nothing \"poo\""
-        fst <$> result
-          `shouldBe` Right
-            ( MTFunction (MTData (mkConstruct "Maybe") []) MTString
-            )
-
--}
+      {-
+            it "type Maybe a = Just a | Nothing in \\maybe -> case maybe of Just \\a -> a | Nothing \"poo\"" $ do
+              result <- eval stdLib "type Maybe a = Just a | Nothing in \\maybe -> case maybe of Just \\a -> a | Nothing \"poo\""
+              fst <$> result
+                `shouldBe` Right
+                  ( MTFunction (MTData (mkConstruct "Maybe") []) MTString
+                  )
+      
+      -}
+      it "let reduce = (\\b -> \\a -> case a of Left \\l -> b | Right \\as -> let [head,tail] = as in reduce(addInt(b)(head))(tail)) in reduce(0)(Right [1,2,3])" $ do
+        result <- eval stdLib "let reduce = (\\b -> \\a -> case a of Left \\l -> b | Right \\as -> let [head,tail] = as in reduce(addInt(b)(head))(tail)) in reduce(0)(Right [1,2,3])"
+        result `shouldBe` Right (MTInt, int 6)

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -301,13 +301,13 @@ spec =
         result `shouldBe` Right (MTInt, int 13)
       it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)" $ do
         result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)"
-        result `shouldBe` Right (MTInt, int 7)
+        result `shouldBe` Right (MTInt, int 3)
       it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty)" $ do
         result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty)"
         result `shouldBe` Right (MTInt, int 0)
       it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Item 3 Empty)" $ do
         result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Item 3 Empty)"
-        result `shouldBe` Right (MTInt, int 7)
+        result `shouldBe` Right (MTInt, int 3)
 {-
 -- this (and any loop with multiple arity function) loops forever
       it "let myReduce = (\\f -> \\b -> \\as -> let [head, tail] = as in case tail of Left \\l -> f(head)(b) | Right \\rest -> myReduce(f)(f(head)(b))(rest)) in myReduce(addInt)(0)([1,2,3])" $ do

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -18,8 +18,8 @@ import Test.StoreData
 eval :: Project -> Text -> IO (Either Text (MonoType, Expr Variable))
 eval env input =
   case evaluateText env input of
-    Right (mt, expr', scope') -> do
-      endExpr <- interpret scope' expr'
+    Right (mt, expr', scope', swaps) -> do
+      endExpr <- interpret scope' swaps expr'
       case endExpr of
         Right a -> pure (Right (mt, a))
         Left e -> pure (Left (prettyPrint $ InterpreterErr e))
@@ -293,3 +293,6 @@ spec =
       it "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)" $ do
         result <- eval stdLib "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)"
         result `shouldBe` Right (MTInt, int 10)
+      it "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> loop(as2)(addInt(b)(1))) in loop(Zero)(0)" $ do
+        result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> loop(as2)(addInt(b)(1))) in loop(Zero)(0)"
+        result `shouldBe` Right (MTInt, int 0)

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -299,9 +299,15 @@ spec =
       it "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> incrementInt(loop(as2)(b))) in loop(Suc Suc Suc Zero)(10)" $ do
         result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> incrementInt(loop(as2)(b))) in loop(Suc Suc Suc Zero)(10)"
         result `shouldBe` Right (MTInt, int 13)
-      it "type Arr a = Empty | Item a (Arr a) in (let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \a -> \rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty))" $ do
-        result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in (let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \a -> \rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty))"
+      it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)" $ do
+        result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)"
+        result `shouldBe` Right (MTInt, int 7)
+      it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty)" $ do
+        result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty)"
         result `shouldBe` Right (MTInt, int 0)
+      it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Item 3 Empty)" $ do
+        result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Item 3 Empty)"
+        result `shouldBe` Right (MTInt, int 7)
 {-
 -- this (and any loop with multiple arity function) loops forever
       it "let myReduce = (\\f -> \\b -> \\as -> let [head, tail] = as in case tail of Left \\l -> f(head)(b) | Right \\rest -> myReduce(f)(f(head)(b))(rest)) in myReduce(addInt)(0)([1,2,3])" $ do

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -293,6 +293,12 @@ spec =
       it "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)" $ do
         result <- eval stdLib "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)"
         result `shouldBe` Right (MTInt, int 10)
-      it "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> loop(as2)(addInt(b)(1))) in loop(Zero)(0)" $ do
-        result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> loop(as2)(addInt(b)(1))) in loop(Zero)(0)"
-        result `shouldBe` Right (MTInt, int 0)
+      it "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Zero)" $ do
+        result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Zero)"
+        result `shouldBe` Right (MTInt, int 1)
+{-
+-- this (and any loop with multiple arity function) loops forever
+      it "let myReduce = (\\f -> \\b -> \\as -> let [head, tail] = as in case tail of Left \\l -> f(head)(b) | Right \\rest -> myReduce(f)(f(head)(b))(rest)) in myReduce(addInt)(0)([1,2,3])" $ do
+        result <- eval stdLib "let myReduce = (\\f -> \\b -> \\as -> let [head, tail] = as in case tail of Left \\l -> f(head)(b) | Right \\rest -> myReduce(f)(f(head)(b))(rest)) in myReduce(addInt)(0)([1,2,3])"
+        result `shouldBe` Right (MTInt, int 6)
+-}

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -293,9 +293,9 @@ spec =
       it "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)" $ do
         result <- eval stdLib "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)"
         result `shouldBe` Right (MTInt, int 10)
-      it "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Zero)" $ do
-        result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Zero)"
-        result `shouldBe` Right (MTInt, int 1)
+      it "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Suc Suc Zero)" $ do
+        result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Suc Suc Zero)"
+        result `shouldBe` Right (MTInt, int 3)
 {-
 -- this (and any loop with multiple arity function) loops forever
       it "let myReduce = (\\f -> \\b -> \\as -> let [head, tail] = as in case tail of Left \\l -> f(head)(b) | Right \\rest -> myReduce(f)(f(head)(b))(rest)) in myReduce(addInt)(0)([1,2,3])" $ do

--- a/test/Test/StoreData.hs
+++ b/test/Test/StoreData.hs
@@ -27,7 +27,13 @@ idExpr :: StoreExpression
 idExpr = unsafeGetExpr "\\i -> i"
 
 incrementInt :: StoreExpression
-incrementInt = unsafeGetExpr "\\a -> addInt(1)(a)"
+incrementInt =
+  unsafeGetExpr'
+    "\\a -> addInt(1)(a)"
+    (Bindings $ M.singleton (mkName "addInt") (ExprHash 18))
+
+addInt :: StoreExpression
+addInt = unsafeGetExpr "\\a -> \\b -> addIntPair((a,b))"
 
 stdLib :: Project
 stdLib = Project store' bindings' mempty
@@ -40,7 +46,8 @@ stdLib = Project store' bindings' mempty
             (ExprHash 6, compose),
             (ExprHash 7, sndExpr),
             (ExprHash 11, idExpr),
-            (ExprHash 17, incrementInt)
+            (ExprHash 17, incrementInt),
+            (ExprHash 18, addInt)
           ]
     bindings' =
       VersionedBindings $
@@ -50,7 +57,8 @@ stdLib = Project store' bindings' mempty
             (mkName "compose", pure $ ExprHash 6),
             (mkName "snd", pure $ ExprHash 7),
             (mkName "id", pure $ ExprHash 11),
-            (mkName "incrementInt", pure $ ExprHash 17)
+            (mkName "incrementInt", pure $ ExprHash 17),
+            (mkName "addInt", pure $ ExprHash 18)
           ]
 
 unsafeGetExpr' :: Text -> Bindings -> StoreExpression

--- a/test/Test/StoreData.hs
+++ b/test/Test/StoreData.hs
@@ -26,6 +26,9 @@ compose =
 idExpr :: StoreExpression
 idExpr = unsafeGetExpr "\\i -> i"
 
+incrementInt :: StoreExpression
+incrementInt = unsafeGetExpr "\\a -> addInt(1)(a)"
+
 stdLib :: Project
 stdLib = Project store' bindings' mempty
   where
@@ -36,7 +39,8 @@ stdLib = Project store' bindings' mempty
             (ExprHash 3, eqTenExpr),
             (ExprHash 6, compose),
             (ExprHash 7, sndExpr),
-            (ExprHash 11, idExpr)
+            (ExprHash 11, idExpr),
+            (ExprHash 17, incrementInt)
           ]
     bindings' =
       VersionedBindings $
@@ -45,7 +49,8 @@ stdLib = Project store' bindings' mempty
             (mkName "eqTen", pure $ ExprHash 3),
             (mkName "compose", pure $ ExprHash 6),
             (mkName "snd", pure $ ExprHash 7),
-            (mkName "id", pure $ ExprHash 11)
+            (mkName "id", pure $ ExprHash 11),
+            (mkName "incrementInt", pure $ ExprHash 17)
           ]
 
 unsafeGetExpr' :: Text -> Bindings -> StoreExpression


### PR DESCRIPTION
Totality is for suckers, let's recurse!

This allows shit like

```haskell
type Nat = Zero | Suc Nat in let loop = (\as -> case as of Zero 0 | Suc \as2 -> incrementInt(loop(as2))) in loop(Suc Zero)
```

Ie, turning a `Nat` into an `Int` by recursing over it's contents.