### PR TITLE
WIP - type inference fix

### DIFF
--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -354,6 +354,15 @@ spec =
                 (MyConstructor (mkConstruct "Some"))
                 (int 1)
             )
+      it "\\a -> case a of Some \\as -> True | Nowt 100" $ do
+        result <- eval stdLib "\\a -> case a of Some \\as -> True | Nowt 100"
+        fst <$> result
+          `shouldSatisfy` isLeft
+      it "\\a -> case a of Some \\as -> as | Nowt 100" $ do
+        result <- eval stdLib "\\a -> case a of Some \\as -> as | Nowt 100"
+        fst <$> result
+          `shouldBe` Right
+            (MTFunction (MTData (mkConstruct "Option") [MTInt]) MTInt)
       it "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some 1)" $ do
         result <- eval stdLib "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some 1)"
         result `shouldSatisfy` isLeft

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -354,3 +354,9 @@ spec =
                 (MyConstructor (mkConstruct "Some"))
                 (int 1)
             )
+      it "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some 1)" $ do
+        result <- eval stdLib "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some 1)"
+        result `shouldSatisfy` isLeft
+      it "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some \"Dog\")" $ do
+        result <- eval stdLib "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some \"Dog\")"
+        result `shouldBe` Right (MTString, str' "Dog")


### PR DESCRIPTION
This fixes the broken types for case matching from #49 .

It does this by `unify`-ing the type we are case matching over against a generalised version of the data constructor. Ie, in the case `case a of Just \as -> as | Nothing "oh no"`, we'd unify `a` with `MTData "Option" [U1]`. This helps us because later when we work out that `U1` is a `String` due to the literal "oh no", we'll know `a` must be `Option String`.

We were also creating a new type var for `a` instead of trying to use one from scope, which meant that new var never got matched to anything. Generally if things go wrong, it's because we've lazily thrown in a `getUnknown` where we didn't need to. TIL.

Also, it turns out we were also never running substitution over the completed type checked expression, so if the expression resolved to a lambda, like `\b -> if b then "Yes" else "no"` - then even though we'd infer that `b` must be a `boolean` we would never apply that fact back to the expression. This should fix quite a lot of inferred types coming back sloppier than they needed to.