### PR TITLE
Bind new expression on changes in watch mode

### DIFF
--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 33f17bd8699615f828000a63f7d1eb73e0af3d84c8c36ecaf328260e3a59e482
+-- hash: f0f822b1024d4c72f55b1e840472a6d7017d27377b92a261e3369ab21b2199c7
 
 name:           mimsa
 version:        0.1.0.0
@@ -46,6 +46,8 @@ library
       Language.Mimsa.Project.Versions
       Language.Mimsa.Repl
       Language.Mimsa.Repl.Actions
+      Language.Mimsa.Repl.ExpressionBind
+      Language.Mimsa.Repl.ExpressionWatch
       Language.Mimsa.Repl.Parser
       Language.Mimsa.Repl.Types
       Language.Mimsa.Repl.Watcher

--- a/src/Language/Mimsa/Project/Versions.hs
+++ b/src/Language/Mimsa/Project/Versions.hs
@@ -1,4 +1,4 @@
-module Language.Mimsa.Project.Versions (findVersions) where
+module Language.Mimsa.Project.Versions (findVersions, findStoreExpressionByName) where
 
 import Control.Monad.Except
 import Data.Bifunctor (first)
@@ -45,6 +45,16 @@ getStoreExpression (Project store' _ _) exprHash =
   case M.lookup exprHash (getStore store') of
     Just storeExpression' -> Right storeExpression'
     _ -> Left (CouldNotFindStoreExpression exprHash)
+
+hush :: Either e a -> Maybe a
+hush (Right a) = Just a
+hush _ = Nothing
+
+findStoreExpressionByName :: Project -> Name -> Maybe StoreExpression
+findStoreExpressionByName env name =
+  case findInProject env name of
+    Right hashes -> hush $ getStoreExpression env (NE.last hashes)
+    _ -> Nothing
 
 getExprDetails ::
   Project ->

--- a/src/Language/Mimsa/Repl/ExpressionBind.hs
+++ b/src/Language/Mimsa/Repl/ExpressionBind.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Repl.ExpressionBind
+  ( doBind,
+    bindStoreExpression,
+  )
+where
+
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Language.Mimsa.Actions
+import Language.Mimsa.Printer
+import Language.Mimsa.Repl.Types
+import Language.Mimsa.Store (saveExpr)
+import Language.Mimsa.Types
+
+doBind :: Project -> Name -> Expr Name -> ReplM Project
+doBind env name expr = do
+  (type', storeExpr, _, _, _) <- liftRepl $ getTypecheckedStoreExpression env expr
+  replPrint $
+    "Bound " <> prettyPrint name <> " to " <> prettyPrint expr
+      <> " :: "
+      <> prettyPrint type'
+  bindStoreExpression env storeExpr name
+
+-- save an expression in the store and bind it to name
+bindStoreExpression ::
+  (MonadIO m) =>
+  Project ->
+  StoreExpression ->
+  Name ->
+  m Project
+bindStoreExpression env storeExpr name = do
+  hash <- liftIO (saveExpr storeExpr)
+  let newEnv = fromItem name storeExpr hash
+  pure (env <> newEnv)

--- a/src/Language/Mimsa/Repl/ExpressionWatch.hs
+++ b/src/Language/Mimsa/Repl/ExpressionWatch.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Repl.ExpressionWatch
+  ( doWatch,
+  )
+where
+
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Bifunctor (first)
+import Data.IORef
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import Language.Mimsa.Actions
+import Language.Mimsa.Parser (parseExpr)
+import Language.Mimsa.Printer
+import Language.Mimsa.Project.Versions
+import Language.Mimsa.Repl.ExpressionBind
+import Language.Mimsa.Repl.Types
+import Language.Mimsa.Repl.Watcher
+import Language.Mimsa.Types
+
+---------
+
+scratchFilename :: String
+scratchFilename = "scratch.mimsa"
+
+writeExpression :: (MonadIO m) => Project -> Name -> m ()
+writeExpression env name =
+  case findStoreExpressionByName env name of
+    Just storeExpr ->
+      liftIO $
+        T.writeFile
+          ("./" <> scratchFilename)
+          (prettyPrint (storeExpression storeExpr))
+    Nothing -> pure ()
+
+doWatch :: Project -> Name -> ReplM Project
+doWatch env name = do
+  writeExpression env name
+  ioEnv <- liftIO $ newIORef env
+  _ <-
+    liftIO $
+      watchFile
+        "./"
+        ( do
+            env' <- liftIO $ readIORef ioEnv
+            newEnv <- runReplM (onFileChange env' name)
+            case newEnv of
+              Just newEnv' -> liftIO $ writeIORef ioEnv newEnv'
+              Nothing -> pure ()
+        )
+  liftIO $ readIORef ioEnv
+
+onFileChange :: Project -> Name -> ReplM Project
+onFileChange env name = do
+  text <-
+    liftIO $ T.readFile $ "./" <> scratchFilename
+  replPrint (T.pack scratchFilename <> " updated!")
+  expr <-
+    liftRepl $ first ParseErr (parseExpr (T.strip text))
+  (type', storeExpr, _, _, _) <-
+    liftRepl $ getTypecheckedStoreExpression env expr
+  replPrint $
+    "+ Using the following from scope: "
+      <> prettyPrint (storeBindings storeExpr)
+  replPrint $
+    "Bound " <> prettyPrint name <> " to " <> prettyPrint expr
+      <> " :: "
+      <> prettyPrint type'
+  bindStoreExpression env storeExpr name

--- a/src/Language/Mimsa/Repl/Parser.hs
+++ b/src/Language/Mimsa/Repl/Parser.hs
@@ -46,7 +46,9 @@ listBindingsParser :: Parser ReplAction
 listBindingsParser = ListBindings <$ literal ":list"
 
 watchParser :: Parser ReplAction
-watchParser = Watch <$ literal ":watch"
+watchParser = do
+  _ <- thenSpace (literal ":watch")
+  Watch <$> nameParser
 
 tuiParser :: Parser ReplAction
 tuiParser = Tui <$ literal ":tui"

--- a/src/Language/Mimsa/Repl/Types.hs
+++ b/src/Language/Mimsa/Repl/Types.hs
@@ -33,5 +33,5 @@ data ReplAction
   | Bind Name (Expr Name)
   | Versions Name
   | ListBindings
-  | Watch
+  | Watch Name
   | Tui

--- a/src/Language/Mimsa/Repl/Watcher.hs
+++ b/src/Language/Mimsa/Repl/Watcher.hs
@@ -2,27 +2,29 @@
 
 module Language.Mimsa.Repl.Watcher where
 
--- for FilePath literals
-
-import Control.Concurrent (threadDelay)
-import Control.Monad (forever)
 import Data.List (isInfixOf)
 import System.FSNotify
+import System.IO
 
 doWeCareAboutThisEvent :: Event -> Bool
 doWeCareAboutThisEvent (Modified path _ _) = "scratch.mimsa" `isInfixOf` path
 doWeCareAboutThisEvent _ = False
 
+waitForKeyPress :: IO ()
+waitForKeyPress = do
+  bufferMode <- hGetBuffering stdin
+  hSetBuffering stdin NoBuffering
+  _ <- getChar
+  hSetBuffering stdin bufferMode
+  pure ()
+
 watchFile :: String -> IO () -> IO ()
 watchFile path action =
   withManager $ \mgr -> do
-    -- start a watching job (in the background)
     _ <-
       watchDir
         mgr -- manager
         path -- directory to watch
         doWeCareAboutThisEvent -- predicate
         (const action) -- action
-
-    -- sleep forever (until interrupted)
-    forever $ threadDelay 1000000
+    waitForKeyPress

--- a/src/Language/Mimsa/Types/Project.hs
+++ b/src/Language/Mimsa/Types/Project.hs
@@ -4,7 +4,9 @@
 module Language.Mimsa.Types.Project where
 
 import qualified Data.Aeson as JSON
+import Data.List (nub)
 import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NE
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Text (Text)
@@ -46,4 +48,12 @@ newtype VersionedBindings
 
 instance Semigroup VersionedBindings where
   (VersionedBindings a) <> (VersionedBindings b) =
-    VersionedBindings (M.unionWith (<>) a b)
+    VersionedBindings (M.unionWith combineUnique a b)
+
+-- we don't want duplicates in list
+-- nub keeps first instance, we want last instance, hence the reversing
+combineUnique :: (Eq a) => NonEmpty a -> NonEmpty a -> NonEmpty a
+combineUnique as bs =
+  let as' = NE.toList as
+      bs' = NE.toList bs
+   in NE.fromList . reverse . nub . reverse $ as' <> bs'


### PR DESCRIPTION
Resolves #44 , take a name when doing `:watch` command so we can save the expressions.

We also close `:watch` when a key is pressed.

One thing we need to fix is that when we bind a function, and that version has already been bound, to remove the previous one and bring the new one to the top of the list.

Ie, given:
`[123,456,789]` and adding `456`, we should end up with `[123,789,456]`.