### PR TITLE
Add annotations to Expr type

### DIFF
--- a/src/Language/Mimsa/Actions.hs
+++ b/src/Language/Mimsa/Actions.hs
@@ -34,7 +34,7 @@ import Language.Mimsa.Types
 ----------
 
 getType ::
-  Monoid ann =>
+  (Eq ann, Monoid ann) =>
   Swaps ->
   Scope ann ->
   Expr ann Variable ->
@@ -124,7 +124,11 @@ getTypecheckedStoreExpression env expr = do
         expr
   resolveStoreExpression (store env) storeExpr
 
-evaluateText :: Project ann -> Text -> Either (Error ann) (ResolvedExpression ann)
+evaluateText ::
+  (Eq ann, Monoid ann) =>
+  Project ann ->
+  Text ->
+  Either (Error ann) (ResolvedExpression ann)
 evaluateText env input = do
   expr <- first OtherError $ parseExpr input
   getTypecheckedStoreExpression env expr

--- a/src/Language/Mimsa/Actions.hs
+++ b/src/Language/Mimsa/Actions.hs
@@ -37,7 +37,7 @@ getType ::
   (Eq ann, Monoid ann) =>
   Swaps ->
   Scope ann ->
-  Expr ann Variable ->
+  Expr Variable ann ->
   Either (Error ann) MonoType
 getType swaps scope' expr =
   first TypeErr $ startInference swaps (chainExprs expr scope')
@@ -63,9 +63,9 @@ getTypesFromStore (Store items') (TypeBindings tBindings) =
 
 chainExprs ::
   Monoid ann =>
-  Expr ann Variable ->
+  Expr Variable ann ->
   Scope ann ->
-  Expr ann Variable
+  Expr Variable ann
 chainExprs expr scope =
   foldr
     (\(name, expr') a -> MyLet mempty name expr' a)
@@ -113,7 +113,7 @@ resolveStoreExpression store' storeExpr = do
 getTypecheckedStoreExpression ::
   (Monoid ann, Eq ann) =>
   Project ann ->
-  Expr ann Name ->
+  Expr Name ann ->
   Either (Error ann) (ResolvedExpression ann)
 getTypecheckedStoreExpression env expr = do
   storeExpr <-

--- a/src/Language/Mimsa/Backend/Backend.hs
+++ b/src/Language/Mimsa/Backend/Backend.hs
@@ -33,7 +33,7 @@ data Backend
 
 data Renderer ann a
   = Renderer
-      { renderFunc :: Name -> Expr ann Name -> a,
+      { renderFunc :: Name -> Expr Name ann -> a,
         renderImport :: Backend -> (Name, ExprHash) -> a,
         renderStdLib :: Backend -> a,
         renderExport :: Backend -> Name -> a

--- a/src/Language/Mimsa/Backend/Javascript.hs
+++ b/src/Language/Mimsa/Backend/Javascript.hs
@@ -50,7 +50,7 @@ outputLiteral (MyInt i) = fromString $ show i
 intercal :: Javascript -> [Javascript] -> Javascript
 intercal sep as = Javascript $ T.intercalate (coerce sep) (coerce as)
 
-outputRecord :: Map Name (Expr Name) -> Javascript
+outputRecord :: Map Name (Expr a Name) -> Javascript
 outputRecord as =
   "{ "
     <> intercal
@@ -63,10 +63,14 @@ outputRecord as =
     outputRecordItem (name, val) =
       Javascript (prettyPrint name) <> ": " <> outputJS val
 
-outputConsApp :: Expr Name -> Expr Name -> Javascript
+outputConsApp :: Expr a Name -> Expr a Name -> Javascript
 outputConsApp c a = "__app(" <> outputJS c <> ", " <> outputJS a <> ")"
 
-outputCaseMatch :: Expr Name -> NonEmpty (TyCon, Expr Name) -> Maybe (Expr Name) -> Javascript
+outputCaseMatch ::
+  Expr a Name ->
+  NonEmpty (TyCon, Expr a Name) ->
+  Maybe (Expr a Name) ->
+  Javascript
 outputCaseMatch value matches catchAll =
   "__match(" <> outputJS value <> ", " <> matchList <> ", " <> catcher <> ")"
   where
@@ -77,65 +81,65 @@ outputCaseMatch value matches catchAll =
     catcher =
       maybe "null" outputJS catchAll
 
-output :: Expr Name -> Javascript
+output :: Expr a Name -> Javascript
 output = outputJS
 
 -- are there any more bindings in this expression?
-containsLet :: Expr Name -> Bool
+containsLet :: Expr a Name -> Bool
 containsLet = getAny . foundLet
 
 -- check for let expressions
-foundLet :: Expr Name -> Any
-foundLet (MyVar _) = mempty
-foundLet (MyIf a b c) = foundLet a <> foundLet b <> foundLet c
+foundLet :: Expr a Name -> Any
+foundLet (MyVar _ _) = mempty
+foundLet (MyIf _ a b c) = foundLet a <> foundLet b <> foundLet c
 foundLet MyLet {} = Any True
-foundLet (MyLambda _ a) = foundLet a
-foundLet (MyApp a b) = foundLet a <> foundLet b
-foundLet (MyLiteral _) = mempty
+foundLet (MyLambda _ _ a) = foundLet a
+foundLet (MyApp _ a b) = foundLet a <> foundLet b
+foundLet (MyLiteral _ _) = mempty
 foundLet MyLetPair {} = Any True
-foundLet (MyPair a b) = foundLet a <> foundLet b
-foundLet (MyRecord map') = foldMap foundLet map'
-foundLet (MyRecordAccess a _) = foundLet a
-foundLet (MyData _ a) =
+foundLet (MyPair _ a b) = foundLet a <> foundLet b
+foundLet (MyRecord _ map') = foldMap foundLet map'
+foundLet (MyRecordAccess _ a _) = foundLet a
+foundLet (MyData _ _ a) =
   foundLet a
-foundLet (MyConstructor _) = mempty
-foundLet (MyConsApp a b) = foundLet a <> foundLet b
-foundLet (MyCaseMatch sum' matches catchAll) =
+foundLet (MyConstructor _ _) = mempty
+foundLet (MyConsApp _ a b) = foundLet a <> foundLet b
+foundLet (MyCaseMatch _ sum' matches catchAll) =
   foundLet sum'
     <> mconcat (foundLet . snd <$> NE.toList matches)
     <> maybe mempty foundLet catchAll
 
 -- if this is the last binding, then we should 'return' the statement
-addReturn :: Expr Name -> Javascript -> Javascript
+addReturn :: Expr a Name -> Javascript -> Javascript
 addReturn expr js = if not $ containsLet expr then "return " <> js else js
 
 -- if a return contains let expresssions, it needs to be wrapped in curly lads
-withCurlyBoys :: Expr Name -> Javascript -> Javascript
+withCurlyBoys :: Expr a Name -> Javascript -> Javascript
 withCurlyBoys expr js = if containsLet expr then "{ " <> js <> " }" else js
 
-outputJS :: Expr Name -> Javascript
+outputJS :: Expr a Name -> Javascript
 outputJS expr =
   case expr of
-    MyLiteral a ->
+    MyLiteral _ a ->
       outputLiteral a
-    MyVar a -> coerce a
-    MyLambda arg func -> coerce arg <> " => " <> withCurlyBoys func (outputJS func)
-    MyApp f a -> outputJS f <> "(" <> outputJS a <> ")"
-    MyIf p a b -> outputJS p <> " ? " <> outputJS a <> " : " <> outputJS b
-    MyLet n a b ->
+    MyVar _ a -> coerce a
+    MyLambda _ arg func -> coerce arg <> " => " <> withCurlyBoys func (outputJS func)
+    MyApp _ f a -> outputJS f <> "(" <> outputJS a <> ")"
+    MyIf _ p a b -> outputJS p <> " ? " <> outputJS a <> " : " <> outputJS b
+    MyLet _ n a b ->
       "const " <> coerce n <> " = "
         <> outputJS a
         <> ";\n"
         <> addReturn b (outputJS b)
-    MyRecord as -> outputRecord as
-    MyLetPair m n a b ->
+    MyRecord _ as -> outputRecord as
+    MyLetPair _ m n a b ->
       "const [" <> coerce m <> "," <> coerce n <> "] = "
         <> outputJS a
         <> ";\n"
         <> addReturn b (outputJS b)
-    MyPair a b -> "[" <> outputJS a <> "," <> outputJS b <> "]"
-    MyRecordAccess r a -> outputJS r <> "." <> coerce a
-    MyData _ a -> outputJS a -- don't output types
-    MyConstructor a -> "{ type: \"" <> coerce a <> "\", vars: [] }"
-    MyConsApp c a -> outputConsApp c a
-    MyCaseMatch a matches catch -> outputCaseMatch a matches catch
+    MyPair _ a b -> "[" <> outputJS a <> "," <> outputJS b <> "]"
+    MyRecordAccess _ r a -> outputJS r <> "." <> coerce a
+    MyData _ _ a -> outputJS a -- don't output types
+    MyConstructor _ a -> "{ type: \"" <> coerce a <> "\", vars: [] }"
+    MyConsApp _ c a -> outputConsApp c a
+    MyCaseMatch _ a matches catch -> outputCaseMatch a matches catch

--- a/src/Language/Mimsa/Interpreter.hs
+++ b/src/Language/Mimsa/Interpreter.hs
@@ -12,7 +12,12 @@ import qualified Data.Map as M
 import Language.Mimsa.Interpreter.Interpret
 import Language.Mimsa.Types
 
-interpret :: Scope -> Swaps -> Expr Variable -> IO (Either InterpreterError (Expr Variable))
+interpret ::
+  (Eq ann, Monoid ann) =>
+  Scope ann ->
+  Swaps ->
+  Expr ann Variable ->
+  IO (Either (InterpreterError ann) (Expr ann Variable))
 interpret scope' swaps expr = fmap fst <$> either'
   where
     scopeSize = M.size . getScope

--- a/src/Language/Mimsa/Interpreter.hs
+++ b/src/Language/Mimsa/Interpreter.hs
@@ -16,8 +16,8 @@ interpret ::
   (Eq ann, Monoid ann) =>
   Scope ann ->
   Swaps ->
-  Expr ann Variable ->
-  IO (Either (InterpreterError ann) (Expr ann Variable))
+  Expr Variable ann ->
+  IO (Either (InterpreterError ann) (Expr Variable ann))
 interpret scope' swaps expr = fmap fst <$> either'
   where
     scopeSize = M.size . getScope

--- a/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -105,7 +105,7 @@ interpretWithScope interpretExpr =
       exprA <- interpretWithScope a
       exprB <- interpretWithScope b
       pure (MyPair ann exprA exprB)
-    (MyLet ann binder expr body) -> do
+    (MyLet _ binder expr body) -> do
       addToScope (Scope $ M.singleton binder expr)
       interpretWithScope body
     (MyLetPair _ binderA binderB (MyPair _ a b) body) -> do

--- a/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -18,7 +18,7 @@ import Language.Mimsa.Types
 -- when we come to do let recursive the name of our binder
 -- may already be turned into a number in the expr
 -- so we look it up to make sure we bind the right thing
-findActualBindingInSwaps :: Int -> App Variable ann
+findActualBindingInSwaps :: Int -> App ann Variable
 findActualBindingInSwaps int = do
   swaps <- askForSwaps
   scope' <- readScope
@@ -91,7 +91,7 @@ unwrapBuiltIn name (OneArg _ _) = do
     )
 
 -- get new var
-newLambdaCopy :: Variable -> Expr ann Variable -> App ann (Variable, Expr Variable ann)
+newLambdaCopy :: Variable -> Expr Variable ann -> App ann (Variable, Expr Variable ann)
 newLambdaCopy name expr = do
   newName' <- nextVariable
   newExpr <- swapName name newName' expr

--- a/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -18,7 +18,7 @@ import Language.Mimsa.Types
 -- when we come to do let recursive the name of our binder
 -- may already be turned into a number in the expr
 -- so we look it up to make sure we bind the right thing
-findActualBindingInSwaps :: Int -> App ann Variable
+findActualBindingInSwaps :: Int -> App Variable ann
 findActualBindingInSwaps int = do
   swaps <- askForSwaps
   scope' <- readScope
@@ -26,7 +26,7 @@ findActualBindingInSwaps int = do
     Just i' -> pure (NamedVar i')
     _ -> throwError $ CouldNotFindVar scope' (NumberedVar int)
 
-useVar :: (Eq ann, Monoid ann) => Variable -> App ann (Expr ann Variable)
+useVar :: (Eq ann, Monoid ann) => Variable -> App ann (Expr Variable ann)
 useVar var' = case var' of
   (NumberedVar i) -> do
     scope' <- readScope
@@ -55,7 +55,7 @@ useVar var' = case var' of
 
 -- make a fresh copy for us to use
 -- is this necessary?
-instantiateVar :: (Eq ann, Monoid ann) => Expr ann Variable -> App ann (Expr ann Variable)
+instantiateVar :: (Eq ann, Monoid ann) => Expr Variable ann -> App ann (Expr Variable ann)
 instantiateVar expr = case expr of
   (MyLambda ann binder expr') -> do
     (freshBinder, freshExpr) <- newLambdaCopy binder expr'
@@ -66,7 +66,7 @@ runBuiltIn ::
   (Eq ann, Monoid ann) =>
   BiIds ->
   ForeignFunc ann ->
-  App ann (Expr ann Variable)
+  App ann (Expr Variable ann)
 runBuiltIn _ (NoArgs _ io) = liftIO io
 runBuiltIn (OneId v1) (OneArg _ io) = do
   expr1 <- useVar v1
@@ -77,7 +77,7 @@ unwrapBuiltIn ::
   (Eq ann, Monoid ann) =>
   Name ->
   ForeignFunc ann ->
-  App ann (Expr ann Variable)
+  App ann (Expr Variable ann)
 unwrapBuiltIn name (NoArgs _ _) = do
   let actual = BuiltInActual name NoId
   addToScope (Scope $ M.singleton actual (MyVar mempty (BuiltIn name)))
@@ -91,13 +91,13 @@ unwrapBuiltIn name (OneArg _ _) = do
     )
 
 -- get new var
-newLambdaCopy :: Variable -> Expr ann Variable -> App ann (Variable, Expr ann Variable)
+newLambdaCopy :: Variable -> Expr ann Variable -> App ann (Variable, Expr Variable ann)
 newLambdaCopy name expr = do
   newName' <- nextVariable
   newExpr <- swapName name newName' expr
   pure (newName', newExpr)
 
-interpretWithScope :: (Eq ann, Monoid ann) => Expr ann Variable -> App ann (Expr ann Variable)
+interpretWithScope :: (Eq ann, Monoid ann) => Expr Variable ann -> App ann (Expr Variable ann)
 interpretWithScope interpretExpr =
   case interpretExpr of
     (MyLiteral ann a) -> pure (MyLiteral ann a)

--- a/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -18,7 +18,7 @@ import Language.Mimsa.Types
 -- when we come to do let recursive the name of our binder
 -- may already be turned into a number in the expr
 -- so we look it up to make sure we bind the right thing
-findActualBindingInSwaps :: Int -> App Variable
+findActualBindingInSwaps :: Int -> App ann Variable
 findActualBindingInSwaps int = do
   swaps <- askForSwaps
   scope' <- readScope
@@ -26,7 +26,7 @@ findActualBindingInSwaps int = do
     Just i' -> pure (NamedVar i')
     _ -> throwError $ CouldNotFindVar scope' (NumberedVar int)
 
-useVar :: Variable -> App (Expr Variable)
+useVar :: (Eq ann, Monoid ann) => Variable -> App ann (Expr ann Variable)
 useVar var' = case var' of
   (NumberedVar i) -> do
     scope' <- readScope
@@ -55,106 +55,114 @@ useVar var' = case var' of
 
 -- make a fresh copy for us to use
 -- is this necessary?
-instantiateVar :: Expr Variable -> App (Expr Variable)
+instantiateVar :: (Eq ann, Monoid ann) => Expr ann Variable -> App ann (Expr ann Variable)
 instantiateVar expr = case expr of
-  (MyLambda binder expr') -> do
+  (MyLambda ann binder expr') -> do
     (freshBinder, freshExpr) <- newLambdaCopy binder expr'
-    interpretWithScope (MyLambda freshBinder freshExpr)
+    interpretWithScope (MyLambda ann freshBinder freshExpr)
   other -> interpretWithScope other
 
-runBuiltIn :: BiIds -> ForeignFunc -> App (Expr Variable)
+runBuiltIn ::
+  (Eq ann, Monoid ann) =>
+  BiIds ->
+  ForeignFunc ann ->
+  App ann (Expr ann Variable)
 runBuiltIn _ (NoArgs _ io) = liftIO io
 runBuiltIn (OneId v1) (OneArg _ io) = do
   expr1 <- useVar v1
   liftIO (io expr1)
 runBuiltIn ids _ = throwError $ CouldNotMatchBuiltInId ids
 
-unwrapBuiltIn :: Name -> ForeignFunc -> App (Expr Variable)
+unwrapBuiltIn ::
+  (Eq ann, Monoid ann) =>
+  Name ->
+  ForeignFunc ann ->
+  App ann (Expr ann Variable)
 unwrapBuiltIn name (NoArgs _ _) = do
   let actual = BuiltInActual name NoId
-  addToScope (Scope $ M.singleton actual (MyVar (BuiltIn name)))
-  pure (MyVar actual)
+  addToScope (Scope $ M.singleton actual (MyVar mempty (BuiltIn name)))
+  pure (MyVar mempty actual)
 unwrapBuiltIn name (OneArg _ _) = do
   v1 <- nextVariable
   let actual = BuiltInActual name (OneId v1)
-  addToScope (Scope $ M.singleton actual (MyVar (BuiltIn name))) -- add new name to scope
+  addToScope (Scope $ M.singleton actual (MyVar mempty (BuiltIn name))) -- add new name to scope
   pure
-    ( MyLambda v1 (MyVar actual)
+    ( MyLambda mempty v1 (MyVar mempty actual)
     )
 
 -- get new var
-newLambdaCopy :: Variable -> Expr Variable -> App (Variable, Expr Variable)
+newLambdaCopy :: Variable -> Expr ann Variable -> App ann (Variable, Expr ann Variable)
 newLambdaCopy name expr = do
   newName' <- nextVariable
   newExpr <- swapName name newName' expr
   pure (newName', newExpr)
 
-interpretWithScope :: Expr Variable -> App (Expr Variable)
+interpretWithScope :: (Eq ann, Monoid ann) => Expr ann Variable -> App ann (Expr ann Variable)
 interpretWithScope interpretExpr =
   case interpretExpr of
-    (MyLiteral a) -> pure (MyLiteral a)
-    (MyPair a b) -> do
+    (MyLiteral ann a) -> pure (MyLiteral ann a)
+    (MyPair ann a b) -> do
       exprA <- interpretWithScope a
       exprB <- interpretWithScope b
-      pure (MyPair exprA exprB)
-    (MyLet binder expr body) -> do
+      pure (MyPair ann exprA exprB)
+    (MyLet ann binder expr body) -> do
       addToScope (Scope $ M.singleton binder expr)
       interpretWithScope body
-    (MyLetPair binderA binderB (MyPair a b) body) -> do
+    (MyLetPair _ binderA binderB (MyPair _ a b) body) -> do
       let newScopes = Scope $ M.fromList [(binderA, a), (binderB, b)]
       addToScope newScopes
       interpretWithScope body
-    (MyLetPair binderA binderB (MyVar v) body) -> do
-      expr <- interpretWithScope (MyVar v)
-      interpretWithScope (MyLetPair binderA binderB expr body)
-    (MyLetPair _ _ a _) ->
+    (MyLetPair ann binderA binderB (MyVar ann' v) body) -> do
+      expr <- interpretWithScope (MyVar ann' v)
+      interpretWithScope (MyLetPair ann binderA binderB expr body)
+    (MyLetPair _ _ _ a _) ->
       throwError $ CannotDestructureAsPair a
-    (MyVar var) ->
+    (MyVar _ var) ->
       useVar var >>= interpretWithScope
-    (MyApp (MyVar f) value) -> do
-      expr <- interpretWithScope (MyVar f)
-      interpretWithScope (MyApp expr value)
-    (MyApp (MyLambda binder expr) value) -> do
+    (MyApp ann (MyVar ann' f) value) -> do
+      expr <- interpretWithScope (MyVar ann' f)
+      interpretWithScope (MyApp ann expr value)
+    (MyApp _ (MyLambda _ binder expr) value) -> do
       value' <- interpretWithScope value
       addToScope (Scope $ M.singleton binder value')
       interpretWithScope expr
-    (MyApp (MyLiteral a) _) ->
-      throwError $ CannotApplyToNonFunction (MyLiteral a)
-    (MyApp other value) -> do
+    (MyApp _ (MyLiteral ann a) _) ->
+      throwError $ CannotApplyToNonFunction (MyLiteral ann a)
+    (MyApp ann other value) -> do
       expr <- interpretWithScope other
-      interpretWithScope (MyApp expr value)
-    (MyRecordAccess (MyRecord record) name) ->
+      interpretWithScope (MyApp ann expr value)
+    (MyRecordAccess _ (MyRecord _ record) name) ->
       case M.lookup name record of
         Just item -> interpretWithScope item
         _ -> throwError $ CannotFindMemberInRecord record name
-    (MyRecordAccess (MyVar a) name) -> do
-      expr <- interpretWithScope (MyVar a)
-      interpretWithScope (MyRecordAccess expr name)
-    (MyRecordAccess (MyRecordAccess a name') name) -> do
-      expr <- interpretWithScope (MyRecordAccess a name')
-      interpretWithScope (MyRecordAccess expr name)
-    (MyRecordAccess a name) ->
+    (MyRecordAccess ann (MyVar ann' a) name) -> do
+      expr <- interpretWithScope (MyVar ann' a)
+      interpretWithScope (MyRecordAccess ann expr name)
+    (MyRecordAccess ann (MyRecordAccess ann' a name') name) -> do
+      expr <- interpretWithScope (MyRecordAccess ann' a name')
+      interpretWithScope (MyRecordAccess ann expr name)
+    (MyRecordAccess _ a name) ->
       throwError $ CannotDestructureAsRecord a name
-    (MyRecord as) -> do
+    (MyRecord ann as) -> do
       exprs <- traverse interpretWithScope as
-      pure (MyRecord exprs)
-    (MyLambda a b) ->
-      pure (MyLambda a b)
-    (MyIf (MyLiteral (MyBool pred')) true false) ->
+      pure (MyRecord ann exprs)
+    (MyLambda ann a b) ->
+      pure (MyLambda ann a b)
+    (MyIf _ (MyLiteral _ (MyBool pred')) true false) ->
       if pred'
         then interpretWithScope true
         else interpretWithScope false
-    (MyIf all'@(MyLiteral _) _ _) ->
+    (MyIf _ all'@(MyLiteral _ _) _ _) ->
       throwError $ PredicateForIfMustBeABoolean all'
-    (MyIf all'@(MyLambda _ _) _ _) ->
+    (MyIf _ all'@MyLambda {} _ _) ->
       throwError $ PredicateForIfMustBeABoolean all'
-    (MyIf pred' true false) -> do
+    (MyIf ann pred' true false) -> do
       predExpr <- interpretWithScope pred'
-      interpretWithScope (MyIf predExpr true false)
-    (MyData _dataType expr) -> interpretWithScope expr
-    (MyConstructor a) -> pure (MyConstructor a)
-    (MyConsApp fn val) ->
-      MyConsApp fn <$> interpretWithScope val
-    (MyCaseMatch expr' matches catchAll) -> do
+      interpretWithScope (MyIf ann predExpr true false)
+    (MyData _ _ expr) -> interpretWithScope expr
+    (MyConstructor ann a) -> pure (MyConstructor ann a)
+    (MyConsApp ann fn val) ->
+      MyConsApp ann fn <$> interpretWithScope val
+    (MyCaseMatch _ expr' matches catchAll) -> do
       expr'' <- interpretWithScope expr'
       patternMatch expr'' matches catchAll >>= interpretWithScope

--- a/src/Language/Mimsa/Interpreter/PatternMatch.hs
+++ b/src/Language/Mimsa/Interpreter/PatternMatch.hs
@@ -13,10 +13,10 @@ import Language.Mimsa.Types
 
 patternMatch ::
   (Monoid ann) =>
-  Expr ann Variable ->
-  NonEmpty (TyCon, Expr ann Variable) ->
-  Maybe (Expr ann Variable) ->
-  App ann (Expr ann Variable)
+  Expr Variable ann ->
+  NonEmpty (TyCon, Expr Variable ann) ->
+  Maybe (Expr Variable ann) ->
+  App ann (Expr Variable ann)
 patternMatch expr' options catchAll = do
   const' <- findConstructor expr'
   case NE.filter (\(c, _) -> c == const') options of
@@ -27,7 +27,7 @@ patternMatch expr' options catchAll = do
         _ -> throwError $ PatternMatchFailure expr'
 
 -- when given an applied constructor, find the name for matching
-findConstructor :: Expr ann Variable -> App ann TyCon
+findConstructor :: Expr Variable ann -> App ann TyCon
 findConstructor (MyConstructor _ c) = pure c
 findConstructor (MyConsApp _ c _) = findConstructor c
 findConstructor e = throwError $ PatternMatchFailure e
@@ -35,8 +35,8 @@ findConstructor e = throwError $ PatternMatchFailure e
 -- apply each part of the constructor to the output function
 createMatchExpression ::
   (Monoid ann) =>
-  Expr ann Variable ->
-  Expr ann Variable ->
-  Expr ann Variable
+  Expr Variable ann ->
+  Expr Variable ann ->
+  Expr Variable ann
 createMatchExpression f (MyConsApp _ c a) = MyApp mempty (createMatchExpression f c) a
 createMatchExpression f _ = f

--- a/src/Language/Mimsa/Interpreter/PatternMatch.hs
+++ b/src/Language/Mimsa/Interpreter/PatternMatch.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Language.Mimsa.Interpreter.PatternMatch (patternMatch) where
+module Language.Mimsa.Interpreter.PatternMatch
+  ( patternMatch,
+  )
+where
 
 import Control.Monad.Except
 import Data.List.NonEmpty (NonEmpty)
@@ -9,10 +12,11 @@ import Language.Mimsa.Interpreter.Types
 import Language.Mimsa.Types
 
 patternMatch ::
-  Expr Variable ->
-  NonEmpty (TyCon, Expr Variable) ->
-  Maybe (Expr Variable) ->
-  App (Expr Variable)
+  (Monoid ann) =>
+  Expr ann Variable ->
+  NonEmpty (TyCon, Expr ann Variable) ->
+  Maybe (Expr ann Variable) ->
+  App ann (Expr ann Variable)
 patternMatch expr' options catchAll = do
   const' <- findConstructor expr'
   case NE.filter (\(c, _) -> c == const') options of
@@ -23,12 +27,16 @@ patternMatch expr' options catchAll = do
         _ -> throwError $ PatternMatchFailure expr'
 
 -- when given an applied constructor, find the name for matching
-findConstructor :: Expr Variable -> App TyCon
-findConstructor (MyConstructor c) = pure c
-findConstructor (MyConsApp c _) = findConstructor c
+findConstructor :: Expr ann Variable -> App ann TyCon
+findConstructor (MyConstructor _ c) = pure c
+findConstructor (MyConsApp _ c _) = findConstructor c
 findConstructor e = throwError $ PatternMatchFailure e
 
 -- apply each part of the constructor to the output function
-createMatchExpression :: Expr Variable -> Expr Variable -> Expr Variable
-createMatchExpression f (MyConsApp c a) = MyApp (createMatchExpression f c) a
+createMatchExpression ::
+  (Monoid ann) =>
+  Expr ann Variable ->
+  Expr ann Variable ->
+  Expr ann Variable
+createMatchExpression f (MyConsApp _ c a) = MyApp mempty (createMatchExpression f c) a
 createMatchExpression f _ = f

--- a/src/Language/Mimsa/Interpreter/SwapName.hs
+++ b/src/Language/Mimsa/Interpreter/SwapName.hs
@@ -9,47 +9,47 @@ import Language.Mimsa.Interpreter.Types
 import Language.Mimsa.Types
 
 -- step through Expr, replacing vars with numbered variables
-swapName :: Variable -> Variable -> Expr Variable -> App (Expr Variable)
-swapName from to (MyVar from') =
+swapName :: Variable -> Variable -> Expr ann Variable -> App ann (Expr ann Variable)
+swapName from to (MyVar ann from') =
   pure $
     if from == from'
-      then MyVar to
-      else MyVar from'
-swapName from to (MyLet name a b) =
-  MyLet name
+      then MyVar ann to
+      else MyVar ann from'
+swapName from to (MyLet ann name a b) =
+  MyLet ann name
     <$> swapName from to a
     <*> swapName from to b
-swapName from to (MyLambda name a) =
-  MyLambda name <$> swapName from to a
-swapName from to (MyRecordAccess a name) =
-  MyRecordAccess <$> swapName from to a <*> pure name
-swapName from to (MyApp a b) =
-  MyApp <$> swapName from to a
+swapName from to (MyLambda ann name a) =
+  MyLambda ann name <$> swapName from to a
+swapName from to (MyRecordAccess ann a name) =
+  MyRecordAccess ann <$> swapName from to a <*> pure name
+swapName from to (MyApp ann a b) =
+  MyApp ann <$> swapName from to a
     <*> swapName from to b
-swapName from to (MyIf a b c) =
-  MyIf
+swapName from to (MyIf ann a b c) =
+  MyIf ann
     <$> swapName from to a
       <*> swapName from to b
       <*> swapName from to c
-swapName from to (MyPair a b) =
-  MyPair
+swapName from to (MyPair ann a b) =
+  MyPair ann
     <$> swapName from to a <*> swapName from to b
-swapName from to (MyLetPair nameA nameB a b) =
-  MyLetPair nameA nameB
+swapName from to (MyLetPair ann nameA nameB a b) =
+  MyLetPair ann nameA nameB
     <$> swapName from to a
     <*> swapName from to b
-swapName from to (MyRecord map') = do
+swapName from to (MyRecord ann map') = do
   map2 <- traverse (swapName from to) map'
-  pure (MyRecord map2)
-swapName _ _ (MyLiteral a) = pure (MyLiteral a)
-swapName from to (MyData dataType expr) =
-  MyData dataType <$> swapName from to expr
-swapName _ _ (MyConstructor n) = pure (MyConstructor n)
-swapName from to (MyConsApp a b) =
-  MyConsApp <$> swapName from to a
+  pure (MyRecord ann map2)
+swapName _ _ (MyLiteral ann a) = pure (MyLiteral ann a)
+swapName from to (MyData ann dataType expr) =
+  MyData ann dataType <$> swapName from to expr
+swapName _ _ (MyConstructor ann n) = pure (MyConstructor ann n)
+swapName from to (MyConsApp ann a b) =
+  MyConsApp ann <$> swapName from to a
     <*> swapName from to b
-swapName from to (MyCaseMatch expr matches catchAll) = do
+swapName from to (MyCaseMatch ann expr matches catchAll) = do
   expr' <- swapName from to expr
   matches' <- traverse (\(k, v) -> (,) k <$> swapName from to v) matches
   catchAll' <- traverse (swapName from to) catchAll
-  pure (MyCaseMatch expr' matches' catchAll')
+  pure (MyCaseMatch ann expr' matches' catchAll')

--- a/src/Language/Mimsa/Interpreter/SwapName.hs
+++ b/src/Language/Mimsa/Interpreter/SwapName.hs
@@ -9,7 +9,7 @@ import Language.Mimsa.Interpreter.Types
 import Language.Mimsa.Types
 
 -- step through Expr, replacing vars with numbered variables
-swapName :: Variable -> Variable -> Expr ann Variable -> App ann (Expr ann Variable)
+swapName :: Variable -> Variable -> Expr Variable ann -> App ann (Expr Variable ann)
 swapName from to (MyVar ann from') =
   pure $
     if from == from'

--- a/src/Language/Mimsa/Interpreter/Types.hs
+++ b/src/Language/Mimsa/Interpreter/Types.hs
@@ -8,28 +8,30 @@ import qualified Data.Map as M
 import Data.Maybe (listToMaybe)
 import Language.Mimsa.Types
 
-type App = StateT (Int, Scope) (ReaderT Swaps (ExceptT InterpreterError IO))
+type App ann =
+  StateT (Int, Scope ann)
+    (ReaderT Swaps (ExceptT (InterpreterError ann) IO))
 
-readScope :: App Scope
+readScope :: App ann (Scope ann)
 readScope = gets snd
 
-nextInt :: App Int
+nextInt :: App ann Int
 nextInt = do
   int' <- gets fst
   modify $ first (1 +)
   pure int'
 
-nextVariable :: App Variable
+nextVariable :: App ann Variable
 nextVariable = NumberedVar <$> nextInt
 
-addToScope :: Scope -> App ()
+addToScope :: (Eq ann, Monoid ann) => Scope ann -> App ann ()
 addToScope scope' =
   case foundALoop scope' of
     Nothing -> modify $ bimap (1 +) (scope' <>)
     Just k -> throwError $ SelfReferencingBinding k
   where
     foundALoop (Scope newScope) =
-      fmap fst . listToMaybe . M.toList . M.filterWithKey (\k a -> MyVar k == a) $ newScope
+      fmap fst . listToMaybe . M.toList . M.filterWithKey (\k a -> MyVar mempty k == a) $ newScope
 
-askForSwaps :: App Swaps
+askForSwaps :: App ann Swaps
 askForSwaps = ask

--- a/src/Language/Mimsa/Library.hs
+++ b/src/Language/Mimsa/Library.hs
@@ -49,7 +49,7 @@ getLibraryFunction (BuiltInActual name _) =
   M.lookup (coerce name) (getLibrary libraryFunctions)
 getLibraryFunction _ = Nothing
 
-logFn :: Monoid ann => ForeignFunc ann
+logFn :: (Monoid ann) => ForeignFunc ann
 logFn =
   let tyA = MTVar (NamedVar (Name "a"))
    in OneArg (tyA, MTUnit) logExpr

--- a/src/Language/Mimsa/Library.hs
+++ b/src/Language/Mimsa/Library.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Language.Mimsa.Library
   ( libraryFunctions,
@@ -15,9 +18,7 @@ import Language.Mimsa.Printer
 import Language.Mimsa.Types
 import System.Random
 
-type ForeignFunc' = ForeignFunc ()
-
-libraryFunctions :: Library ()
+libraryFunctions :: (Eq ann, Monoid ann) => Library ann
 libraryFunctions =
   Library $
     M.fromList
@@ -28,11 +29,18 @@ libraryFunctions =
         (FuncName "addIntPair", addIntPair)
       ]
 
-isLibraryName :: Name -> Bool
+isLibraryName ::
+  forall ann.
+  (Eq ann, Monoid ann) =>
+  Name ->
+  Bool
 isLibraryName name =
-  M.member (coerce name) (getLibrary libraryFunctions)
+  M.member (coerce name) (getLibrary @ann libraryFunctions)
 
-getLibraryFunction :: Variable -> Maybe ForeignFunc'
+getLibraryFunction ::
+  (Eq ann, Monoid ann) =>
+  Variable ->
+  Maybe (ForeignFunc ann)
 getLibraryFunction (BuiltIn name) =
   M.lookup (coerce name) (getLibrary libraryFunctions)
 getLibraryFunction (NamedVar name) =
@@ -41,30 +49,30 @@ getLibraryFunction (BuiltInActual name _) =
   M.lookup (coerce name) (getLibrary libraryFunctions)
 getLibraryFunction _ = Nothing
 
-logFn :: ForeignFunc'
+logFn :: Monoid ann => ForeignFunc ann
 logFn =
   let tyA = MTVar (NamedVar (Name "a"))
    in OneArg (tyA, MTUnit) logExpr
   where
     logExpr i = do
       T.putStrLn (prettyPrint i)
-      pure (MyLiteral () MyUnit)
+      pure (MyLiteral mempty MyUnit)
 
-randomInt :: ForeignFunc'
+randomInt :: Monoid ann => ForeignFunc ann
 randomInt = NoArgs MTInt action
   where
-    action = MyLiteral () . MyInt <$> randomIO
+    action = MyLiteral mempty . MyInt <$> randomIO
 
-randomIntFrom :: ForeignFunc'
+randomIntFrom :: Monoid ann => ForeignFunc ann
 randomIntFrom =
   OneArg
     (MTInt, MTInt)
     ( \(MyLiteral _ (MyInt i)) -> do
         val <- randomIO
-        pure (MyLiteral () (MyInt (max val i)))
+        pure (MyLiteral mempty (MyInt (max val i)))
     )
 
-eqPair :: ForeignFunc'
+eqPair :: (Eq ann, Monoid ann) => ForeignFunc ann
 eqPair =
   let tyA = MTVar (NamedVar (Name "a"))
    in OneArg
@@ -73,9 +81,9 @@ eqPair =
   where
     equality pair' =
       let (MyPair _ x y) = pair'
-       in pure $ MyLiteral () (MyBool (x == y))
+       in pure $ MyLiteral mempty (MyBool (x == y))
 
-addIntPair :: ForeignFunc'
+addIntPair :: Monoid ann => ForeignFunc ann
 addIntPair =
   OneArg
     (MTPair MTInt MTInt, MTInt)
@@ -83,9 +91,9 @@ addIntPair =
            _
            (MyLiteral _ (MyInt a))
            (MyLiteral _ (MyInt b))
-         ) -> pure (MyLiteral () (MyInt (a + b)))
+         ) -> pure (MyLiteral mempty (MyInt (a + b)))
     )
 
-getFFType :: ForeignFunc' -> MonoType
+getFFType :: ForeignFunc ann -> MonoType
 getFFType (NoArgs out _) = out
 getFFType (OneArg (in1, out) _) = MTFunction in1 out

--- a/src/Language/Mimsa/Library.hs
+++ b/src/Language/Mimsa/Library.hs
@@ -15,7 +15,9 @@ import Language.Mimsa.Printer
 import Language.Mimsa.Types
 import System.Random
 
-libraryFunctions :: Library
+type ForeignFunc' = ForeignFunc ()
+
+libraryFunctions :: Library ()
 libraryFunctions =
   Library $
     M.fromList
@@ -30,7 +32,7 @@ isLibraryName :: Name -> Bool
 isLibraryName name =
   M.member (coerce name) (getLibrary libraryFunctions)
 
-getLibraryFunction :: Variable -> Maybe ForeignFunc
+getLibraryFunction :: Variable -> Maybe ForeignFunc'
 getLibraryFunction (BuiltIn name) =
   M.lookup (coerce name) (getLibrary libraryFunctions)
 getLibraryFunction (NamedVar name) =
@@ -39,52 +41,51 @@ getLibraryFunction (BuiltInActual name _) =
   M.lookup (coerce name) (getLibrary libraryFunctions)
 getLibraryFunction _ = Nothing
 
-logFn :: ForeignFunc
+logFn :: ForeignFunc'
 logFn =
   let tyA = MTVar (NamedVar (Name "a"))
    in OneArg (tyA, MTUnit) logExpr
+  where
+    logExpr i = do
+      T.putStrLn (prettyPrint i)
+      pure (MyLiteral () MyUnit)
 
-logExpr :: (Printer p) => p -> IO (Expr a)
-logExpr i = do
-  T.putStrLn (prettyPrint i)
-  pure (MyLiteral MyUnit)
-
-randomInt :: ForeignFunc
+randomInt :: ForeignFunc'
 randomInt = NoArgs MTInt action
   where
-    action = MyLiteral . MyInt <$> randomIO
+    action = MyLiteral () . MyInt <$> randomIO
 
-randomIntFrom :: ForeignFunc
+randomIntFrom :: ForeignFunc'
 randomIntFrom =
   OneArg
     (MTInt, MTInt)
-    ( \(MyLiteral (MyInt i)) -> do
+    ( \(MyLiteral _ (MyInt i)) -> do
         val <- randomIO
-        pure (MyLiteral (MyInt (max val i)))
+        pure (MyLiteral () (MyInt (max val i)))
     )
 
-eqPair :: ForeignFunc
+eqPair :: ForeignFunc'
 eqPair =
   let tyA = MTVar (NamedVar (Name "a"))
    in OneArg
         (MTPair tyA tyA, MTBool)
         equality
+  where
+    equality pair' =
+      let (MyPair _ x y) = pair'
+       in pure $ MyLiteral () (MyBool (x == y))
 
-equality :: (Monad m, Eq a) => Expr a -> m (Expr a)
-equality pair' =
-  let (MyPair x y) = pair'
-   in pure $ MyLiteral (MyBool (x == y))
-
-addIntPair :: ForeignFunc
+addIntPair :: ForeignFunc'
 addIntPair =
   OneArg
     (MTPair MTInt MTInt, MTInt)
     ( \( MyPair
-           (MyLiteral (MyInt a))
-           (MyLiteral (MyInt b))
-         ) -> pure (MyLiteral (MyInt (a + b)))
+           _
+           (MyLiteral _ (MyInt a))
+           (MyLiteral _ (MyInt b))
+         ) -> pure (MyLiteral () (MyInt (a + b)))
     )
 
-getFFType :: ForeignFunc -> MonoType
+getFFType :: ForeignFunc' -> MonoType
 getFFType (NoArgs out _) = out
 getFFType (OneArg (in1, out) _) = MTFunction in1 out

--- a/src/Language/Mimsa/Parser/Language.hs
+++ b/src/Language/Mimsa/Parser/Language.hs
@@ -36,7 +36,7 @@ import Language.Mimsa.Types
     safeMkTyCon,
   )
 
-type ParserExpr a = Expr a Name
+type ParserExpr ann = Expr Name ann
 
 -- parse expr, using it all up
 parseExpr :: Monoid ann => Text -> Either Text (ParserExpr ann)

--- a/src/Language/Mimsa/Parser/Language.hs
+++ b/src/Language/Mimsa/Parser/Language.hs
@@ -21,6 +21,7 @@ import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
+import Data.Void
 import Language.Mimsa.Parser.Parser (Parser)
 import qualified Language.Mimsa.Parser.Parser as P
 import Language.Mimsa.Types
@@ -35,23 +36,23 @@ import Language.Mimsa.Types
     safeMkTyCon,
   )
 
-type ParserExpr = Expr Name
+type ParserExpr a = Expr a Name
 
 -- parse expr, using it all up
-parseExpr :: Text -> Either Text ParserExpr
+parseExpr :: Monoid ann => Text -> Either Text (ParserExpr ann)
 parseExpr input = P.runParser (P.thenOptionalSpace expressionParser) input
   >>= \(leftover, a) ->
     if T.length leftover == 0
       then Right a
       else Left ("Leftover input: >>>" <> leftover <> "<<<")
 
-parseExpr' :: Text -> Either Text ParserExpr
+parseExpr' :: Monoid ann => Text -> Either Text (ParserExpr ann)
 parseExpr' input = snd <$> P.runParser expressionParser input
 
-failer :: Parser ParserExpr
+failer :: Parser (ParserExpr ann)
 failer = P.parseFail (\input -> "Could not parse expression for >>>" <> input <> "<<<")
 
-expressionParser :: Parser ParserExpr
+expressionParser :: Monoid ann => Parser (ParserExpr ann)
 expressionParser =
   let parsers =
         literalParser
@@ -67,14 +68,14 @@ inBrackets = P.between2 '(' ')'
 orInBrackets :: Parser a -> Parser a
 orInBrackets parser = parser <|> inBrackets parser
 
-literalParser :: Parser ParserExpr
+literalParser :: Monoid ann => Parser (ParserExpr ann)
 literalParser =
   boolParser
     <|> unitParser
     <|> intParser
     <|> stringParser
 
-complexParser :: Parser ParserExpr
+complexParser :: Monoid ann => Parser (ParserExpr ann)
 complexParser =
   letPairParser
     <|> recordParser
@@ -107,34 +108,34 @@ protectedNames =
 
 ----
 
-boolParser :: Parser ParserExpr
+boolParser :: Monoid ann => Parser (ParserExpr ann)
 boolParser = trueParser <|> falseParser
 
-trueParser :: Parser ParserExpr
-trueParser = P.literal "True" $> MyLiteral (MyBool True)
+trueParser :: Monoid ann => Parser (ParserExpr ann)
+trueParser = P.literal "True" $> MyLiteral mempty (MyBool True)
 
-falseParser :: Parser ParserExpr
-falseParser = P.literal "False" $> MyLiteral (MyBool False)
-
------
-
-unitParser :: Parser ParserExpr
-unitParser = P.literal "Unit" $> MyLiteral MyUnit
+falseParser :: Monoid ann => Parser (ParserExpr ann)
+falseParser = P.literal "False" $> MyLiteral mempty (MyBool False)
 
 -----
 
-intParser :: Parser ParserExpr
-intParser = MyLiteral . MyInt <$> P.integer
+unitParser :: Monoid ann => Parser (ParserExpr ann)
+unitParser = P.literal "Unit" $> MyLiteral mempty MyUnit
 
 -----
 
-stringParser :: Parser ParserExpr
-stringParser = MyLiteral . MyString . StringType <$> P.between '"'
+intParser :: Monoid ann => Parser (ParserExpr ann)
+intParser = MyLiteral mempty . MyInt <$> P.integer
 
 -----
 
-varParser :: Parser ParserExpr
-varParser = MyVar <$> nameParser
+stringParser :: Monoid ann => Parser (ParserExpr ann)
+stringParser = MyLiteral mempty . MyString . StringType <$> P.between '"'
+
+-----
+
+varParser :: Monoid ann => Parser (ParserExpr ann)
+varParser = MyVar mempty <$> nameParser
 
 ---
 
@@ -149,8 +150,8 @@ inProtected tx = if S.member tx protectedNames then Nothing else Just tx
 
 ---
 
-constructorParser :: Parser ParserExpr
-constructorParser = MyConstructor <$> tyConParser
+constructorParser :: Monoid ann => Parser (ParserExpr ann)
+constructorParser = MyConstructor mempty <$> tyConParser
 
 tyConParser :: Parser TyCon
 tyConParser =
@@ -160,7 +161,7 @@ tyConParser =
 
 -----
 
-letParser :: Parser ParserExpr
+letParser :: Monoid ann => Parser (ParserExpr ann)
 letParser = letInParser <|> letNewlineParser
 
 letNameIn :: Parser Name
@@ -170,19 +171,19 @@ letNameIn = do
   _ <- P.thenSpace (P.literal "=")
   pure name
 
-letInParser :: Parser ParserExpr
+letInParser :: Monoid ann => Parser (ParserExpr ann)
 letInParser = do
   name <- letNameIn
   expr <- P.thenSpace expressionParser
   _ <- P.thenSpace (P.literal "in")
-  MyLet name expr <$> expressionParser
+  MyLet mempty name expr <$> expressionParser
 
-letNewlineParser :: Parser ParserExpr
+letNewlineParser :: Monoid ann => Parser (ParserExpr ann)
 letNewlineParser = do
   name <- letNameIn
   expr <- expressionParser
   _ <- literalWithSpace ";"
-  MyLet name expr <$> expressionParser
+  MyLet mempty name expr <$> expressionParser
 
 -----
 
@@ -195,8 +196,11 @@ spacedName = do
 
 -----
 
-letPairParser :: Parser ParserExpr
-letPairParser = MyLetPair <$> binder1 <*> binder2 <*> equalsParser <*> inParser
+letPairParser :: Monoid ann => Parser (ParserExpr ann)
+letPairParser =
+  MyLetPair mempty <$> binder1 <*> binder2
+    <*> equalsParser
+    <*> inParser
   where
     binder1 = do
       _ <- P.thenSpace (P.literal "let")
@@ -210,17 +214,17 @@ letPairParser = MyLetPair <$> binder1 <*> binder2 <*> equalsParser <*> inParser
 
 -----
 
-equalsParser :: Parser ParserExpr
+equalsParser :: Monoid ann => Parser (ParserExpr ann)
 equalsParser =
   P.right (P.thenSpace (P.literal "=")) (P.thenSpace expressionParser)
 
-inParser :: Parser ParserExpr
+inParser :: Monoid ann => Parser (ParserExpr ann)
 inParser = P.right (P.thenSpace (P.literal "in")) expressionParser
 
 -----
 
-lambdaParser :: Parser ParserExpr
-lambdaParser = MyLambda <$> slashNameBinder <*> arrowExprBinder
+lambdaParser :: Monoid ann => Parser (ParserExpr ann)
+lambdaParser = MyLambda mempty <$> slashNameBinder <*> arrowExprBinder
 
 -- matches \varName
 slashNameBinder :: Parser Name
@@ -229,19 +233,19 @@ slashNameBinder = do
   _ <- P.space0
   P.thenSpace nameParser
 
-arrowExprBinder :: Parser ParserExpr
+arrowExprBinder :: Monoid ann => Parser (ParserExpr ann)
 arrowExprBinder = P.right (P.thenSpace (P.literal "->")) expressionParser
 
 -----
 
-appFunc :: Parser ParserExpr
+appFunc :: Monoid ann => Parser (ParserExpr ann)
 appFunc = recordAccessParser <|> inBrackets lambdaParser <|> varParser
 
-appParser :: Parser ParserExpr
+appParser :: Monoid ann => Parser (ParserExpr ann)
 appParser = do
   app <- appFunc
   exprs <- P.oneOrMore (withOptionalSpace exprInBrackets)
-  pure (foldl MyApp app exprs)
+  pure (foldl (MyApp mempty) app exprs)
 
 literalWithSpace :: Text -> Parser ()
 literalWithSpace tx = () <$ withOptionalSpace (P.literal tx)
@@ -253,7 +257,7 @@ withOptionalSpace p = do
   _ <- P.space0
   pure a
 
-exprInBrackets :: Parser ParserExpr
+exprInBrackets :: Monoid ann => Parser (ParserExpr ann)
 exprInBrackets = do
   literalWithSpace "("
   expr <- expressionParser
@@ -263,24 +267,24 @@ exprInBrackets = do
 
 -----
 
-recordParser :: Parser ParserExpr
+recordParser :: Monoid ann => Parser (ParserExpr ann)
 recordParser = fullRecordParser <|> emptyRecordParser
 
-emptyRecordParser :: Parser ParserExpr
+emptyRecordParser :: Monoid ann => Parser (ParserExpr ann)
 emptyRecordParser = do
   literalWithSpace "{"
   literalWithSpace "}"
-  pure (MyRecord mempty)
+  pure (MyRecord mempty mempty)
 
-fullRecordParser :: Parser ParserExpr
+fullRecordParser :: Monoid ann => Parser (ParserExpr ann)
 fullRecordParser = do
   literalWithSpace "{"
   args <- P.zeroOrMore (P.left recordItemParser (P.left (P.literal ",") P.space0))
   last' <- recordItemParser
   literalWithSpace "}"
-  pure (MyRecord (M.fromList $ args <> [last']))
+  pure (MyRecord mempty (M.fromList $ args <> [last']))
 
-recordItemParser :: Parser (Name, ParserExpr)
+recordItemParser :: Monoid ann => Parser (Name, ParserExpr ann)
 recordItemParser = do
   name <- nameParser
   literalWithSpace ":"
@@ -289,33 +293,33 @@ recordItemParser = do
 
 -----
 
-recordAccessParser :: Parser ParserExpr
+recordAccessParser :: Monoid ann => Parser (ParserExpr ann)
 recordAccessParser =
   recordAccessParser3
     <|> recordAccessParser2
     <|> recordAccessParser1
 
-recordAccessParser1 :: Parser ParserExpr
+recordAccessParser1 :: Monoid ann => Parser (ParserExpr ann)
 recordAccessParser1 = do
   expr <- varParser
   name <- dotName
   _ <- P.space0
-  pure (MyRecordAccess expr name)
+  pure (MyRecordAccess mempty expr name)
 
 dotName :: Parser Name
 dotName = do
   _ <- P.literal "."
   nameParser
 
-recordAccessParser2 :: Parser ParserExpr
+recordAccessParser2 :: Monoid ann => Parser (ParserExpr ann)
 recordAccessParser2 = do
   expr <- varParser
   name <- dotName
   name2 <- dotName
   _ <- P.space0
-  pure (MyRecordAccess (MyRecordAccess expr name) name2)
+  pure (MyRecordAccess mempty (MyRecordAccess mempty expr name) name2)
 
-recordAccessParser3 :: Parser ParserExpr
+recordAccessParser3 :: Monoid ann => Parser (ParserExpr ann)
 recordAccessParser3 = do
   expr <- varParser
   _ <- P.literal "."
@@ -325,25 +329,25 @@ recordAccessParser3 = do
   _ <- P.literal "."
   name3 <- nameParser
   _ <- P.space0
-  pure (MyRecordAccess (MyRecordAccess (MyRecordAccess expr name) name2) name3)
+  pure (MyRecordAccess mempty (MyRecordAccess mempty (MyRecordAccess mempty expr name) name2) name3)
 
 -----
 
-ifParser :: Parser ParserExpr
-ifParser = MyIf <$> predParser <*> thenParser <*> elseParser
+ifParser :: Monoid ann => Parser (ParserExpr ann)
+ifParser = MyIf mempty <$> predParser <*> thenParser <*> elseParser
 
-predParser :: Parser ParserExpr
+predParser :: Monoid ann => Parser (ParserExpr ann)
 predParser = P.right (P.thenSpace (P.literal "if")) expressionParser
 
-thenParser :: Parser ParserExpr
+thenParser :: Monoid ann => Parser (ParserExpr ann)
 thenParser = P.right (P.thenSpace (P.literal "then")) expressionParser
 
-elseParser :: Parser ParserExpr
+elseParser :: Monoid ann => Parser (ParserExpr ann)
 elseParser = P.right (P.thenSpace (P.literal "else")) expressionParser
 
 -----
 
-pairParser :: Parser ParserExpr
+pairParser :: Monoid ann => Parser (ParserExpr ann)
 pairParser = do
   _ <- P.literal "("
   _ <- P.space0
@@ -355,7 +359,7 @@ pairParser = do
   _ <- P.space0
   _ <- P.literal ")"
   _ <- P.space0
-  pure $ MyPair exprA exprB
+  pure $ MyPair mempty exprA exprB
 
 -----
 
@@ -379,17 +383,17 @@ typeDeclParserWithCons = do
 
 --------
 
-typeParser :: Parser ParserExpr
+typeParser :: Monoid ann => Parser (ParserExpr ann)
 typeParser =
-  MyData <$> (typeDeclParserWithCons <|> typeDeclParserEmpty)
+  MyData mempty <$> (typeDeclParserWithCons <|> typeDeclParserEmpty)
     <*> (inExpr <|> inNewLineExpr)
 
-inNewLineExpr :: Parser ParserExpr
+inNewLineExpr :: Monoid ann => Parser (ParserExpr ann)
 inNewLineExpr = do
   _ <- literalWithSpace ";"
   expressionParser
 
-inExpr :: Parser ParserExpr
+inExpr :: Monoid ann => Parser (ParserExpr ann)
 inExpr = do
   _ <- P.space0
   _ <- P.thenSpace (P.literal "in")
@@ -429,30 +433,30 @@ varNameParser = VarName <$> nameParser
 
 ---
 --
-constructorAppParser :: Parser ParserExpr
+constructorAppParser :: Monoid ann => Parser (ParserExpr ann)
 constructorAppParser = do
   cons <- tyConParser
   exprs <- P.oneOrMore (P.right P.space1 (orInBrackets expressionParser))
-  pure (foldl MyConsApp (MyConstructor cons) exprs)
+  pure (foldl (MyConsApp mempty) (MyConstructor mempty cons) exprs)
 
 ----------
-caseExprOfParser :: Parser ParserExpr
+caseExprOfParser :: Monoid ann => Parser (ParserExpr ann)
 caseExprOfParser = do
   _ <- P.thenSpace (P.literal "case")
   sumExpr <- expressionParser
   _ <- P.thenSpace (P.literal "of")
   pure sumExpr
 
-caseMatchParser :: Parser ParserExpr
+caseMatchParser :: Monoid ann => Parser (ParserExpr ann)
 caseMatchParser = do
   sumExpr <- caseExprOfParser
   matches <-
     matchesParser <|> pure <$> matchParser
   catchAll <-
     optional (otherwiseParser (not . null $ matches))
-  pure $ MyCaseMatch sumExpr matches catchAll
+  pure $ MyCaseMatch mempty sumExpr matches catchAll
 
-otherwiseParser :: Bool -> Parser ParserExpr
+otherwiseParser :: Monoid ann => Bool -> Parser (ParserExpr ann)
 otherwiseParser needsBar = do
   if needsBar
     then () <$ P.thenSpace (P.literal "|")
@@ -460,11 +464,11 @@ otherwiseParser needsBar = do
   _ <- P.thenSpace (P.literal "otherwise")
   expressionParser
 
-matchesParser :: Parser (NonEmpty (TyCon, ParserExpr))
+matchesParser :: Monoid ann => Parser (NonEmpty (TyCon, ParserExpr ann))
 matchesParser = do
   cons <- P.zeroOrMore (P.left matchParser (P.thenSpace (P.literal "|")))
   lastCons <- matchParser
   pure $ NE.fromList (cons <> [lastCons])
 
-matchParser :: Parser (TyCon, Expr Name)
+matchParser :: Monoid ann => Parser (TyCon, ParserExpr ann)
 matchParser = (,) <$> P.thenSpace tyConParser <*> expressionParser

--- a/src/Language/Mimsa/Parser/Language.hs
+++ b/src/Language/Mimsa/Parser/Language.hs
@@ -21,7 +21,6 @@ import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Void
 import Language.Mimsa.Parser.Parser (Parser)
 import qualified Language.Mimsa.Parser.Parser as P
 import Language.Mimsa.Types

--- a/src/Language/Mimsa/Printer.hs
+++ b/src/Language/Mimsa/Printer.hs
@@ -34,6 +34,9 @@ class Printer a where
   default prettyDoc :: a -> Doc ann
   prettyDoc = pretty . T.unpack . prettyPrint
 
+instance Printer () where
+  prettyDoc = const ""
+
 instance Printer Text where
   prettyPrint a = a
   prettyDoc = pretty

--- a/src/Language/Mimsa/Project/Default.hs
+++ b/src/Language/Mimsa/Project/Default.hs
@@ -10,6 +10,6 @@ import Language.Mimsa.Types
 servers :: [ServerUrl]
 servers = pure (ServerUrl "https://raw.githubusercontent.com/danieljharvey/mimsa-store/master/")
 
-defaultProject :: Project
+defaultProject :: Project ann
 defaultProject =
   Project mempty mempty mempty servers

--- a/src/Language/Mimsa/Project/Persistence.hs
+++ b/src/Language/Mimsa/Project/Persistence.hs
@@ -29,9 +29,11 @@ hush :: Either IOError a -> Maybe a
 hush (Right a) = pure a
 hush _ = Nothing
 
+type LoadProject = Project ()
+
 -- load environment.json and any hashed exprs mentioned in it
 -- should probably consider loading the exprs lazily as required in future
-loadProject :: (JSON.FromJSON ann, JSON.ToJSON ann) => PersistApp (Project ann)
+loadProject :: PersistApp LoadProject
 loadProject = do
   project' <- liftIO $ try $ BS.readFile envPath
   case hush project' >>= JSON.decode of
@@ -54,7 +56,11 @@ saveProject env = do
 
 --
 
-loadBoundExpressions :: (JSON.ToJSON ann, JSON.FromJSON ann) => [ServerUrl] -> Set ExprHash -> PersistApp (Store ann)
+loadBoundExpressions ::
+  (JSON.ToJSON ann, JSON.FromJSON ann) =>
+  [ServerUrl] ->
+  Set ExprHash ->
+  PersistApp (Store ann)
 loadBoundExpressions urls hashes = do
   items' <-
     traverse

--- a/src/Language/Mimsa/Project/Usages.hs
+++ b/src/Language/Mimsa/Project/Usages.hs
@@ -15,15 +15,15 @@ import Language.Mimsa.Types.Store
 import Language.Mimsa.Types.StoreExpression
 import Language.Mimsa.Types.Usage
 
-findUsages :: Project -> ExprHash -> Either UsageError (Set Usage)
+findUsages :: Project ann -> ExprHash -> Either UsageError (Set Usage)
 findUsages (Project store' bindings' _ _) =
   findUsages_ store' (getCurrentBindings bindings')
 
-resolveDepsOrUsageError :: Store -> Bindings -> Either UsageError ResolvedDeps
+resolveDepsOrUsageError :: Store ann -> Bindings -> Either UsageError (ResolvedDeps ann)
 resolveDepsOrUsageError store' bindings' =
   first CouldNotResolveDeps (resolveDeps store' bindings')
 
-findUsages_ :: Store -> Bindings -> ExprHash -> Either UsageError (Set Usage)
+findUsages_ :: Store ann -> Bindings -> ExprHash -> Either UsageError (Set Usage)
 findUsages_ store' bindings' exprHash = do
   (ResolvedDeps resolvedDeps) <- resolveDepsOrUsageError store' bindings'
   let directDeps = mconcat $ addUsageIfMatching exprHash <$> M.toList resolvedDeps
@@ -38,7 +38,7 @@ findUsages_ store' bindings' exprHash = do
       (M.toList resolvedDeps)
   pure $ directDeps <> mconcat inDirectDeps
 
-addUsageIfMatching :: ExprHash -> (Name, (ExprHash, StoreExpression)) -> Set Usage
+addUsageIfMatching :: ExprHash -> (Name, (ExprHash, StoreExpression ann)) -> Set Usage
 addUsageIfMatching exprHash (name, (hash, storeExpr')) =
   let matchingNames = getMatches exprHash (storeBindings storeExpr')
    in if S.null matchingNames

--- a/src/Language/Mimsa/Project/Versions.hs
+++ b/src/Language/Mimsa/Project/Versions.hs
@@ -26,7 +26,7 @@ findVersions ::
   (Eq ann, Monoid ann) =>
   Project ann ->
   Name ->
-  Either (Error ann) (NonEmpty (Int, Expr ann Variable, MonoType, Set Usage))
+  Either (Error ann) (NonEmpty (Int, Expr Variable ann, MonoType, Set Usage))
 findVersions project name = do
   versioned <- first UsageErr (findInProject project name)
   as <- traverse (getExprDetails project) versioned
@@ -62,7 +62,7 @@ getExprDetails ::
   (Eq ann, Monoid ann) =>
   Project ann ->
   ExprHash ->
-  Either (Error ann) (Expr ann Variable, MonoType, Set Usage)
+  Either (Error ann) (Expr Variable ann, MonoType, Set Usage)
 getExprDetails project exprHash = do
   usages <- first UsageErr (findUsages project exprHash)
   storeExpr <- first UsageErr (getStoreExpression project exprHash)

--- a/src/Language/Mimsa/Repl.hs
+++ b/src/Language/Mimsa/Repl.hs
@@ -8,10 +8,12 @@ where
 
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except
+import qualified Data.Aeson as JSON
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Language.Mimsa.Parser as P
+import Language.Mimsa.Printer
 import Language.Mimsa.Project
   ( defaultProject,
     loadProject,
@@ -32,7 +34,15 @@ repl = do
   _ <- doReplAction env Help
   runInputT defaultSettings (loop env)
   where
-    loop :: Project ann -> InputT IO ()
+    loop ::
+      ( Ord ann,
+        Printer ann,
+        Monoid ann,
+        Show ann,
+        JSON.ToJSON ann
+      ) =>
+      Project ann ->
+      InputT IO ()
     loop exprs' = do
       minput <- getInputLine ":> "
       case minput of
@@ -42,7 +52,11 @@ repl = do
           newEnv <- liftIO $ parseCommand exprs' (T.pack input)
           loop newEnv
 
-parseCommand :: Project ann -> Text -> IO (Project ann)
+parseCommand ::
+  (Ord ann, Monoid ann, Show ann, JSON.ToJSON ann, Printer ann) =>
+  Project ann ->
+  Text ->
+  IO (Project ann)
 parseCommand env input =
   case P.runParserComplete replParser input of
     Left e -> do

--- a/src/Language/Mimsa/Repl.hs
+++ b/src/Language/Mimsa/Repl.hs
@@ -32,7 +32,7 @@ repl = do
   _ <- doReplAction env Help
   runInputT defaultSettings (loop env)
   where
-    loop :: Project -> InputT IO ()
+    loop :: Project ann -> InputT IO ()
     loop exprs' = do
       minput <- getInputLine ":> "
       case minput of
@@ -42,7 +42,7 @@ repl = do
           newEnv <- liftIO $ parseCommand exprs' (T.pack input)
           loop newEnv
 
-parseCommand :: Project -> Text -> IO Project
+parseCommand :: Project ann -> Text -> IO (Project ann)
 parseCommand env input =
   case P.runParserComplete replParser input of
     Left e -> do

--- a/src/Language/Mimsa/Repl/ExpressionBind.hs
+++ b/src/Language/Mimsa/Repl/ExpressionBind.hs
@@ -19,7 +19,7 @@ doBind ::
   (Eq ann, Monoid ann, JSON.ToJSON ann) =>
   Project ann ->
   Name ->
-  Expr ann Name ->
+  Expr Name ann ->
   ReplM ann (Project ann)
 doBind env name expr = do
   (ResolvedExpression type' storeExpr _ _ _) <- liftRepl $ getTypecheckedStoreExpression env expr

--- a/src/Language/Mimsa/Repl/ExpressionBind.hs
+++ b/src/Language/Mimsa/Repl/ExpressionBind.hs
@@ -8,13 +8,19 @@ module Language.Mimsa.Repl.ExpressionBind
 where
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
+import qualified Data.Aeson as JSON
 import Language.Mimsa.Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Repl.Types
 import Language.Mimsa.Store (saveExpr)
 import Language.Mimsa.Types
 
-doBind :: Project -> Name -> Expr Name -> ReplM Project
+doBind ::
+  (Eq ann, Monoid ann, JSON.ToJSON ann) =>
+  Project ann ->
+  Name ->
+  Expr ann Name ->
+  ReplM ann (Project ann)
 doBind env name expr = do
   (ResolvedExpression type' storeExpr _ _ _) <- liftRepl $ getTypecheckedStoreExpression env expr
   replPrint $
@@ -23,15 +29,23 @@ doBind env name expr = do
       <> prettyPrint type'
   bindStoreExpression env storeExpr name
 
-doBindType :: Project -> DataType -> ReplM Project
+doBindType ::
+  (Eq ann, Monoid ann, JSON.ToJSON ann) =>
+  Project ann ->
+  DataType ->
+  ReplM ann (Project ann)
 doBindType env dt = do
-  let expr = MyData dt (MyRecord mempty)
+  let expr = MyData mempty dt (MyRecord mempty mempty)
   (ResolvedExpression _ storeExpr _ _ _) <- liftRepl $ getTypecheckedStoreExpression env expr
   replPrint $
     "Bound type " <> prettyPrint dt
   bindTypeExpression env storeExpr
 
-bindTypeExpression :: (MonadIO m) => Project -> StoreExpression -> m Project
+bindTypeExpression ::
+  (MonadIO m, JSON.ToJSON ann) =>
+  Project ann ->
+  StoreExpression ann ->
+  m (Project ann)
 bindTypeExpression env storeExpr = do
   hash <- liftIO (saveExpr storeExpr)
   let newEnv = fromType storeExpr hash
@@ -39,11 +53,11 @@ bindTypeExpression env storeExpr = do
 
 -- save an expression in the store and bind it to name
 bindStoreExpression ::
-  (MonadIO m) =>
-  Project ->
-  StoreExpression ->
+  (MonadIO m, JSON.ToJSON ann) =>
+  Project ann ->
+  StoreExpression ann ->
   Name ->
-  m Project
+  m (Project ann)
 bindStoreExpression env storeExpr name = do
   hash <- liftIO (saveExpr storeExpr)
   let newEnv = fromItem name storeExpr hash

--- a/src/Language/Mimsa/Repl/ExpressionWatch.hs
+++ b/src/Language/Mimsa/Repl/ExpressionWatch.hs
@@ -6,6 +6,7 @@ module Language.Mimsa.Repl.ExpressionWatch
 where
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
+import qualified Data.Aeson as JSON
 import Data.Bifunctor (first)
 import Data.IORef
 import qualified Data.Text as T
@@ -24,7 +25,7 @@ import Language.Mimsa.Types
 scratchFilename :: String
 scratchFilename = "scratch.mimsa"
 
-writeExpression :: (MonadIO m) => Project -> Name -> m ()
+writeExpression :: (MonadIO m) => Project ann -> Name -> m ()
 writeExpression env name =
   case findStoreExpressionByName env name of
     Just storeExpr ->
@@ -34,7 +35,11 @@ writeExpression env name =
           (prettyPrint (storeExpression storeExpr))
     Nothing -> pure ()
 
-doWatch :: Project -> Name -> ReplM Project
+doWatch ::
+  (Eq ann, Monoid ann, Show ann, JSON.ToJSON ann) =>
+  Project ann ->
+  Name ->
+  ReplM ann (Project ann)
 doWatch env name = do
   writeExpression env name
   ioEnv <- liftIO $ newIORef env
@@ -51,7 +56,11 @@ doWatch env name = do
         )
   liftIO $ readIORef ioEnv
 
-onFileChange :: Project -> Name -> ReplM Project
+onFileChange ::
+  (Eq ann, Monoid ann, JSON.ToJSON ann) =>
+  Project ann ->
+  Name ->
+  ReplM ann (Project ann)
 onFileChange env name = do
   text <-
     liftIO $ T.readFile $ "./" <> scratchFilename

--- a/src/Language/Mimsa/Repl/ExpressionWatch.hs
+++ b/src/Language/Mimsa/Repl/ExpressionWatch.hs
@@ -36,7 +36,12 @@ writeExpression env name =
     Nothing -> pure ()
 
 doWatch ::
-  (Eq ann, Monoid ann, Show ann, JSON.ToJSON ann) =>
+  ( Eq ann,
+    Monoid ann,
+    Show ann,
+    Printer ann,
+    JSON.ToJSON ann
+  ) =>
   Project ann ->
   Name ->
   ReplM ann (Project ann)

--- a/src/Language/Mimsa/Repl/Parser.hs
+++ b/src/Language/Mimsa/Repl/Parser.hs
@@ -9,7 +9,9 @@ import Control.Applicative ((<|>))
 import Language.Mimsa.Parser
 import Language.Mimsa.Repl.Types
 
-replParser :: Parser ReplAction
+type ReplAction' = ReplAction ()
+
+replParser :: Parser ReplAction'
 replParser =
   helpParser
     <|> infoParser
@@ -27,52 +29,52 @@ replParser =
 failer :: Parser a
 failer = parseFail (\input -> "Could not parse expression for >>>" <> input <> "<<<")
 
-helpParser :: Parser ReplAction
+helpParser :: Parser ReplAction'
 helpParser = Help <$ literal ":help"
 
-infoParser :: Parser ReplAction
+infoParser :: Parser ReplAction'
 infoParser =
   Info
     <$> right
       (thenSpace (literal ":info"))
       expressionParser
 
-evalParser :: Parser ReplAction
+evalParser :: Parser ReplAction'
 evalParser =
   Evaluate
     <$> expressionParser
 
-treeParser :: Parser ReplAction
+treeParser :: Parser ReplAction'
 treeParser = Tree <$> right (thenSpace (literal ":tree")) expressionParser
 
-bindParser :: Parser ReplAction
+bindParser :: Parser ReplAction'
 bindParser =
   Bind
     <$> right (thenSpace (literal ":bind")) (thenSpace nameParser)
     <*> right (thenSpace (literal "=")) expressionParser
 
-bindTypeParser :: Parser ReplAction
+bindTypeParser :: Parser ReplAction'
 bindTypeParser = do
   _ <- thenSpace (literal ":bindType")
   BindType <$> typeDeclParser
 
-listBindingsParser :: Parser ReplAction
+listBindingsParser :: Parser ReplAction'
 listBindingsParser = ListBindings <$ literal ":list"
 
-watchParser :: Parser ReplAction
+watchParser :: Parser ReplAction'
 watchParser = do
   _ <- thenSpace (literal ":watch")
   Watch <$> nameParser
 
-tuiParser :: Parser ReplAction
+tuiParser :: Parser ReplAction'
 tuiParser = Tui <$ literal ":tui"
 
-versionsParser :: Parser ReplAction
+versionsParser :: Parser ReplAction'
 versionsParser = do
   _ <- thenSpace (literal ":versions")
   Versions <$> nameParser
 
-outputJSParser :: Parser ReplAction
+outputJSParser :: Parser ReplAction'
 outputJSParser = do
   _ <- thenSpace (literal ":outputJS")
   OutputJS <$> expressionParser

--- a/src/Language/Mimsa/Repl/Parser.hs
+++ b/src/Language/Mimsa/Repl/Parser.hs
@@ -9,9 +9,7 @@ import Control.Applicative ((<|>))
 import Language.Mimsa.Parser
 import Language.Mimsa.Repl.Types
 
-type ReplAction' = ReplAction ()
-
-replParser :: Parser ReplAction'
+replParser :: (Monoid ann) => Parser (ReplAction ann)
 replParser =
   helpParser
     <|> infoParser
@@ -29,52 +27,52 @@ replParser =
 failer :: Parser a
 failer = parseFail (\input -> "Could not parse expression for >>>" <> input <> "<<<")
 
-helpParser :: Parser ReplAction'
+helpParser :: Parser (ReplAction ann)
 helpParser = Help <$ literal ":help"
 
-infoParser :: Parser ReplAction'
+infoParser :: (Monoid ann) => Parser (ReplAction ann)
 infoParser =
   Info
     <$> right
       (thenSpace (literal ":info"))
       expressionParser
 
-evalParser :: Parser ReplAction'
+evalParser :: (Monoid ann) => Parser (ReplAction ann)
 evalParser =
   Evaluate
     <$> expressionParser
 
-treeParser :: Parser ReplAction'
+treeParser :: (Monoid ann) => Parser (ReplAction ann)
 treeParser = Tree <$> right (thenSpace (literal ":tree")) expressionParser
 
-bindParser :: Parser ReplAction'
+bindParser :: (Monoid ann) => Parser (ReplAction ann)
 bindParser =
   Bind
     <$> right (thenSpace (literal ":bind")) (thenSpace nameParser)
     <*> right (thenSpace (literal "=")) expressionParser
 
-bindTypeParser :: Parser ReplAction'
+bindTypeParser :: Parser (ReplAction ann)
 bindTypeParser = do
   _ <- thenSpace (literal ":bindType")
   BindType <$> typeDeclParser
 
-listBindingsParser :: Parser ReplAction'
+listBindingsParser :: Parser (ReplAction ann)
 listBindingsParser = ListBindings <$ literal ":list"
 
-watchParser :: Parser ReplAction'
+watchParser :: Parser (ReplAction ann)
 watchParser = do
   _ <- thenSpace (literal ":watch")
   Watch <$> nameParser
 
-tuiParser :: Parser ReplAction'
+tuiParser :: Parser (ReplAction ann)
 tuiParser = Tui <$ literal ":tui"
 
-versionsParser :: Parser ReplAction'
+versionsParser :: Parser (ReplAction ann)
 versionsParser = do
   _ <- thenSpace (literal ":versions")
   Versions <$> nameParser
 
-outputJSParser :: Parser ReplAction'
+outputJSParser :: (Monoid ann) => Parser (ReplAction ann)
 outputJSParser = do
   _ <- thenSpace (literal ":outputJS")
   OutputJS <$> expressionParser

--- a/src/Language/Mimsa/Repl/Types.hs
+++ b/src/Language/Mimsa/Repl/Types.hs
@@ -9,7 +9,7 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 
-type ReplM a = ExceptT (Error a) IO
+type ReplM ann = ExceptT (Error ann) IO
 
 runReplM :: (Printer ann, Show ann) => ReplM ann a -> IO (Maybe a)
 runReplM computation = do

--- a/src/Language/Mimsa/Repl/Types.hs
+++ b/src/Language/Mimsa/Repl/Types.hs
@@ -11,7 +11,7 @@ import Language.Mimsa.Types.Identifiers
 
 type ReplM a = ExceptT (Error a) IO
 
-runReplM :: (Show ann) => ReplM ann a -> IO (Maybe a)
+runReplM :: (Printer ann, Show ann) => ReplM ann a -> IO (Maybe a)
 runReplM computation = do
   either' <- runExceptT computation
   case either' of

--- a/src/Language/Mimsa/Repl/Types.hs
+++ b/src/Language/Mimsa/Repl/Types.hs
@@ -27,13 +27,13 @@ liftRepl :: Either (Error ann) a -> ReplM ann a
 liftRepl (Right a) = pure a
 liftRepl (Left e) = throwError e
 
-data ReplAction a
+data ReplAction ann
   = Help
-  | Info (Expr a Name)
-  | Evaluate (Expr a Name)
-  | Tree (Expr a Name)
-  | Bind Name (Expr a Name)
-  | OutputJS (Expr a Name)
+  | Info (Expr Name ann)
+  | Evaluate (Expr Name ann)
+  | Tree (Expr Name ann)
+  | Bind Name (Expr Name ann)
+  | OutputJS (Expr Name ann)
   | BindType DataType
   | Versions Name
   | ListBindings

--- a/src/Language/Mimsa/Repl/Types.hs
+++ b/src/Language/Mimsa/Repl/Types.hs
@@ -9,9 +9,9 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 
-type ReplM = ExceptT Error IO
+type ReplM a = ExceptT (Error a) IO
 
-runReplM :: ReplM a -> IO (Maybe a)
+runReplM :: (Show ann) => ReplM ann a -> IO (Maybe a)
 runReplM computation = do
   either' <- runExceptT computation
   case either' of
@@ -20,20 +20,20 @@ runReplM computation = do
       T.putStrLn (prettyPrint a)
       pure Nothing
 
-replPrint :: (Printer a) => a -> ReplM ()
+replPrint :: (Printer a) => a -> ReplM ann ()
 replPrint a = liftIO $ T.putStrLn (prettyPrint a)
 
-liftRepl :: Either Error a -> ReplM a
+liftRepl :: Either (Error ann) a -> ReplM ann a
 liftRepl (Right a) = pure a
 liftRepl (Left e) = throwError e
 
-data ReplAction
+data ReplAction a
   = Help
-  | Info (Expr Name)
-  | Evaluate (Expr Name)
-  | Tree (Expr Name)
-  | Bind Name (Expr Name)
-  | OutputJS (Expr Name)
+  | Info (Expr a Name)
+  | Evaluate (Expr a Name)
+  | Tree (Expr a Name)
+  | Bind Name (Expr a Name)
+  | OutputJS (Expr a Name)
   | BindType DataType
   | Versions Name
   | ListBindings

--- a/src/Language/Mimsa/Store/DepGraph.hs
+++ b/src/Language/Mimsa/Store/DepGraph.hs
@@ -2,6 +2,7 @@
 
 module Language.Mimsa.Store.DepGraph where
 
+import qualified Data.Aeson as JSON
 import Data.Map ((!))
 import qualified Data.Map as M
 import Data.Text (Text)
@@ -46,7 +47,7 @@ showFuncLine i info children = spaces <> prettyPrint info <> children'
                 <$> (a : as)
             )
 
-createDepGraph :: Name -> Store -> StoreExpression -> DepGraph
+createDepGraph :: (JSON.ToJSON ann) => Name -> Store ann -> StoreExpression ann -> DepGraph
 createDepGraph name (Store store') storeExpr' = Func depInfo leaves
   where
     depInfo = DepInfo (name, getStoreExpressionHash storeExpr')

--- a/src/Language/Mimsa/Store/ExtractTypes.hs
+++ b/src/Language/Mimsa/Store/ExtractTypes.hs
@@ -18,10 +18,10 @@ import Language.Mimsa.Types.Identifiers (Name, TyCon, TypeName (ConsName, VarNam
 
 -- this works out which external types have been used in a given expression
 -- therefore, we must remove any which are declared in the expression itself
-extractTypes :: Expr a Name -> Set TyCon
+extractTypes :: Expr Name ann -> Set TyCon
 extractTypes = filterBuiltIns . extractTypes_
 
-extractTypes_ :: Expr a Name -> Set TyCon
+extractTypes_ :: Expr Name ann -> Set TyCon
 extractTypes_ (MyVar _ _) = mempty
 extractTypes_ (MyIf _ a b c) = extractTypes_ a <> extractTypes_ b <> extractTypes_ c
 extractTypes_ (MyLet _ _ a b) = extractTypes_ a <> extractTypes_ b
@@ -64,13 +64,13 @@ extractLocalTypeDeclarations (DataType cName _ cons) =
 
 -----------
 
-extractTypeDecl :: Expr a var -> Set TyCon
+extractTypeDecl :: Expr var ann -> Set TyCon
 extractTypeDecl = withDataTypes extractLocalTypeDeclarations
 
-extractDataTypes :: Expr a var -> Set DataType
+extractDataTypes :: Expr var ann -> Set DataType
 extractDataTypes = withDataTypes S.singleton
 
-withDataTypes :: (Monoid b) => (DataType -> b) -> Expr a var -> b
+withDataTypes :: (Monoid b) => (DataType -> b) -> Expr var ann -> b
 withDataTypes _ (MyVar _ _) = mempty
 withDataTypes f (MyIf _ a b c) = withDataTypes f a <> withDataTypes f b <> withDataTypes f c
 withDataTypes f (MyLet _ _ a b) = withDataTypes f a <> withDataTypes f b

--- a/src/Language/Mimsa/Store/ExtractTypes.hs
+++ b/src/Language/Mimsa/Store/ExtractTypes.hs
@@ -10,37 +10,36 @@ import qualified Data.Map as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Language.Mimsa.Typechecker.DataTypes (builtInTypes)
-import Language.Mimsa.Types.AST (DataType (DataType), Expr (..))
-import Language.Mimsa.Types.Identifiers
-  ( Name,
-    TyCon,
-    TypeName (ConsName, VarName),
+import Language.Mimsa.Types.AST
+  ( DataType (DataType),
+    Expr (..),
   )
+import Language.Mimsa.Types.Identifiers (Name, TyCon, TypeName (ConsName, VarName))
 
 -- this works out which external types have been used in a given expression
 -- therefore, we must remove any which are declared in the expression itself
-extractTypes :: Expr Name -> Set TyCon
+extractTypes :: Expr a Name -> Set TyCon
 extractTypes = filterBuiltIns . extractTypes_
 
-extractTypes_ :: Expr Name -> Set TyCon
-extractTypes_ (MyVar _) = mempty
-extractTypes_ (MyIf a b c) = extractTypes_ a <> extractTypes_ b <> extractTypes_ c
-extractTypes_ (MyLet _ a b) = extractTypes_ a <> extractTypes_ b
-extractTypes_ (MyLambda _ a) = extractTypes_ a
-extractTypes_ (MyApp a b) = extractTypes_ a <> extractTypes_ b
-extractTypes_ (MyLiteral _) = mempty
-extractTypes_ (MyLetPair _ _ a b) =
+extractTypes_ :: Expr a Name -> Set TyCon
+extractTypes_ (MyVar _ _) = mempty
+extractTypes_ (MyIf _ a b c) = extractTypes_ a <> extractTypes_ b <> extractTypes_ c
+extractTypes_ (MyLet _ _ a b) = extractTypes_ a <> extractTypes_ b
+extractTypes_ (MyLambda _ _ a) = extractTypes_ a
+extractTypes_ (MyApp _ a b) = extractTypes_ a <> extractTypes_ b
+extractTypes_ (MyLiteral _ _) = mempty
+extractTypes_ (MyLetPair _ _ _ a b) =
   extractTypes_ a <> extractTypes_ b
-extractTypes_ (MyPair a b) = extractTypes_ a <> extractTypes_ b
-extractTypes_ (MyRecord map') = foldMap extractTypes_ map'
-extractTypes_ (MyRecordAccess a _) = extractTypes_ a
-extractTypes_ (MyData dt a) =
+extractTypes_ (MyPair _ a b) = extractTypes_ a <> extractTypes_ b
+extractTypes_ (MyRecord _ map') = foldMap extractTypes_ map'
+extractTypes_ (MyRecordAccess _ a _) = extractTypes_ a
+extractTypes_ (MyData _ dt a) =
   S.difference
     (extractConstructors dt <> extractTypes_ a)
     (extractLocalTypeDeclarations dt)
-extractTypes_ (MyConstructor t) = S.singleton t
-extractTypes_ (MyConsApp a b) = extractTypes_ a <> extractTypes_ b
-extractTypes_ (MyCaseMatch sum' matches catchAll) =
+extractTypes_ (MyConstructor _ t) = S.singleton t
+extractTypes_ (MyConsApp _ a b) = extractTypes_ a <> extractTypes_ b
+extractTypes_ (MyCaseMatch _ sum' matches catchAll) =
   extractTypes_ sum'
     <> mconcat (extractTypes_ . snd <$> NE.toList matches)
     <> mconcat (S.singleton . fst <$> NE.toList matches)
@@ -65,30 +64,30 @@ extractLocalTypeDeclarations (DataType cName _ cons) =
 
 -----------
 
-extractTypeDecl :: Expr a -> Set TyCon
+extractTypeDecl :: Expr a var -> Set TyCon
 extractTypeDecl = withDataTypes extractLocalTypeDeclarations
 
-extractDataTypes :: Expr a -> Set DataType
+extractDataTypes :: Expr a var -> Set DataType
 extractDataTypes = withDataTypes S.singleton
 
-withDataTypes :: (Monoid b) => (DataType -> b) -> Expr a -> b
-withDataTypes _ (MyVar _) = mempty
-withDataTypes f (MyIf a b c) = withDataTypes f a <> withDataTypes f b <> withDataTypes f c
-withDataTypes f (MyLet _ a b) = withDataTypes f a <> withDataTypes f b
-withDataTypes f (MyLambda _ a) = withDataTypes f a
-withDataTypes f (MyApp a b) = withDataTypes f a <> withDataTypes f b
-withDataTypes _ (MyLiteral _) = mempty
-withDataTypes f (MyLetPair _ _ a b) =
+withDataTypes :: (Monoid b) => (DataType -> b) -> Expr a var -> b
+withDataTypes _ (MyVar _ _) = mempty
+withDataTypes f (MyIf _ a b c) = withDataTypes f a <> withDataTypes f b <> withDataTypes f c
+withDataTypes f (MyLet _ _ a b) = withDataTypes f a <> withDataTypes f b
+withDataTypes f (MyLambda _ _ a) = withDataTypes f a
+withDataTypes f (MyApp _ a b) = withDataTypes f a <> withDataTypes f b
+withDataTypes _ (MyLiteral _ _) = mempty
+withDataTypes f (MyLetPair _ _ _ a b) =
   withDataTypes f a <> withDataTypes f b
-withDataTypes f (MyPair a b) = withDataTypes f a <> withDataTypes f b
-withDataTypes f (MyRecord map') = foldMap (withDataTypes f) map'
-withDataTypes f (MyRecordAccess a _) = withDataTypes f a
-withDataTypes f (MyData dt a) =
+withDataTypes f (MyPair _ a b) = withDataTypes f a <> withDataTypes f b
+withDataTypes f (MyRecord _ map') = foldMap (withDataTypes f) map'
+withDataTypes f (MyRecordAccess _ a _) = withDataTypes f a
+withDataTypes f (MyData _ dt a) =
   withDataTypes f a
     <> f dt
-withDataTypes _ (MyConstructor _) = mempty
-withDataTypes f (MyConsApp a b) = withDataTypes f a <> withDataTypes f b
-withDataTypes f (MyCaseMatch sum' matches catchAll) =
+withDataTypes _ (MyConstructor _ _) = mempty
+withDataTypes f (MyConsApp _ a b) = withDataTypes f a <> withDataTypes f b
+withDataTypes f (MyCaseMatch _ sum' matches catchAll) =
   withDataTypes f sum'
     <> mconcat (withDataTypes f . snd <$> NE.toList matches)
     <> maybe mempty (withDataTypes f) catchAll

--- a/src/Language/Mimsa/Store/ExtractVars.hs
+++ b/src/Language/Mimsa/Store/ExtractVars.hs
@@ -12,27 +12,27 @@ import Language.Mimsa.Types
 -- important - we must not count variables brought in via lambdas, as those
 -- aren't external deps
 
-extractVars :: Expr Name -> Set Name
+extractVars :: Expr ann Name -> Set Name
 extractVars = filterBuiltIns . extractVars_
 
-extractVars_ :: Expr Name -> Set Name
-extractVars_ (MyVar a) = S.singleton a
-extractVars_ (MyIf a b c) = extractVars_ a <> extractVars_ b <> extractVars_ c
-extractVars_ (MyLet newVar a b) = S.delete newVar (extractVars_ a <> extractVars_ b)
-extractVars_ (MyLambda newVar a) = S.delete newVar (extractVars_ a)
-extractVars_ (MyApp a b) = extractVars_ a <> extractVars_ b
-extractVars_ (MyLiteral _) = mempty
-extractVars_ (MyLetPair newVarA newVarB a b) =
+extractVars_ :: Expr ann Name -> Set Name
+extractVars_ (MyVar _ a) = S.singleton a
+extractVars_ (MyIf _ a b c) = extractVars_ a <> extractVars_ b <> extractVars_ c
+extractVars_ (MyLet _ newVar a b) = S.delete newVar (extractVars_ a <> extractVars_ b)
+extractVars_ (MyLambda _ newVar a) = S.delete newVar (extractVars_ a)
+extractVars_ (MyApp _ a b) = extractVars_ a <> extractVars_ b
+extractVars_ (MyLiteral _ _) = mempty
+extractVars_ (MyLetPair _ newVarA newVarB a b) =
   S.delete
     newVarA
     (S.delete newVarB (extractVars_ a <> extractVars_ b))
-extractVars_ (MyPair a b) = extractVars_ a <> extractVars_ b
-extractVars_ (MyRecord map') = foldMap extractVars_ map'
-extractVars_ (MyRecordAccess a _) = extractVars_ a
-extractVars_ (MyData _ a) = extractVars_ a
-extractVars_ (MyConstructor _) = mempty
-extractVars_ (MyConsApp a b) = extractVars_ a <> extractVars_ b
-extractVars_ (MyCaseMatch sum' matches catchAll) =
+extractVars_ (MyPair _ a b) = extractVars_ a <> extractVars_ b
+extractVars_ (MyRecord _ map') = foldMap extractVars_ map'
+extractVars_ (MyRecordAccess _ a _) = extractVars_ a
+extractVars_ (MyData _ _ a) = extractVars_ a
+extractVars_ (MyConstructor _ _) = mempty
+extractVars_ (MyConsApp _ a b) = extractVars_ a <> extractVars_ b
+extractVars_ (MyCaseMatch _ sum' matches catchAll) =
   extractVars sum'
     <> mconcat (extractVars . snd <$> NE.toList matches)
     <> maybe mempty extractVars catchAll

--- a/src/Language/Mimsa/Store/ExtractVars.hs
+++ b/src/Language/Mimsa/Store/ExtractVars.hs
@@ -16,10 +16,10 @@ import Language.Mimsa.Types
 -- important - we must not count variables brought in via lambdas, as those
 -- aren't external deps
 
-extractVars :: forall ann. (Eq ann, Monoid ann) => Expr ann Name -> Set Name
+extractVars :: forall ann. (Eq ann, Monoid ann) => Expr Name ann -> Set Name
 extractVars = filterBuiltIns @ann . extractVars_
 
-extractVars_ :: (Eq ann, Monoid ann) => Expr ann Name -> Set Name
+extractVars_ :: (Eq ann, Monoid ann) => Expr Name ann -> Set Name
 extractVars_ (MyVar _ a) = S.singleton a
 extractVars_ (MyIf _ a b c) = extractVars_ a <> extractVars_ b <> extractVars_ c
 extractVars_ (MyLet _ newVar a b) = S.delete newVar (extractVars_ a <> extractVars_ b)

--- a/src/Language/Mimsa/Store/Resolver.hs
+++ b/src/Language/Mimsa/Store/Resolver.hs
@@ -43,7 +43,7 @@ createStoreExpression ::
   (Eq ann, Monoid ann) =>
   Bindings ->
   TypeBindings ->
-  Expr ann Name ->
+  Expr Name ann ->
   Either ResolverError (StoreExpression ann)
 createStoreExpression bindings' tBindings expr =
   StoreExpression expr <$> findBindings bindings' expr
@@ -52,7 +52,7 @@ createStoreExpression bindings' tBindings expr =
 findBindings ::
   (Eq ann, Monoid ann) =>
   Bindings ->
-  Expr ann Name ->
+  Expr Name ann ->
   Either ResolverError Bindings
 findBindings bindings' expr = do
   let findValueHash name =
@@ -69,7 +69,7 @@ findHashInTypeBindings (TypeBindings bindings') cName =
     Just a -> Right a
     _ -> Left $ MissingType cName (TypeBindings bindings')
 
-findTypeBindings :: TypeBindings -> Expr ann Name -> Either ResolverError TypeBindings
+findTypeBindings :: TypeBindings -> Expr Name ann -> Either ResolverError TypeBindings
 findTypeBindings tBindings expr = do
   let findTypeHash cName =
         (,) cName

--- a/src/Language/Mimsa/Store/Resolver.hs
+++ b/src/Language/Mimsa/Store/Resolver.hs
@@ -42,13 +42,13 @@ findHashInBindings (Bindings bindings') name =
 createStoreExpression ::
   Bindings ->
   TypeBindings ->
-  Expr Name ->
-  Either ResolverError StoreExpression
+  Expr ann Name ->
+  Either ResolverError (StoreExpression ann)
 createStoreExpression bindings' tBindings expr =
   StoreExpression expr <$> findBindings bindings' expr
     <*> findTypeBindings tBindings expr
 
-findBindings :: Bindings -> Expr Name -> Either ResolverError Bindings
+findBindings :: Bindings -> Expr ann Name -> Either ResolverError Bindings
 findBindings bindings' expr = do
   let findValueHash name =
         (,) name
@@ -64,7 +64,7 @@ findHashInTypeBindings (TypeBindings bindings') cName =
     Just a -> Right a
     _ -> Left $ MissingType cName (TypeBindings bindings')
 
-findTypeBindings :: TypeBindings -> Expr Name -> Either ResolverError TypeBindings
+findTypeBindings :: TypeBindings -> Expr ann Name -> Either ResolverError TypeBindings
 findTypeBindings tBindings expr = do
   let findTypeHash cName =
         (,) cName
@@ -73,7 +73,11 @@ findTypeBindings tBindings expr = do
   pure (TypeBindings $ M.fromList hashes)
 
 -- given a data type declaration, create a StoreExpression for it
-createTypeStoreExpression :: TypeBindings -> DataType -> Either ResolverError StoreExpression
+createTypeStoreExpression ::
+  (Monoid ann) =>
+  TypeBindings ->
+  DataType ->
+  Either ResolverError (StoreExpression ann)
 createTypeStoreExpression tBindings dt =
-  let expr = MyData dt (MyRecord mempty)
+  let expr = MyData mempty dt (MyRecord mempty mempty)
    in createStoreExpression mempty tBindings expr

--- a/src/Language/Mimsa/Store/Resolver.hs
+++ b/src/Language/Mimsa/Store/Resolver.hs
@@ -40,6 +40,7 @@ findHashInBindings (Bindings bindings') name =
 -- given an expression, and the current environment, create a
 -- store expression that captures the hashes of the functions we'll need
 createStoreExpression ::
+  (Eq ann, Monoid ann) =>
   Bindings ->
   TypeBindings ->
   Expr ann Name ->
@@ -48,7 +49,11 @@ createStoreExpression bindings' tBindings expr =
   StoreExpression expr <$> findBindings bindings' expr
     <*> findTypeBindings tBindings expr
 
-findBindings :: Bindings -> Expr ann Name -> Either ResolverError Bindings
+findBindings ::
+  (Eq ann, Monoid ann) =>
+  Bindings ->
+  Expr ann Name ->
+  Either ResolverError Bindings
 findBindings bindings' expr = do
   let findValueHash name =
         (,) name
@@ -74,7 +79,7 @@ findTypeBindings tBindings expr = do
 
 -- given a data type declaration, create a StoreExpression for it
 createTypeStoreExpression ::
-  (Monoid ann) =>
+  (Eq ann, Monoid ann) =>
   TypeBindings ->
   DataType ->
   Either ResolverError (StoreExpression ann)

--- a/src/Language/Mimsa/Store/Substitutor.hs
+++ b/src/Language/Mimsa/Store/Substitutor.hs
@@ -50,7 +50,7 @@ doSubstitutions ::
   (Monoid ann, Eq ann) =>
   Store ann ->
   StoreExpression ann ->
-  App ann (Expr ann Variable)
+  App ann (Expr Variable ann)
 doSubstitutions store' (StoreExpression expr bindings' tBindings) = do
   newScopes <- traverse (substituteWithKey store') (getExprPairs store' bindings')
   addScope $ mconcat newScopes

--- a/src/Language/Mimsa/Store/Substitutor.hs
+++ b/src/Language/Mimsa/Store/Substitutor.hs
@@ -17,16 +17,20 @@ import Language.Mimsa.Types
 --
 -- we'll also store what our substitutions were for errors sake
 
-data SubsState
+data SubsState ann
   = SubsState
       { subsSwaps :: Swaps,
-        subsScope :: Scope,
+        subsScope :: Scope ann,
         subsCounter :: Int
       }
 
-type App = State SubsState
+type App ann = State (SubsState ann)
 
-substitute :: Store -> StoreExpression -> SubstitutedExpression
+substitute ::
+  (Eq ann, Monoid ann) =>
+  Store ann ->
+  StoreExpression ann ->
+  SubstitutedExpression ann
 substitute store' storeExpr =
   let startingState = SubsState mempty mempty 0
       (expr', SubsState swaps' scope' _) =
@@ -39,7 +43,11 @@ substitute store' storeExpr =
         scope'
 
 -- get the list of deps for this expression, turn from hashes to StoreExprs
-doSubstitutions :: Store -> StoreExpression -> App (Expr Variable)
+doSubstitutions ::
+  (Monoid ann, Eq ann) =>
+  Store ann ->
+  StoreExpression ann ->
+  App ann (Expr ann Variable)
 doSubstitutions store' (StoreExpression expr bindings' tBindings) = do
   newScopes <- traverse (substituteWithKey store') (getExprPairs store' bindings')
   addScope $ mconcat newScopes
@@ -50,30 +58,34 @@ doSubstitutions store' (StoreExpression expr bindings' tBindings) = do
 ------------ type stuff
 
 -- why doesn't this exist already
-lookupStoreItem :: Store -> ExprHash -> Maybe StoreExpression
+lookupStoreItem :: Store ann -> ExprHash -> Maybe (StoreExpression ann)
 lookupStoreItem (Store s') hash' = M.lookup hash' s'
 
 -- find all types needed by our expression in the store
-resolveTypes :: Store -> TypeBindings -> App [StoreExpression]
+resolveTypes :: Store ann -> TypeBindings -> App ann [StoreExpression ann]
 resolveTypes store' (TypeBindings tBindings) =
   let typeLookup (_, hash) = case lookupStoreItem store' hash of
         Just sExpr -> pure [sExpr]
         _ -> pure mempty
    in mconcat <$> traverse typeLookup (M.toList tBindings)
 
-toDataTypeList :: [StoreExpression] -> [DataType]
+toDataTypeList :: [StoreExpression ann] -> [DataType]
 toDataTypeList sExprs =
   let getDts sExpr = extractDataTypes (storeExpression sExpr)
    in S.toList . mconcat $ (getDts <$> sExprs)
 
 -- add required type declarations into our Expr
-addDataTypesToExpr :: Expr a -> [DataType] -> Expr a
+addDataTypesToExpr :: (Monoid ann) => Expr ann a -> [DataType] -> Expr ann a
 addDataTypesToExpr =
-  foldr MyData
+  foldr (MyData mempty)
 
 --------------
 
-substituteWithKey :: Store -> (Name, StoreExpression) -> App Scope
+substituteWithKey ::
+  (Eq ann, Monoid ann) =>
+  Store ann ->
+  (Name, StoreExpression ann) ->
+  App ann (Scope ann)
 substituteWithKey store' (key, storeExpr') = do
   expr' <- doSubstitutions store' storeExpr'
   maybeKey <- scopeExists expr'
@@ -84,16 +96,16 @@ substituteWithKey store' (key, storeExpr') = do
 
 -- if the expression we're already saving is in the scope
 -- that's the name we want to use
-scopeExists :: Expr Variable -> App (Maybe Variable)
+scopeExists :: (Eq ann) => Expr ann Variable -> App ann (Maybe Variable)
 scopeExists var = do
   (Scope scope') <- gets subsScope
   pure (mapKeyFind (var ==) scope')
 
-addScope :: Scope -> App ()
+addScope :: Scope ann -> App ann ()
 addScope scope' =
   modify (\s -> s {subsScope = subsScope s <> scope'})
 
-addSwap :: Name -> Variable -> App ()
+addSwap :: Name -> Variable -> App ann ()
 addSwap old new =
   modify (\s -> s {subsSwaps = subsSwaps s <> M.singleton new old})
 
@@ -103,12 +115,12 @@ mapKeyFind pred' map' = case M.toList (M.filter pred' map') of
   ((k, _) : _) -> pure k
 
 -- if we've already made up a name for this var, return that
-findInSwaps :: Name -> App (Maybe Variable)
+findInSwaps :: Name -> App ann (Maybe Variable)
 findInSwaps name = do
   swaps' <- gets subsSwaps
   pure (mapKeyFind (name ==) swaps')
 
-getExprPairs :: Store -> Bindings -> [(Name, StoreExpression)]
+getExprPairs :: Store ann -> Bindings -> [(Name, StoreExpression ann)]
 getExprPairs (Store items') (Bindings bindings') = join $ do
   (name, hash) <- M.toList bindings'
   case M.lookup hash items' of
@@ -119,7 +131,7 @@ getExprPairs (Store items') (Bindings bindings') = join $ do
 -- Swaps list
 -- we don't do this for built-ins (ie, randomInt) or variables introduced by
 -- lambdas
-getNextVar :: [Name] -> Name -> App Variable
+getNextVar :: [Name] -> Name -> App ann Variable
 getNextVar protected name
   | name `elem` protected = pure (NamedVar name)
   | isLibraryName name = pure (BuiltIn name)
@@ -132,7 +144,7 @@ getNextVar protected name
         addSwap name nextName
         pure nextName
 
-nextNum :: App Int
+nextNum :: App ann Int
 nextNum = do
   p <- gets subsCounter
   modify (\s -> s {subsCounter = p + 1})
@@ -142,35 +154,35 @@ nameToVar :: (Monad m) => Name -> m Variable
 nameToVar = pure . NamedVar
 
 -- step through Expr, replacing vars with numbered variables
-mapVar :: [Name] -> Expr Name -> App (Expr Variable)
-mapVar p (MyVar a) =
-  MyVar <$> getNextVar p a
-mapVar p (MyLet name a b) =
-  MyLet <$> nameToVar name <*> mapVar p a
+mapVar :: [Name] -> Expr ann Name -> App ann (Expr ann Variable)
+mapVar p (MyVar ann a) =
+  MyVar ann <$> getNextVar p a
+mapVar p (MyLet ann name a b) =
+  MyLet ann <$> nameToVar name <*> mapVar p a
     <*> mapVar (p <> [name]) b
-mapVar p (MyLambda name a) =
-  MyLambda <$> nameToVar name <*> mapVar (p <> [name]) a
-mapVar p (MyRecordAccess a name) =
-  MyRecordAccess
+mapVar p (MyLambda ann name a) =
+  MyLambda ann <$> nameToVar name <*> mapVar (p <> [name]) a
+mapVar p (MyRecordAccess ann a name) =
+  MyRecordAccess ann
     <$> mapVar p a <*> pure name
-mapVar p (MyApp a b) = MyApp <$> mapVar p a <*> mapVar p b
-mapVar p (MyIf a b c) = MyIf <$> mapVar p a <*> mapVar p b <*> mapVar p c
-mapVar p (MyPair a b) = MyPair <$> mapVar p a <*> mapVar p b
-mapVar p (MyLetPair nameA nameB a b) =
-  MyLetPair
+mapVar p (MyApp ann a b) = MyApp ann <$> mapVar p a <*> mapVar p b
+mapVar p (MyIf ann a b c) = MyIf ann <$> mapVar p a <*> mapVar p b <*> mapVar p c
+mapVar p (MyPair ann a b) = MyPair ann <$> mapVar p a <*> mapVar p b
+mapVar p (MyLetPair ann nameA nameB a b) =
+  MyLetPair ann
     <$> nameToVar nameA <*> nameToVar nameB
       <*> mapVar (p <> [nameA, nameB]) a
       <*> mapVar (p <> [nameA, nameB]) b
-mapVar p (MyRecord map') = do
+mapVar p (MyRecord ann map') = do
   map2 <- traverse (mapVar p) map'
-  pure (MyRecord map2)
-mapVar _ (MyLiteral a) = pure (MyLiteral a)
-mapVar p (MyData dt b) =
-  MyData dt <$> mapVar p b
-mapVar _ (MyConstructor name) = pure (MyConstructor name)
-mapVar p (MyConsApp fn var) = MyConsApp <$> mapVar p fn <*> mapVar p var
-mapVar p (MyCaseMatch expr' matches catchAll) = do
+  pure (MyRecord ann map2)
+mapVar _ (MyLiteral ann a) = pure (MyLiteral ann a)
+mapVar p (MyData ann dt b) =
+  MyData ann dt <$> mapVar p b
+mapVar _ (MyConstructor ann name) = pure (MyConstructor ann name)
+mapVar p (MyConsApp ann fn var) = MyConsApp ann <$> mapVar p fn <*> mapVar p var
+mapVar p (MyCaseMatch ann expr' matches catchAll) = do
   let mapVarPair (name, expr'') = (,) name <$> mapVar p expr''
   matches' <- traverse mapVarPair matches
   catchAll' <- traverse (mapVar p) catchAll
-  MyCaseMatch <$> mapVar p expr' <*> pure matches' <*> pure catchAll'
+  MyCaseMatch ann <$> mapVar p expr' <*> pure matches' <*> pure catchAll'

--- a/src/Language/Mimsa/Store/Substitutor.hs
+++ b/src/Language/Mimsa/Store/Substitutor.hs
@@ -78,7 +78,7 @@ toDataTypeList sExprs =
    in S.toList . mconcat $ (getDts <$> sExprs)
 
 -- add required type declarations into our Expr
-addDataTypesToExpr :: (Monoid ann) => Expr ann a -> [DataType] -> Expr ann a
+addDataTypesToExpr :: (Monoid ann) => Expr var ann -> [DataType] -> Expr var ann
 addDataTypesToExpr =
   foldr (MyData mempty)
 
@@ -99,7 +99,7 @@ substituteWithKey store' (key, storeExpr') = do
 
 -- if the expression we're already saving is in the scope
 -- that's the name we want to use
-scopeExists :: (Eq ann) => Expr ann Variable -> App ann (Maybe Variable)
+scopeExists :: (Eq ann) => Expr Variable ann -> App ann (Maybe Variable)
 scopeExists var = do
   (Scope scope') <- gets subsScope
   pure (mapKeyFind (var ==) scope')
@@ -165,8 +165,8 @@ nameToVar = pure . NamedVar
 mapVar ::
   (Eq ann, Monoid ann) =>
   [Name] ->
-  Expr ann Name ->
-  App ann (Expr ann Variable)
+  Expr Name ann ->
+  App ann (Expr Variable ann)
 mapVar p (MyVar ann a) =
   MyVar ann <$> getNextVar p a
 mapVar p (MyLet ann name a b) =

--- a/src/Language/Mimsa/Tui.hs
+++ b/src/Language/Mimsa/Tui.hs
@@ -19,7 +19,7 @@ import Language.Mimsa.Tui.State
 import Language.Mimsa.Tui.Styles
 import Language.Mimsa.Types
 
-drawUI :: TuiState -> [Widget ()]
+drawUI :: (Eq ann, Monoid ann) => TuiState ann -> [Widget ()]
 drawUI tuiState =
   case uiState tuiState of
     TuiError err -> [drawError err]
@@ -28,7 +28,13 @@ drawUI tuiState =
           (BindingsList name deps l) = NE.head items
       pure (drawBindingsList store' name deps l)
 
-drawBindingsList :: Store -> Name -> ResolvedDeps -> L.List () Name -> Widget ()
+drawBindingsList ::
+  (Eq ann, Monoid ann) =>
+  Store ann ->
+  Name ->
+  ResolvedDeps ann ->
+  L.List () Name ->
+  Widget ()
 drawBindingsList store' name deps l = twoColumnLayout "Current scope" left right
   where
     left = C.vCenter $ drawListWithTitle (T.unpack $ prettyPrint name) l
@@ -50,7 +56,7 @@ drawError (MissingStoreItems missing) =
            )
     )
 
-drawExpressionInfo :: ExpressionInfo -> Widget ()
+drawExpressionInfo :: ExpressionInfo ann -> Widget ()
 drawExpressionInfo exprInfo = ui
   where
     label = withAttr "title" . str . T.unpack . prettyPrint . eiName $ exprInfo
@@ -72,7 +78,7 @@ drawExpressionInfo exprInfo = ui
           drawPretty (eiDeps exprInfo)
         ]
 
-theApp :: M.App TuiState e ()
+theApp :: (Eq ann, Monoid ann) => M.App (TuiState ann) e ()
 theApp =
   M.App
     { M.appDraw = drawUI,
@@ -82,7 +88,7 @@ theApp =
       M.appAttrMap = const stylesAttrMap
     }
 
-goTui :: Project -> IO Project
+goTui :: (Eq ann, Monoid ann) => Project ann -> IO (Project ann)
 goTui project' =
   do
     _ <- M.defaultMain theApp (initialState project')

--- a/src/Language/Mimsa/Tui/Evaluate.hs
+++ b/src/Language/Mimsa/Tui/Evaluate.hs
@@ -10,7 +10,7 @@ evaluateStoreExprToInfo ::
   (Eq ann, Monoid ann) =>
   Store ann ->
   StoreExpression ann ->
-  Maybe (MonoType, Expr ann Name)
+  Maybe (MonoType, Expr Name ann)
 evaluateStoreExprToInfo store' storeExpr =
   case resolveStoreExpression store' storeExpr of
     Right (ResolvedExpression mt _ _ _ _) -> Just (mt, storeExpression storeExpr)

--- a/src/Language/Mimsa/Tui/Evaluate.hs
+++ b/src/Language/Mimsa/Tui/Evaluate.hs
@@ -7,9 +7,10 @@ import Language.Mimsa.Store
 import Language.Mimsa.Types
 
 evaluateStoreExprToInfo ::
-  Store ->
-  StoreExpression ->
-  Maybe (MonoType, Expr Name)
+  (Eq ann, Monoid ann) =>
+  Store ann ->
+  StoreExpression ann ->
+  Maybe (MonoType, Expr ann Name)
 evaluateStoreExprToInfo store' storeExpr =
   case resolveStoreExpression store' storeExpr of
     Right (ResolvedExpression mt _ _ _ _) -> Just (mt, storeExpression storeExpr)
@@ -20,10 +21,11 @@ hush (Right a) = Just a
 hush _ = Nothing
 
 getExpressionForBinding ::
-  Store ->
-  ResolvedDeps ->
+  (Eq ann, Monoid ann) =>
+  Store ann ->
+  ResolvedDeps ann ->
   L.List () Name ->
-  Maybe ExpressionInfo
+  Maybe (ExpressionInfo ann)
 getExpressionForBinding store' (ResolvedDeps deps) l = do
   (_, name) <- L.listSelectedElement l
   (_, storeExpr') <- M.lookup name deps

--- a/src/Language/Mimsa/Tui/State.hs
+++ b/src/Language/Mimsa/Tui/State.hs
@@ -21,7 +21,11 @@ import Language.Mimsa.Types
 
 -- we don't want this to do much so binning it in exchange for an Elm style
 -- reducer pattern
-appEvent :: (Eq ann, Monoid ann) => TuiState ann -> BT.BrickEvent () e -> BT.EventM () (BT.Next (TuiState ann))
+appEvent ::
+  (Eq ann, Monoid ann) =>
+  TuiState ann ->
+  BT.BrickEvent () e ->
+  BT.EventM () (BT.Next (TuiState ann))
 appEvent tuiState (BT.VtyEvent e) = do
   let tuiAction = case e of
         V.EvKey V.KEsc [] -> Exit

--- a/src/Language/Mimsa/Tui/State.hs
+++ b/src/Language/Mimsa/Tui/State.hs
@@ -21,7 +21,7 @@ import Language.Mimsa.Types
 
 -- we don't want this to do much so binning it in exchange for an Elm style
 -- reducer pattern
-appEvent :: TuiState -> BT.BrickEvent () e -> BT.EventM () (BT.Next TuiState)
+appEvent :: (Eq ann, Monoid ann) => TuiState ann -> BT.BrickEvent () e -> BT.EventM () (BT.Next (TuiState ann))
 appEvent tuiState (BT.VtyEvent e) = do
   let tuiAction = case e of
         V.EvKey V.KEsc [] -> Exit
@@ -48,7 +48,7 @@ data TuiAction
   | GoDown
   | Unknown
 
-reducer :: Project -> TuiAction -> UIState -> Maybe UIState
+reducer :: (Eq ann, Monoid ann) => Project ann -> TuiAction -> UIState ann -> Maybe (UIState ann)
 reducer _ Exit _ = Nothing
 reducer _ GoUp (ViewBindings items) =
   let mapF (BindingsList n deps l) = BindingsList n deps (L.listMoveUp l)
@@ -80,7 +80,7 @@ mapHead f list = NE.fromList ([hd] <> tl)
 
 -- if all the deps are in place, we start by showing all the bound items
 -- in the project
-initialState :: Project -> TuiState
+initialState :: Project ann -> TuiState ann
 initialState project' =
   TuiState
     { uiState = initialUiState,
@@ -98,7 +98,7 @@ initialState project' =
               )
         Left missing -> TuiError (MissingStoreItems missing)
 
-makeBindingsList :: Name -> ResolvedDeps -> BindingsList
+makeBindingsList :: Name -> ResolvedDeps ann -> BindingsList ann
 makeBindingsList name deps =
   BindingsList name deps (resolvedDepsToList deps 0)
   where

--- a/src/Language/Mimsa/Typechecker/Environment.hs
+++ b/src/Language/Mimsa/Typechecker/Environment.hs
@@ -14,7 +14,7 @@ import Language.Mimsa.Types
 lookupConstructor ::
   Environment ->
   TyCon ->
-  TcMonad DataType
+  TcMonad ann DataType
 lookupConstructor env name =
   case M.toList $ M.filter (containsConstructor name) (getDataTypes env) of
     [(_, a)] -> pure a -- we only want a single match

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -35,7 +35,7 @@ import Language.Mimsa.Types
 startInference ::
   (Eq ann, Monoid ann) =>
   Swaps ->
-  Expr ann Variable ->
+  Expr Variable ann ->
   Either (TypeError ann) MonoType
 startInference swaps expr = snd <$> doInference swaps mempty expr
 
@@ -43,7 +43,7 @@ doInference ::
   (Eq ann, Monoid ann) =>
   Swaps ->
   Environment ->
-  Expr ann Variable ->
+  Expr Variable ann ->
   Either (TypeError ann) (Substitutions, MonoType)
 doInference swaps env expr = runTcMonad swaps (inferAndSubst (defaultEnv <> env) expr)
 
@@ -58,7 +58,7 @@ doDataTypeInference env dt =
 inferAndSubst ::
   (Eq ann, Monoid ann) =>
   Environment ->
-  Expr ann Variable ->
+  Expr Variable ann ->
   TcMonad ann (Substitutions, MonoType)
 inferAndSubst env expr = do
   (s, tyExpr) <- infer env expr
@@ -132,8 +132,8 @@ splitRecordTypes map' = (subs, MTRecord types)
 inferApplication ::
   (Eq ann, Monoid ann) =>
   Environment ->
-  Expr ann Variable ->
-  Expr ann Variable ->
+  Expr Variable ann ->
+  Expr Variable ann ->
   TcMonad ann (Substitutions, MonoType)
 inferApplication env function argument = do
   tyRes <- getUnknown
@@ -159,8 +159,8 @@ inferLetBinding ::
   (Eq ann, Monoid ann) =>
   Environment ->
   Variable ->
-  Expr ann Variable ->
-  Expr ann Variable ->
+  Expr Variable ann ->
+  Expr Variable ann ->
   TcMonad ann (Substitutions, MonoType)
 inferLetBinding env binder expr body = do
   tyUnknown <- getUnknown
@@ -177,8 +177,8 @@ inferLetPairBinding ::
   Environment ->
   Variable ->
   Variable ->
-  Expr ann Variable ->
-  Expr ann Variable ->
+  Expr Variable ann ->
+  Expr Variable ann ->
   TcMonad ann (Substitutions, MonoType)
 inferLetPairBinding env binder1 binder2 expr body = do
   (s1, tyExpr) <- infer env expr
@@ -202,7 +202,7 @@ storeDataDeclaration ::
   (Eq ann, Monoid ann) =>
   Environment ->
   DataType ->
-  Expr ann Variable ->
+  Expr Variable ann ->
   TcMonad ann (Substitutions, MonoType)
 storeDataDeclaration env dt@(DataType tyName _ _) expr' =
   if M.member tyName (getDataTypes env)
@@ -284,7 +284,7 @@ inferSumExpressionType ::
   (Eq ann, Monoid ann) =>
   Environment ->
   Map TyCon TypeConstructor ->
-  Expr ann Variable ->
+  Expr Variable ann ->
   TcMonad ann (Substitutions, MonoType)
 inferSumExpressionType env consTypes sumExpr =
   let fromName name =
@@ -312,9 +312,9 @@ inferSumExpressionType env consTypes sumExpr =
 inferCaseMatch ::
   (Eq ann, Monoid ann) =>
   Environment ->
-  Expr ann Variable ->
-  NonEmpty (TyCon, Expr ann Variable) ->
-  Maybe (Expr ann Variable) ->
+  Expr Variable ann ->
+  NonEmpty (TyCon, Expr Variable ann) ->
+  Maybe (Expr Variable ann) ->
   TcMonad ann (Substitutions, MonoType)
 inferCaseMatch env sumExpr matches catchAll = do
   dataType <- checkCompleteness env matches catchAll
@@ -360,7 +360,7 @@ inferMatch ::
   Environment ->
   Map TyCon TypeConstructor ->
   TyCon ->
-  Expr ann Variable ->
+  Expr Variable ann ->
   TcMonad ann (Substitutions, MonoType)
 inferMatch env constructTypes name expr' =
   case M.lookup name constructTypes of
@@ -389,7 +389,7 @@ applyList vars tyFun = case vars of
 infer ::
   (Eq ann, Monoid ann) =>
   Environment ->
-  Expr ann Variable ->
+  Expr Variable ann ->
   TcMonad ann (Substitutions, MonoType)
 infer env inferExpr =
   case inferExpr of

--- a/src/Language/Mimsa/Typechecker/Patterns.hs
+++ b/src/Language/Mimsa/Typechecker/Patterns.hs
@@ -19,9 +19,9 @@ import Language.Mimsa.Types
 
 checkCompleteness ::
   Environment ->
-  NonEmpty (TyCon, Expr Variable) ->
-  Maybe (Expr Variable) ->
-  TcMonad DataType
+  NonEmpty (TyCon, Expr ann Variable) ->
+  Maybe (Expr ann Variable) ->
+  TcMonad ann DataType
 checkCompleteness env opts catchAll = do
   -- find data type for each match
   items <- traverse (\(name, _) -> lookupConstructor env name) opts
@@ -35,7 +35,7 @@ checkCompleteness env opts catchAll = do
     _ -> allPatternsExist optionNames dataType
   pure dataType
 
-allPatternsExist :: [TyCon] -> DataType -> TcMonad ()
+allPatternsExist :: [TyCon] -> DataType -> TcMonad ann ()
 allPatternsExist optNames' (DataType _ _ dataTypes) = do
   -- check each one of optNames exists in dataTypes
   let dtNames = S.fromList (M.keys dataTypes)

--- a/src/Language/Mimsa/Typechecker/Patterns.hs
+++ b/src/Language/Mimsa/Typechecker/Patterns.hs
@@ -19,8 +19,8 @@ import Language.Mimsa.Types
 
 checkCompleteness ::
   Environment ->
-  NonEmpty (TyCon, Expr ann Variable) ->
-  Maybe (Expr ann Variable) ->
+  NonEmpty (TyCon, Expr Variable ann) ->
+  Maybe (Expr Variable ann) ->
   TcMonad ann DataType
 checkCompleteness env opts catchAll = do
   -- find data type for each match

--- a/src/Language/Mimsa/Typechecker/TcMonad.hs
+++ b/src/Language/Mimsa/Typechecker/TcMonad.hs
@@ -5,22 +5,22 @@ import Control.Monad.Reader
 import Control.Monad.State (State, get, put, runState)
 import Language.Mimsa.Types
 
-type TcMonad = ExceptT TypeError (ReaderT Swaps (State Int))
+type TcMonad a = ExceptT (TypeError a) (ReaderT Swaps (State Int))
 
 runTcMonad ::
   Swaps ->
-  TcMonad a ->
-  Either TypeError a
+  TcMonad ann a ->
+  Either (TypeError ann) a
 runTcMonad swaps value =
   fst either'
   where
     either' = runState (runReaderT (runExceptT value) swaps) 1
 
-getNextUniVar :: TcMonad Int
+getNextUniVar :: TcMonad ann Int
 getNextUniVar = do
   nextUniVar <- get
   put (nextUniVar + 1)
   pure nextUniVar
 
-getUnknown :: TcMonad MonoType
+getUnknown :: TcMonad ann MonoType
 getUnknown = MTVar . NumberedVar <$> getNextUniVar

--- a/src/Language/Mimsa/Typechecker/Unify.hs
+++ b/src/Language/Mimsa/Typechecker/Unify.hs
@@ -30,7 +30,7 @@ freeTypeVars ty = case ty of
     S.empty
 
 -- | Creates a fresh unification variable and binds it to the given type
-varBind :: Variable -> MonoType -> TcMonad Substitutions
+varBind :: Variable -> MonoType -> TcMonad ann Substitutions
 varBind var ty
   | ty == MTVar var = pure mempty
   | S.member var (freeTypeVars ty) = do
@@ -43,13 +43,13 @@ varBind var ty
 unifyPairs ::
   (MonoType, MonoType) ->
   (MonoType, MonoType) ->
-  TcMonad Substitutions
+  TcMonad ann Substitutions
 unifyPairs (a, b) (a', b') = do
   s1 <- unify a a'
   s2 <- unify (applySubst s1 b) (applySubst s1 b')
   pure (s2 <> s1)
 
-unify :: MonoType -> MonoType -> TcMonad Substitutions
+unify :: MonoType -> MonoType -> TcMonad ann Substitutions
 unify tyA tyB =
   case (tyA, tyB) of
     (a, b) | a == b -> pure mempty
@@ -74,7 +74,7 @@ unify tyA tyB =
     (a, b) ->
       throwError $ UnificationError a b
 
-getTypeOrFresh :: Name -> Map Name MonoType -> TcMonad MonoType
+getTypeOrFresh :: Name -> Map Name MonoType -> TcMonad ann MonoType
 getTypeOrFresh name map' =
   case M.lookup name map' of
     Just found -> pure found

--- a/src/Language/Mimsa/Types/AST/Expr.hs
+++ b/src/Language/Mimsa/Types/AST/Expr.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Language.Mimsa.Types.AST.Expr
   ( Expr (..),
+    toEmptyAnnotation,
   )
 where
 
@@ -37,7 +39,13 @@ data Expr var ann
   | MyConstructor ann TyCon -- use a constructor by name
   | MyConsApp ann (Expr var ann) (Expr var ann) -- constructor, value
   | MyCaseMatch ann (Expr var ann) (NonEmpty (TyCon, Expr var ann)) (Maybe (Expr var ann)) -- expr, matches, catchAll
-  deriving (Eq, Ord, Show, Generic, JSON.FromJSON, JSON.ToJSON)
+  deriving (Eq, Ord, Show, Functor, Generic, JSON.FromJSON, JSON.ToJSON)
+
+toEmptyAnnotation ::
+  (Monoid b) =>
+  Expr var a ->
+  Expr var b
+toEmptyAnnotation = fmap (const mempty)
 
 instance (Show var, Printer var) => Printer (Expr var ann) where
   prettyDoc (MyLiteral _ l) = prettyDoc l

--- a/src/Language/Mimsa/Types/AST/Expr.hs
+++ b/src/Language/Mimsa/Types/AST/Expr.hs
@@ -22,24 +22,24 @@ import Language.Mimsa.Types.Identifiers (Name, TyCon)
 
 -------
 
-data Expr a var
-  = MyLiteral a Literal
-  | MyVar a var
-  | MyLet a var (Expr a var) (Expr a var) -- binder, expr, body
-  | MyLetPair a var var (Expr a var) (Expr a var) -- binderA, binderB, expr, body
-  | MyLambda a var (Expr a var) -- binder, body
-  | MyApp a (Expr a var) (Expr a var) -- function, argument
-  | MyIf a (Expr a var) (Expr a var) (Expr a var) -- expr, thencase, elsecase
-  | MyPair a (Expr a var) (Expr a var) -- (a,b)
-  | MyRecord a (Map Name (Expr a var)) -- { dog: MyLiteral (MyInt 1), cat: MyLiteral (MyInt 2) }
-  | MyRecordAccess a (Expr a var) Name -- a.foo
-  | MyData a DataType (Expr a var) -- tyName, tyArgs, Map constructor args, body
-  | MyConstructor a TyCon -- use a constructor by name
-  | MyConsApp a (Expr a var) (Expr a var) -- constructor, value
-  | MyCaseMatch a (Expr a var) (NonEmpty (TyCon, Expr a var)) (Maybe (Expr a var)) -- expr, matches, catchAll
+data Expr var ann
+  = MyLiteral ann Literal
+  | MyVar ann var
+  | MyLet ann var (Expr var ann) (Expr var ann) -- binder, expr, body
+  | MyLetPair ann var var (Expr var ann) (Expr var ann) -- binderA, binderB, expr, body
+  | MyLambda ann var (Expr var ann) -- binder, body
+  | MyApp ann (Expr var ann) (Expr var ann) -- function, argument
+  | MyIf ann (Expr var ann) (Expr var ann) (Expr var ann) -- expr, thencase, elsecase
+  | MyPair ann (Expr var ann) (Expr var ann) -- (a,b)
+  | MyRecord ann (Map Name (Expr var ann)) -- { dog: MyLiteral (MyInt 1), cat: MyLiteral (MyInt 2) }
+  | MyRecordAccess ann (Expr var ann) Name -- a.foo
+  | MyData ann DataType (Expr var ann) -- tyName, tyArgs, Map constructor args, body
+  | MyConstructor ann TyCon -- use a constructor by name
+  | MyConsApp ann (Expr var ann) (Expr var ann) -- constructor, value
+  | MyCaseMatch ann (Expr var ann) (NonEmpty (TyCon, Expr var ann)) (Maybe (Expr var ann)) -- expr, matches, catchAll
   deriving (Eq, Ord, Show, Generic, JSON.FromJSON, JSON.ToJSON)
 
-instance (Show var, Printer var) => Printer (Expr a var) where
+instance (Show var, Printer var) => Printer (Expr var ann) where
   prettyDoc (MyLiteral _ l) = prettyDoc l
   prettyDoc (MyVar _ var) = prettyDoc var
   prettyDoc (MyLet _ var expr1 expr2) =
@@ -128,11 +128,11 @@ instance (Show var, Printer var) => Printer (Expr a var) where
       printMatch (construct, expr') =
         prettyDoc construct <+> printSubExpr expr'
 
-inParens :: (Show var, Printer var) => Expr a var -> Doc ann
+inParens :: (Show var, Printer var) => Expr var ann -> Doc style
 inParens = parens . prettyDoc
 
 -- print simple things with no brackets, and complex things inside brackets
-printSubExpr :: (Show var, Printer var) => Expr a var -> Doc ann
+printSubExpr :: (Show var, Printer var) => Expr var ann -> Doc style
 printSubExpr expr = case expr of
   all'@MyLet {} -> inParens all'
   all'@MyLambda {} -> inParens all'

--- a/src/Language/Mimsa/Types/Error.hs
+++ b/src/Language/Mimsa/Types/Error.hs
@@ -15,16 +15,16 @@ import Language.Mimsa.Types.Error.ResolverError
 import Language.Mimsa.Types.Error.TypeError
 import Language.Mimsa.Types.Usage
 
-data Error
-  = TypeErr TypeError
+data Error a
+  = TypeErr (TypeError a)
   | ResolverErr ResolverError
-  | InterpreterErr InterpreterError
+  | InterpreterErr (InterpreterError a)
   | UsageErr UsageError
   | ParseErr Text
   | OtherError Text
   deriving (Eq, Ord, Show)
 
-instance Printer Error where
+instance (Show a) => Printer (Error a) where
   prettyPrint (TypeErr t) = "TypeError: " <> prettyPrint t
   prettyPrint (ResolverErr a) = "ResolverError: " <> prettyPrint a
   prettyPrint (InterpreterErr a) = "InterpreterError: " <> prettyPrint a

--- a/src/Language/Mimsa/Types/Error.hs
+++ b/src/Language/Mimsa/Types/Error.hs
@@ -15,16 +15,16 @@ import Language.Mimsa.Types.Error.ResolverError
 import Language.Mimsa.Types.Error.TypeError
 import Language.Mimsa.Types.Usage
 
-data Error a
-  = TypeErr (TypeError a)
+data Error ann
+  = TypeErr (TypeError ann)
   | ResolverErr ResolverError
-  | InterpreterErr (InterpreterError a)
+  | InterpreterErr (InterpreterError ann)
   | UsageErr UsageError
   | ParseErr Text
   | OtherError Text
   deriving (Eq, Ord, Show)
 
-instance (Show a) => Printer (Error a) where
+instance (Show ann, Printer ann) => Printer (Error ann) where
   prettyPrint (TypeErr t) = "TypeError: " <> prettyPrint t
   prettyPrint (ResolverErr a) = "ResolverError: " <> prettyPrint a
   prettyPrint (InterpreterErr a) = "InterpreterError: " <> prettyPrint a

--- a/src/Language/Mimsa/Types/Error/InterpreterError.hs
+++ b/src/Language/Mimsa/Types/Error/InterpreterError.hs
@@ -10,30 +10,30 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Scope
 
-data InterpreterError
+data InterpreterError a
   = UnknownInterpreterError
-  | CouldNotFindVar Scope Variable
-  | CouldNotFindBuiltIn Scope Variable
-  | CannotDestructureAsPair (Expr Variable)
-  | CannotDestructureAsSum (Expr Variable)
-  | CannotDestructureAsRecord (Expr Variable) Name
-  | CannotDestructureAsList (Expr Variable)
-  | CannotApplyToNonFunction (Expr Variable)
-  | CannotFindMemberInRecord (Map Name (Expr Variable)) Name
-  | PredicateForIfMustBeABoolean (Expr Variable)
+  | CouldNotFindVar (Scope a) Variable
+  | CouldNotFindBuiltIn (Scope a) Variable
+  | CannotDestructureAsPair (Expr a Variable)
+  | CannotDestructureAsSum (Expr a Variable)
+  | CannotDestructureAsRecord (Expr a Variable) Name
+  | CannotDestructureAsList (Expr a Variable)
+  | CannotApplyToNonFunction (Expr a Variable)
+  | CannotFindMemberInRecord (Map Name (Expr a Variable)) Name
+  | PredicateForIfMustBeABoolean (Expr a Variable)
   | CouldNotUnwrapBuiltIn Variable
   | CouldNotMatchBuiltInId BiIds
-  | PatternMatchFailure (Expr Variable)
+  | PatternMatchFailure (Expr a Variable)
   | SelfReferencingBinding Variable
   deriving (Eq, Ord, Show)
 
-instance Semigroup InterpreterError where
+instance Semigroup (InterpreterError a) where
   a <> _ = a
 
-instance Monoid InterpreterError where
+instance Monoid (InterpreterError a) where
   mempty = UnknownInterpreterError
 
-instance Printer InterpreterError where
+instance Printer (InterpreterError a) where
   prettyPrint (CouldNotFindVar _ name) = "Could not find var " <> prettyPrint name
   prettyPrint (CouldNotFindBuiltIn _ name) = "Could not find built-in " <> prettyPrint name
   prettyPrint (CannotDestructureAsPair expr) = "Expected a pair. Cannot destructure: " <> prettyPrint expr

--- a/src/Language/Mimsa/Types/Error/InterpreterError.hs
+++ b/src/Language/Mimsa/Types/Error/InterpreterError.hs
@@ -10,20 +10,20 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Scope
 
-data InterpreterError a
+data InterpreterError ann
   = UnknownInterpreterError
-  | CouldNotFindVar (Scope a) Variable
-  | CouldNotFindBuiltIn (Scope a) Variable
-  | CannotDestructureAsPair (Expr a Variable)
-  | CannotDestructureAsSum (Expr a Variable)
-  | CannotDestructureAsRecord (Expr a Variable) Name
-  | CannotDestructureAsList (Expr a Variable)
-  | CannotApplyToNonFunction (Expr a Variable)
-  | CannotFindMemberInRecord (Map Name (Expr a Variable)) Name
-  | PredicateForIfMustBeABoolean (Expr a Variable)
+  | CouldNotFindVar (Scope ann) Variable
+  | CouldNotFindBuiltIn (Scope ann) Variable
+  | CannotDestructureAsPair (Expr Variable ann)
+  | CannotDestructureAsSum (Expr Variable ann)
+  | CannotDestructureAsRecord (Expr Variable ann) Name
+  | CannotDestructureAsList (Expr Variable ann)
+  | CannotApplyToNonFunction (Expr Variable ann)
+  | CannotFindMemberInRecord (Map Name (Expr Variable ann)) Name
+  | PredicateForIfMustBeABoolean (Expr Variable ann)
   | CouldNotUnwrapBuiltIn Variable
   | CouldNotMatchBuiltInId BiIds
-  | PatternMatchFailure (Expr a Variable)
+  | PatternMatchFailure (Expr Variable ann)
   | SelfReferencingBinding Variable
   deriving (Eq, Ord, Show)
 
@@ -33,7 +33,7 @@ instance Semigroup (InterpreterError a) where
 instance Monoid (InterpreterError a) where
   mempty = UnknownInterpreterError
 
-instance Printer (InterpreterError a) where
+instance (Show ann, Printer ann) => Printer (InterpreterError ann) where
   prettyPrint (CouldNotFindVar _ name) = "Could not find var " <> prettyPrint name
   prettyPrint (CouldNotFindBuiltIn _ name) = "Could not find built-in " <> prettyPrint name
   prettyPrint (CannotDestructureAsPair expr) = "Expected a pair. Cannot destructure: " <> prettyPrint expr

--- a/src/Language/Mimsa/Types/Error/TypeError.hs
+++ b/src/Language/Mimsa/Types/Error/TypeError.hs
@@ -30,7 +30,7 @@ import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.MonoType (MonoType)
 import Language.Mimsa.Types.Swaps (Swaps)
 
-data TypeError a
+data TypeError ann
   = UnknownTypeError
   | FailsOccursCheck Swaps Variable MonoType
   | UnificationError MonoType MonoType
@@ -41,9 +41,9 @@ data TypeError a
   | CannotUnifyBoundVariable Variable MonoType
   | CannotMatchRecord Environment MonoType
   | CaseMatchExpectedPair MonoType
-  | CannotCaseMatchOnType (Expr a Variable)
+  | CannotCaseMatchOnType (Expr Variable ann)
   | TypeConstructorNotInScope Environment TyCon
-  | TypeIsNotConstructor (Expr a Variable)
+  | TypeIsNotConstructor (Expr Variable ann)
   | TypeVariableNotInDataType TyCon Name [Name]
   | ConflictingConstructors TyCon
   | CannotApplyToType TyCon

--- a/src/Language/Mimsa/Types/Error/TypeError.hs
+++ b/src/Language/Mimsa/Types/Error/TypeError.hs
@@ -12,16 +12,14 @@ import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text.Prettyprint.Doc
-  ( Doc,
+  ( (<+>),
+    Doc,
     Pretty (pretty),
     vsep,
-    (<+>),
   )
 import Language.Mimsa.Printer (Printer (prettyDoc))
 import Language.Mimsa.Types.AST (DataType (DataType), Expr)
-import Language.Mimsa.Types.Environment
-  ( Environment (getDataTypes),
-  )
+import Language.Mimsa.Types.Environment (Environment (getDataTypes))
 import Language.Mimsa.Types.Identifiers
   ( Name,
     TyCon,
@@ -32,7 +30,7 @@ import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.MonoType (MonoType)
 import Language.Mimsa.Types.Swaps (Swaps)
 
-data TypeError
+data TypeError a
   = UnknownTypeError
   | FailsOccursCheck Swaps Variable MonoType
   | UnificationError MonoType MonoType
@@ -43,9 +41,9 @@ data TypeError
   | CannotUnifyBoundVariable Variable MonoType
   | CannotMatchRecord Environment MonoType
   | CaseMatchExpectedPair MonoType
-  | CannotCaseMatchOnType (Expr Variable)
+  | CannotCaseMatchOnType (Expr a Variable)
   | TypeConstructorNotInScope Environment TyCon
-  | TypeIsNotConstructor (Expr Variable)
+  | TypeIsNotConstructor (Expr a Variable)
   | TypeVariableNotInDataType TyCon Name [Name]
   | ConflictingConstructors TyCon
   | CannotApplyToType TyCon
@@ -54,13 +52,13 @@ data TypeError
   | MixedUpPatterns [TyCon]
   deriving (Eq, Ord, Show)
 
-instance Semigroup TypeError where
+instance Semigroup (TypeError a) where
   a <> _ = a
 
-instance Monoid TypeError where
+instance Monoid (TypeError a) where
   mempty = UnknownTypeError
 
-instance Printer TypeError where
+instance (Show a) => Printer (TypeError a) where
   prettyDoc = vsep . renderTypeError
 
 showKeys :: (p -> Doc ann) -> Map p a -> [Doc ann]
@@ -83,7 +81,7 @@ withSwap swaps (NumberedVar i) =
     (mkName "unknownvar")
     (M.lookup (NumberedVar i) swaps)
 
-renderTypeError :: TypeError -> [Doc ann]
+renderTypeError :: (Show a) => TypeError a -> [Doc ann]
 renderTypeError UnknownTypeError =
   ["Unknown type error"]
 renderTypeError (FailsOccursCheck swaps var mt) =

--- a/src/Language/Mimsa/Types/ForeignFunc.hs
+++ b/src/Language/Mimsa/Types/ForeignFunc.hs
@@ -4,8 +4,8 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.MonoType
 
-type FFExpr = Expr Variable
+type FFExpr a = Expr a Variable
 
-data ForeignFunc
-  = NoArgs MonoType (IO FFExpr)
-  | OneArg (MonoType, MonoType) (FFExpr -> IO FFExpr)
+data ForeignFunc a
+  = NoArgs MonoType (IO (FFExpr a))
+  | OneArg (MonoType, MonoType) (FFExpr a -> IO (FFExpr a))

--- a/src/Language/Mimsa/Types/ForeignFunc.hs
+++ b/src/Language/Mimsa/Types/ForeignFunc.hs
@@ -4,8 +4,8 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.MonoType
 
-type FFExpr a = Expr a Variable
+type FFExpr ann = Expr Variable ann
 
-data ForeignFunc a
-  = NoArgs MonoType (IO (FFExpr a))
-  | OneArg (MonoType, MonoType) (FFExpr a -> IO (FFExpr a))
+data ForeignFunc ann
+  = NoArgs MonoType (IO (FFExpr ann))
+  | OneArg (MonoType, MonoType) (FFExpr ann -> IO (FFExpr ann))

--- a/src/Language/Mimsa/Types/Library.hs
+++ b/src/Language/Mimsa/Types/Library.hs
@@ -6,4 +6,4 @@ import Language.Mimsa.Types.Identifiers
 
 -- our built-in functions for doing IO things etc
 -- statically defined and made available in all computations for now
-newtype Library = Library {getLibrary :: Map FuncName ForeignFunc}
+newtype Library a = Library {getLibrary :: Map FuncName (ForeignFunc a)}

--- a/src/Language/Mimsa/Types/Project.hs
+++ b/src/Language/Mimsa/Types/Project.hs
@@ -23,19 +23,20 @@ newtype ServerUrl = ServerUrl {getServerUrl :: Text}
 
 -- our environment contains whichever hash/expr pairs we have flapping about
 -- and a list of mappings of names to those pieces
-data Project = Project
-  { store :: Store,
-    bindings :: VersionedBindings,
-    typeBindings :: VersionedTypeBindings,
-    serverUrl :: [ServerUrl]
-  }
+data Project a
+  = Project
+      { store :: Store a,
+        bindings :: VersionedBindings,
+        typeBindings :: VersionedTypeBindings,
+        serverUrl :: [ServerUrl]
+      }
   deriving (Eq, Ord, Show)
 
-instance Semigroup Project where
+instance Semigroup (Project a) where
   Project a a1 a2 a3 <> Project b b1 b2 b3 =
     Project (a <> b) (a1 <> b1) (a2 <> b2) (a3 <> b3)
 
-instance Monoid Project where
+instance Monoid (Project a) where
   mempty = Project mempty mempty mempty mempty
 
 -------------
@@ -46,17 +47,18 @@ type VersionedTypeBindings = VersionedMap TyCon ExprHash
 
 --------
 
-data SaveProject = SaveProject
-  { projectVersion :: Int,
-    projectBindings :: VersionedBindings,
-    projectTypes :: VersionedTypeBindings,
-    projectServers :: [ServerUrl]
-  }
+data SaveProject
+  = SaveProject
+      { projectVersion :: Int,
+        projectBindings :: VersionedBindings,
+        projectTypes :: VersionedTypeBindings,
+        projectServers :: [ServerUrl]
+      }
   deriving (Eq, Ord, Show, Generic, JSON.FromJSON, JSON.ToJSON)
 
 -----
 
-projectFromSaved :: Store -> SaveProject -> Project
+projectFromSaved :: Store a -> SaveProject -> Project a
 projectFromSaved store' sp =
   Project
     { store = store',
@@ -65,7 +67,7 @@ projectFromSaved store' sp =
       serverUrl = projectServers sp
     }
 
-projectToSaved :: Project -> SaveProject
+projectToSaved :: Project a -> SaveProject
 projectToSaved proj =
   SaveProject
     { projectVersion = 1,

--- a/src/Language/Mimsa/Types/ResolvedDeps.hs
+++ b/src/Language/Mimsa/Types/ResolvedDeps.hs
@@ -10,17 +10,17 @@ import Language.Mimsa.Types.ExprHash
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.StoreExpression
 
-newtype ResolvedDeps
+newtype ResolvedDeps a
   = ResolvedDeps
       { getResolvedDeps ::
           Map Name
-            (ExprHash, StoreExpression)
+            (ExprHash, StoreExpression a)
       }
 
-hasNoDeps :: ResolvedDeps -> Bool
+hasNoDeps :: ResolvedDeps a -> Bool
 hasNoDeps (ResolvedDeps m) = M.size m == 0
 
-instance Printer ResolvedDeps where
+instance Printer (ResolvedDeps a) where
   prettyDoc (ResolvedDeps deps) =
     encloseSep
       lbrace

--- a/src/Language/Mimsa/Types/ResolvedExpression.hs
+++ b/src/Language/Mimsa/Types/ResolvedExpression.hs
@@ -7,11 +7,11 @@ import Language.Mimsa.Types.Scope
 import Language.Mimsa.Types.StoreExpression
 import Language.Mimsa.Types.Swaps
 
-data ResolvedExpression
+data ResolvedExpression a
   = ResolvedExpression
       { reMonoType :: MonoType,
-        reStoreExpression :: StoreExpression,
-        reExpression :: Expr Variable,
-        reScope :: Scope,
+        reStoreExpression :: StoreExpression a,
+        reExpression :: Expr a Variable,
+        reScope :: Scope a,
         reSwaps :: Swaps
       }

--- a/src/Language/Mimsa/Types/ResolvedExpression.hs
+++ b/src/Language/Mimsa/Types/ResolvedExpression.hs
@@ -7,11 +7,11 @@ import Language.Mimsa.Types.Scope
 import Language.Mimsa.Types.StoreExpression
 import Language.Mimsa.Types.Swaps
 
-data ResolvedExpression a
+data ResolvedExpression ann
   = ResolvedExpression
       { reMonoType :: MonoType,
-        reStoreExpression :: StoreExpression a,
-        reExpression :: Expr a Variable,
-        reScope :: Scope a,
+        reStoreExpression :: StoreExpression ann,
+        reExpression :: Expr Variable ann,
+        reScope :: Scope ann,
         reSwaps :: Swaps
       }

--- a/src/Language/Mimsa/Types/Scope.hs
+++ b/src/Language/Mimsa/Types/Scope.hs
@@ -12,10 +12,10 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 
 -- dependencies resolved into actual expressions
-newtype Scope a = Scope {getScope :: Map Variable (Expr a Variable)}
+newtype Scope ann = Scope {getScope :: Map Variable (Expr Variable ann)}
   deriving newtype (Eq, Ord, Show, Semigroup, Monoid)
 
-instance Printer (Scope a) where
+instance (Show ann, Printer ann) => Printer (Scope ann) where
   prettyPrint (Scope s) = "{ " <> T.intercalate ", " (printItem <$> M.toList s) <> " }"
     where
       printItem (k, a) = prettyPrint k <> ": " <> prettyPrint a

--- a/src/Language/Mimsa/Types/Scope.hs
+++ b/src/Language/Mimsa/Types/Scope.hs
@@ -12,10 +12,10 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 
 -- dependencies resolved into actual expressions
-newtype Scope = Scope {getScope :: Map Variable (Expr Variable)}
+newtype Scope a = Scope {getScope :: Map Variable (Expr a Variable)}
   deriving newtype (Eq, Ord, Show, Semigroup, Monoid)
 
-instance Printer Scope where
+instance Printer (Scope a) where
   prettyPrint (Scope s) = "{ " <> T.intercalate ", " (printItem <$> M.toList s) <> " }"
     where
       printItem (k, a) = prettyPrint k <> ": " <> prettyPrint a

--- a/src/Language/Mimsa/Types/Scope.hs
+++ b/src/Language/Mimsa/Types/Scope.hs
@@ -12,7 +12,10 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 
 -- dependencies resolved into actual expressions
-newtype Scope ann = Scope {getScope :: Map Variable (Expr Variable ann)}
+newtype Scope ann
+  = Scope
+      { getScope :: Map Variable (Expr Variable ann)
+      }
   deriving newtype (Eq, Ord, Show, Semigroup, Monoid)
 
 instance (Show ann, Printer ann) => Printer (Scope ann) where

--- a/src/Language/Mimsa/Types/Store.hs
+++ b/src/Language/Mimsa/Types/Store.hs
@@ -8,5 +8,5 @@ import Language.Mimsa.Types.ExprHash
 import Language.Mimsa.Types.StoreExpression
 
 -- store is where we keep the big map of hashes to expresions
-newtype Store = Store {getStore :: Map ExprHash StoreExpression}
+newtype Store a = Store {getStore :: Map ExprHash (StoreExpression a)}
   deriving newtype (Eq, Ord, Show, Semigroup, Monoid)

--- a/src/Language/Mimsa/Types/StoreExpression.hs
+++ b/src/Language/Mimsa/Types/StoreExpression.hs
@@ -13,9 +13,9 @@ import Language.Mimsa.Types.TypeBindings
 -- a storeExpression contains the AST Expr
 -- and a map of names to hashes with further functions inside
 -- not sure whether to store the builtins we need here too?
-data StoreExpression
+data StoreExpression a
   = StoreExpression
-      { storeExpression :: Expr Name,
+      { storeExpression :: Expr a Name,
         storeBindings :: Bindings,
         storeTypeBindings :: TypeBindings
       }

--- a/src/Language/Mimsa/Types/StoreExpression.hs
+++ b/src/Language/Mimsa/Types/StoreExpression.hs
@@ -13,9 +13,9 @@ import Language.Mimsa.Types.TypeBindings
 -- a storeExpression contains the AST Expr
 -- and a map of names to hashes with further functions inside
 -- not sure whether to store the builtins we need here too?
-data StoreExpression a
+data StoreExpression ann
   = StoreExpression
-      { storeExpression :: Expr a Name,
+      { storeExpression :: Expr Name ann,
         storeBindings :: Bindings,
         storeTypeBindings :: TypeBindings
       }

--- a/src/Language/Mimsa/Types/SubstitutedExpression.hs
+++ b/src/Language/Mimsa/Types/SubstitutedExpression.hs
@@ -5,10 +5,10 @@ import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Scope
 import Language.Mimsa.Types.Swaps
 
-data SubstitutedExpression
+data SubstitutedExpression a
   = SubstitutedExpression
       { seSwaps :: Swaps,
-        seExpr :: Expr Variable,
-        seScope :: Scope
+        seExpr :: Expr a Variable,
+        seScope :: Scope a
       }
   deriving (Eq, Ord, Show)

--- a/src/Language/Mimsa/Types/SubstitutedExpression.hs
+++ b/src/Language/Mimsa/Types/SubstitutedExpression.hs
@@ -5,10 +5,10 @@ import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Scope
 import Language.Mimsa.Types.Swaps
 
-data SubstitutedExpression a
+data SubstitutedExpression ann
   = SubstitutedExpression
       { seSwaps :: Swaps,
-        seExpr :: Expr a Variable,
-        seScope :: Scope a
+        seExpr :: Expr Variable ann,
+        seScope :: Scope ann
       }
   deriving (Eq, Ord, Show)

--- a/src/Language/Mimsa/Types/Tui.hs
+++ b/src/Language/Mimsa/Types/Tui.hs
@@ -8,30 +8,30 @@ import Language.Mimsa.Types.MonoType
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.ResolvedDeps
 
-data ExpressionInfo
+data ExpressionInfo a
   = ExpressionInfo
       { eiType :: MonoType,
-        eiExpr :: Expr Name,
+        eiExpr :: Expr a Name,
         eiName :: Name,
-        eiDeps :: ResolvedDeps
+        eiDeps :: ResolvedDeps a
       }
 
-data TuiState
+data TuiState a
   = TuiState
-      { project :: Project,
-        uiState :: UIState
+      { project :: Project a,
+        uiState :: UIState a
       }
 
 newtype UIError
   = MissingStoreItems [Name]
 
-data BindingsList
+data BindingsList a
   = BindingsList
       { bName :: Name,
-        bDeps :: ResolvedDeps,
+        bDeps :: ResolvedDeps a,
         bList :: L.List () Name
       }
 
-data UIState
+data UIState a
   = TuiError UIError
-  | ViewBindings (NonEmpty BindingsList)
+  | ViewBindings (NonEmpty (BindingsList a))

--- a/src/Language/Mimsa/Types/Tui.hs
+++ b/src/Language/Mimsa/Types/Tui.hs
@@ -8,12 +8,12 @@ import Language.Mimsa.Types.MonoType
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.ResolvedDeps
 
-data ExpressionInfo a
+data ExpressionInfo ann
   = ExpressionInfo
       { eiType :: MonoType,
-        eiExpr :: Expr a Name,
+        eiExpr :: Expr Name ann,
         eiName :: Name,
-        eiDeps :: ResolvedDeps a
+        eiDeps :: ResolvedDeps ann
       }
 
 data TuiState a

--- a/test/Test/BackendJS.hs
+++ b/test/Test/BackendJS.hs
@@ -19,7 +19,7 @@ import Language.Mimsa.Types
 import Test.Data.Project
 import Test.Hspec
 
-eval :: Project -> Text -> Either Text Javascript
+eval :: Project () -> Text -> Either Text Javascript
 eval env input =
   case evaluateText env input of
     Left e -> Left $ prettyPrint e
@@ -27,7 +27,7 @@ eval env input =
       pure $
         output (storeExpression storeExpr)
 
-evalModule :: Project -> Text -> IO (Either Text Javascript)
+evalModule :: Project () -> Text -> IO (Either Text Javascript)
 evalModule env input =
   case evaluateText env input of
     Left e -> pure $ Left $ prettyPrint e

--- a/test/Test/Data/Project.hs
+++ b/test/Test/Data/Project.hs
@@ -17,48 +17,48 @@ import Language.Mimsa.Types
     mkTyCon,
   )
 
-fstExpr :: StoreExpression ()
+fstExpr :: (Monoid ann, Show ann) => StoreExpression ann
 fstExpr =
   unsafeGetExpr "\\tuple -> let (tupleFirst,tupleSecond) = tuple in tupleFirst"
 
-sndExpr :: StoreExpression ()
+sndExpr :: (Monoid ann, Show ann) => StoreExpression ann
 sndExpr = unsafeGetExpr "\\tuple -> let (tupleFirst,tupleSecond) = tuple in tupleSecond"
 
-eqTenExpr :: StoreExpression ()
+eqTenExpr :: (Monoid ann, Show ann) => StoreExpression ann
 eqTenExpr =
   unsafeGetExpr'
     "\\i -> eq(10)(i)"
     (Bindings $ M.singleton (mkName "eq") (ExprHash 2))
 
-compose :: StoreExpression ()
+compose :: (Monoid ann, Show ann) => StoreExpression ann
 compose =
   unsafeGetExpr "\\f -> \\g -> \\aValue -> f(g(aValue))"
 
-idExpr :: StoreExpression ()
+idExpr :: (Monoid ann, Show ann) => StoreExpression ann
 idExpr = unsafeGetExpr "\\i -> i"
 
-incrementInt :: StoreExpression ()
+incrementInt :: (Monoid ann, Show ann) => StoreExpression ann
 incrementInt =
   unsafeGetExpr'
     "\\a -> addInt(1)(a)"
     (Bindings $ M.singleton (mkName "addInt") (ExprHash 18))
 
-addInt :: StoreExpression ()
+addInt :: (Monoid ann, Show ann) => StoreExpression ann
 addInt = unsafeGetExpr "\\a -> \\b -> addIntPair((a,b))"
 
-eqExpr :: StoreExpression ()
+eqExpr :: (Monoid ann, Show ann) => StoreExpression ann
 eqExpr = unsafeGetExpr "\\a -> \\b -> eqPair((a,b))"
 
-optionExpr :: StoreExpression ()
+optionExpr :: (Monoid ann, Show ann) => StoreExpression ann
 optionExpr = unsafeGetExpr "type Option a = Some a | Nowt in {}"
 
-aPairExpr :: StoreExpression ()
+aPairExpr :: (Monoid ann, Show ann) => StoreExpression ann
 aPairExpr = unsafeGetExpr "(1,2)"
 
-aRecordExpr :: StoreExpression ()
+aRecordExpr :: (Monoid ann, Show ann) => StoreExpression ann
 aRecordExpr = unsafeGetExpr "{ a: 1, b: \"dog\" }"
 
-stdLib :: Project ()
+stdLib :: (Monoid ann, Show ann) => Project ann
 stdLib = Project store' bindings' typeBindings' mempty
   where
     store' =
@@ -97,11 +97,11 @@ stdLib = Project store' bindings' typeBindings' mempty
             (mkTyCon "Nowt", pure $ ExprHash 4)
           ]
 
-unsafeGetExpr' :: Text -> Bindings -> StoreExpression ()
+unsafeGetExpr' :: (Monoid ann, Show ann) => Text -> Bindings -> StoreExpression ann
 unsafeGetExpr' input bindings' =
   case parseExpr input of
     Right expr' -> StoreExpression expr' bindings' mempty
     a -> error $ "Error evaluating " <> T.unpack input <> ": " <> show a
 
-unsafeGetExpr :: Text -> StoreExpression ()
+unsafeGetExpr :: (Monoid ann, Show ann) => Text -> StoreExpression ann
 unsafeGetExpr input = unsafeGetExpr' input mempty

--- a/test/Test/Data/Project.hs
+++ b/test/Test/Data/Project.hs
@@ -17,48 +17,48 @@ import Language.Mimsa.Types
     mkTyCon,
   )
 
-fstExpr :: StoreExpression
+fstExpr :: StoreExpression ()
 fstExpr =
   unsafeGetExpr "\\tuple -> let (tupleFirst,tupleSecond) = tuple in tupleFirst"
 
-sndExpr :: StoreExpression
+sndExpr :: StoreExpression ()
 sndExpr = unsafeGetExpr "\\tuple -> let (tupleFirst,tupleSecond) = tuple in tupleSecond"
 
-eqTenExpr :: StoreExpression
+eqTenExpr :: StoreExpression ()
 eqTenExpr =
   unsafeGetExpr'
     "\\i -> eq(10)(i)"
     (Bindings $ M.singleton (mkName "eq") (ExprHash 2))
 
-compose :: StoreExpression
+compose :: StoreExpression ()
 compose =
   unsafeGetExpr "\\f -> \\g -> \\aValue -> f(g(aValue))"
 
-idExpr :: StoreExpression
+idExpr :: StoreExpression ()
 idExpr = unsafeGetExpr "\\i -> i"
 
-incrementInt :: StoreExpression
+incrementInt :: StoreExpression ()
 incrementInt =
   unsafeGetExpr'
     "\\a -> addInt(1)(a)"
     (Bindings $ M.singleton (mkName "addInt") (ExprHash 18))
 
-addInt :: StoreExpression
+addInt :: StoreExpression ()
 addInt = unsafeGetExpr "\\a -> \\b -> addIntPair((a,b))"
 
-eqExpr :: StoreExpression
+eqExpr :: StoreExpression ()
 eqExpr = unsafeGetExpr "\\a -> \\b -> eqPair((a,b))"
 
-optionExpr :: StoreExpression
+optionExpr :: StoreExpression ()
 optionExpr = unsafeGetExpr "type Option a = Some a | Nowt in {}"
 
-aPairExpr :: StoreExpression
+aPairExpr :: StoreExpression ()
 aPairExpr = unsafeGetExpr "(1,2)"
 
-aRecordExpr :: StoreExpression
+aRecordExpr :: StoreExpression ()
 aRecordExpr = unsafeGetExpr "{ a: 1, b: \"dog\" }"
 
-stdLib :: Project
+stdLib :: Project ()
 stdLib = Project store' bindings' typeBindings' mempty
   where
     store' =
@@ -97,11 +97,11 @@ stdLib = Project store' bindings' typeBindings' mempty
             (mkTyCon "Nowt", pure $ ExprHash 4)
           ]
 
-unsafeGetExpr' :: Text -> Bindings -> StoreExpression
+unsafeGetExpr' :: Text -> Bindings -> StoreExpression ()
 unsafeGetExpr' input bindings' =
   case parseExpr input of
     Right expr' -> StoreExpression expr' bindings' mempty
     a -> error $ "Error evaluating " <> T.unpack input <> ": " <> show a
 
-unsafeGetExpr :: Text -> StoreExpression
+unsafeGetExpr :: Text -> StoreExpression ()
 unsafeGetExpr input = unsafeGetExpr' input mempty

--- a/test/Test/Helpers.hs
+++ b/test/Test/Helpers.hs
@@ -3,16 +3,16 @@ module Test.Helpers where
 import Data.Text (Text)
 import Language.Mimsa.Types
 
-bool :: (Monoid ann) => Bool -> Expr ann a
+bool :: (Monoid ann) => Bool -> Expr a ann
 bool a = MyLiteral mempty (MyBool a)
 
-int :: (Monoid ann) => Int -> Expr ann a
+int :: (Monoid ann) => Int -> Expr a ann
 int a = MyLiteral mempty (MyInt a)
 
-str :: (Monoid ann) => StringType -> Expr ann a
+str :: (Monoid ann) => StringType -> Expr a ann
 str a = MyLiteral mempty (MyString a)
 
-str' :: (Monoid ann) => Text -> Expr ann a
+str' :: (Monoid ann) => Text -> Expr a ann
 str' = str . StringType
 
 --

--- a/test/Test/Helpers.hs
+++ b/test/Test/Helpers.hs
@@ -3,16 +3,16 @@ module Test.Helpers where
 import Data.Text (Text)
 import Language.Mimsa.Types
 
-bool :: Bool -> Expr a
-bool a = MyLiteral (MyBool a)
+bool :: (Monoid ann) => Bool -> Expr ann a
+bool a = MyLiteral mempty (MyBool a)
 
-int :: Int -> Expr a
-int a = MyLiteral (MyInt a)
+int :: (Monoid ann) => Int -> Expr ann a
+int a = MyLiteral mempty (MyInt a)
 
-str :: StringType -> Expr a
-str a = MyLiteral (MyString a)
+str :: (Monoid ann) => StringType -> Expr ann a
+str a = MyLiteral mempty (MyString a)
 
-str' :: Text -> Expr a
+str' :: (Monoid ann) => Text -> Expr ann a
 str' = str . StringType
 
 --

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Test.Repl
@@ -21,7 +22,18 @@ import Test.Data.Project
 import Test.Helpers
 import Test.Hspec
 
-eval :: Project -> Text -> IO (Either Text (MonoType, Expr Variable))
+eval' :: Project () -> Text -> IO (Either Text (MonoType, Expr Variable ()))
+eval' = eval
+
+eval ::
+  ( Eq ann,
+    Monoid ann,
+    Show ann,
+    Printer ann
+  ) =>
+  Project ann ->
+  Text ->
+  IO (Either Text (MonoType, Expr Variable ann))
 eval env input =
   case prettyPrintingParses input of
     Left e -> pure (Left $ prettyPrint e)
@@ -41,7 +53,7 @@ prettyPrintingParses input = do
   expr1 <- parseExpr input
   case parseExpr (prettyPrint expr1) of
     Left _ -> Left ("Could not parse >>>" <> prettyPrint expr1 <> "<<<")
-    Right expr2 ->
+    Right (expr2 :: Expr Name ()) ->
       if expr1 /= expr2
         then
           Left
@@ -61,110 +73,117 @@ spec =
     $ describe "End to end parsing to evaluation"
     $ do
       it "let x = ((1,2)) in fst(x)" $ do
-        result <- eval stdLib "let x = ((1,2)) in fst(x)"
+        result <- eval' stdLib "let x = ((1,2)) in fst(x)"
         result
           `shouldBe` Right
             (MTInt, int 1)
       it "let good = { dog: True } in good.dog" $ do
-        result <- eval stdLib "let good = ({ dog: True }) in good.dog"
+        result <- eval' stdLib "let good = ({ dog: True }) in good.dog"
         result `shouldBe` Right (MTBool, bool True)
       it "let prelude = { id: (\\i -> i) } in prelude.id" $ do
-        result <- eval stdLib "let prelude = ({ id: (\\i -> i) }) in prelude.id"
+        result <- eval' stdLib "let prelude = ({ id: (\\i -> i) }) in prelude.id"
         result
           `shouldBe` Right
             ( MTFunction (unknown 4) (unknown 4),
-              MyLambda (named "i") (MyVar (named "i"))
+              MyLambda mempty (named "i") (MyVar mempty (named "i"))
             )
       it "let prelude = ({ id: (\\i -> i) }) in prelude.id(1)" $ do
-        result <- eval stdLib "let prelude = ({ id: (\\i -> i) }) in prelude.id(1)"
+        result <- eval' stdLib "let prelude = ({ id: (\\i -> i) }) in prelude.id(1)"
         result
           `shouldBe` Right
             ( MTInt,
               int 1
             )
       it "let bigPrelude = ({ prelude: { id: (\\i -> i) } }) in bigPrelude.prelude.id(1)" $ do
-        result <- eval stdLib "let bigPrelude = ({ prelude: { id: (\\i -> i) } }) in bigPrelude.prelude.id(1)"
+        result <- eval' stdLib "let bigPrelude = ({ prelude: { id: (\\i -> i) } }) in bigPrelude.prelude.id(1)"
         result
           `shouldBe` Right
             ( MTInt,
               int 1
             )
       it "let compose = (\\f -> \\g -> \\a -> f(g(a))) in compose(incrementInt)(incrementInt)(67)" $ do
-        result <- eval stdLib "let compose = (\\f -> \\g -> \\a -> f(g(a))) in compose(incrementInt)(incrementInt)(67)"
+        result <- eval' stdLib "let compose = (\\f -> \\g -> \\a -> f(g(a))) in compose(incrementInt)(incrementInt)(67)"
         result `shouldBe` Right (MTInt, int 69)
       it "let reuse = ({ first: id(1), second: id(2) }) in reuse.first" $ do
-        result <- eval stdLib "let reuse = ({ first: id(1), second: id(2) }) in reuse.first"
+        result <- eval' stdLib "let reuse = ({ first: id(1), second: id(2) }) in reuse.first"
         result `shouldBe` Right (MTInt, int 1)
       it "let id = \\a -> a in id(1)" $ do
-        result <- eval mempty "let id = \\a -> a in id(1)"
+        result <- eval' mempty "let id = \\a -> a in id(1)"
         result `shouldBe` Right (MTInt, int 1)
       it "let reuse = ({ first: id(True), second: id(2) }) in reuse.first" $ do
-        result <- eval stdLib "let reuse = ({ first: id(True), second: id(2) }) in reuse.first"
+        result <- eval' stdLib "let reuse = ({ first: id(True), second: id(2) }) in reuse.first"
         result `shouldBe` Right (MTBool, bool True)
       it "let reuse = ({ first: id, second: id(2) }) in reuse.first(True)" $ do
-        result <- eval stdLib "let reuse = ({ first: id, second: id(2) }) in reuse.first(True)"
+        result <- eval' stdLib "let reuse = ({ first: id, second: id(2) }) in reuse.first(True)"
         result `shouldBe` Right (MTBool, bool True)
       it "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(1), second: const2(True) }) in reuse.first(100))" $ do
-        result <- eval stdLib "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(1), second: const2(True) }) in reuse.first(100))"
+        result <- eval' stdLib "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(1), second: const2(True) }) in reuse.first(100))"
         result `shouldBe` Right (MTInt, int 1)
       it "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(True), second: const2(2) }) in reuse.second(100))" $ do
-        result <- eval stdLib "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(True), second: const2(2) }) in reuse.second(100))"
+        result <- eval' stdLib "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(True), second: const2(2) }) in reuse.second(100))"
         result `shouldBe` Right (MTInt, int 2)
       it "addInt(1)(2)" $ do
-        result <- eval stdLib "addInt(1)(2)"
+        result <- eval' stdLib "addInt(1)(2)"
         result `shouldBe` Right (MTInt, int 3)
       it "(\\a -> a)(1)" $ do
-        result <- eval stdLib "(\\a -> a)(1)"
+        result <- eval' stdLib "(\\a -> a)(1)"
         result `shouldBe` Right (MTInt, int 1)
       it "(\\b -> (\\a -> b))(0)(1)" $ do
-        result <- eval stdLib "(\\b -> (\\a -> b))(0)(1)"
+        result <- eval' stdLib "(\\b -> (\\a -> b))(0)(1)"
         result `shouldBe` Right (MTInt, int 0)
       it "addInt(1)(addInt(addInt(2)(4))(5))" $ do
-        result <- eval stdLib "addInt(1)(addInt(addInt(2)(4))(5))"
+        result <- eval' stdLib "addInt(1)(addInt(addInt(2)(4))(5))"
         result `shouldBe` Right (MTInt, int 12)
       it "type LeBool = Vrai | Faux in Vrai" $ do
-        result <- eval stdLib "type LeBool = Vrai | Faux in Vrai"
+        result <- eval' stdLib "type LeBool = Vrai | Faux in Vrai"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "LeBool") [],
-              MyConstructor (mkTyCon "Vrai")
+              MyConstructor mempty (mkTyCon "Vrai")
             )
       it "type Nat = Zero | Suc Nat in Suc Zero" $ do
-        result <- eval stdLib "type Nat = Zero | Suc Nat in Suc Zero"
-        result
-          `shouldBe` Right
-            ( MTData (mkTyCon "Nat") [],
-              MyConsApp (MyConstructor (mkTyCon "Suc")) (MyConstructor (mkTyCon "Zero"))
-            )
-      it "type Nat = Zero | Suc Nat in Suc Suc Zero" $ do
-        result <- eval stdLib "type Nat = Zero | Suc Nat in Suc Suc Zero"
+        result <- eval' stdLib "type Nat = Zero | Suc Nat in Suc Zero"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Nat") [],
               MyConsApp
-                (MyConstructor (mkTyCon "Suc"))
-                ( MyConsApp (MyConstructor (mkTyCon "Suc")) (MyConstructor (mkTyCon "Zero"))
+                mempty
+                (MyConstructor mempty (mkTyCon "Suc"))
+                (MyConstructor mempty (mkTyCon "Zero"))
+            )
+      it "type Nat = Zero | Suc Nat in Suc Suc Zero" $ do
+        result <- eval' stdLib "type Nat = Zero | Suc Nat in Suc Suc Zero"
+        result
+          `shouldBe` Right
+            ( MTData (mkTyCon "Nat") [],
+              MyConsApp
+                mempty
+                (MyConstructor mempty (mkTyCon "Suc"))
+                ( MyConsApp
+                    mempty
+                    (MyConstructor mempty (mkTyCon "Suc"))
+                    (MyConstructor mempty (mkTyCon "Zero"))
                 )
             )
       it "type Nat = Zero | Suc Nat in Suc 1" $ do
-        result <- eval stdLib "type Nat = Zero | Suc Nat in Suc 1"
+        result <- eval' stdLib "type Nat = Zero | Suc Nat in Suc 1"
         result
           `shouldSatisfy` isLeft
       it "type Nat = Zero | Suc Nat in Suc Dog" $ do
-        result <- eval stdLib "type Nat = Zero | Suc Nat in Suc Dog"
+        result <- eval' stdLib "type Nat = Zero | Suc Nat in Suc Dog"
         result
           `shouldSatisfy` isLeft
       it "type Nat = Zero | Suc Nat in Suc" $ do
-        result <- eval stdLib "type Nat = Zero | Suc Nat in Suc"
+        result <- eval' stdLib "type Nat = Zero | Suc Nat in Suc"
         result
           `shouldBe` Right
             ( MTFunction
                 (MTData (mkTyCon "Nat") [])
                 (MTData (mkTyCon "Nat") []),
-              MyConstructor (mkTyCon "Suc")
+              MyConstructor mempty (mkTyCon "Suc")
             )
       it "type OhNat = Zero | Suc OhNat String in Suc" $ do
-        result <- eval stdLib "type OhNat = Zero | Suc OhNat String in Suc"
+        result <- eval' stdLib "type OhNat = Zero | Suc OhNat String in Suc"
         result
           `shouldBe` Right
             ( MTFunction
@@ -173,23 +192,26 @@ spec =
                     MTString
                     (MTData (mkTyCon "OhNat") [])
                 ),
-              MyConstructor (mkTyCon "Suc")
+              MyConstructor mempty (mkTyCon "Suc")
             )
       it "type Pet = Cat String | Dog String in Cat \"mimsa\"" $ do
-        result <- eval stdLib "type Pet = Cat String | Dog String in Cat \"mimsa\""
+        result <- eval' stdLib "type Pet = Cat String | Dog String in Cat \"mimsa\""
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Pet") [],
-              MyConsApp (MyConstructor (mkTyCon "Cat")) (str' "mimsa")
+              MyConsApp
+                mempty
+                (MyConstructor mempty (mkTyCon "Cat"))
+                (str' "mimsa")
             )
       it "type Void in 1" $ do
-        result <- eval stdLib "type Void in 1"
+        result <- eval' stdLib "type Void in 1"
         result `shouldBe` Right (MTInt, int 1)
       it "type String = Should | Error in Error" $ do
-        result <- eval stdLib "type String = Should | Error in Error"
+        result <- eval' stdLib "type String = Should | Error in Error"
         result `shouldSatisfy` isLeft
       it "type LongBoy = Stuff String Int String in Stuff \"yes\"" $ do
-        result <- eval stdLib "type LongBoy = Stuff String Int String in Stuff \"yes\""
+        result <- eval' stdLib "type LongBoy = Stuff String Int String in Stuff \"yes\""
         result
           `shouldBe` Right
             ( MTFunction
@@ -199,118 +221,130 @@ spec =
                     (MTData (mkTyCon "LongBoy") [])
                 ),
               MyConsApp
-                (MyConstructor (mkTyCon "Stuff"))
+                mempty
+                (MyConstructor mempty (mkTyCon "Stuff"))
                 (str' "yes")
             )
       it "type Tree = Leaf Int | Branch Tree Tree in Branch (Leaf 1) (Leaf 2)" $ do
-        result <- eval stdLib "type Tree = Leaf Int | Branch Tree Tree in Branch (Leaf 1) (Leaf 2)"
+        result <- eval' stdLib "type Tree = Leaf Int | Branch Tree Tree in Branch (Leaf 1) (Leaf 2)"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Tree") [],
               MyConsApp
+                mempty
                 ( MyConsApp
-                    (MyConstructor $ mkTyCon "Branch")
-                    (MyConsApp (MyConstructor $ mkTyCon "Leaf") (int 1))
+                    mempty
+                    (MyConstructor mempty $ mkTyCon "Branch")
+                    (MyConsApp mempty (MyConstructor mempty $ mkTyCon "Leaf") (int 1))
                 )
-                (MyConsApp (MyConstructor $ mkTyCon "Leaf") (int 2))
+                (MyConsApp mempty (MyConstructor mempty $ mkTyCon "Leaf") (int 2))
             )
       it "type Maybe a = Just a | Nothing in Just" $ do
-        result <- eval stdLib "type Maybe a = Just a | Nothing in Just"
+        result <- eval' stdLib "type Maybe a = Just a | Nothing in Just"
         result
           `shouldBe` Right
             ( MTFunction
                 (MTVar (NumberedVar 1))
                 (MTData (mkTyCon "Maybe") [MTVar (NumberedVar 1)]),
-              MyConstructor $ mkTyCon "Just"
+              MyConstructor mempty $ mkTyCon "Just"
             )
       it "type Maybe a = Just a | Nothing in Nothing" $ do
-        result <- eval stdLib "type Maybe a = Just a | Nothing in Nothing"
+        result <- eval' stdLib "type Maybe a = Just a | Nothing in Nothing"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Maybe") [MTVar (NumberedVar 1)],
-              MyConstructor $ mkTyCon "Nothing"
+              MyConstructor mempty $ mkTyCon "Nothing"
             )
       it "type Maybe a = Just a | Nothing in Just 1" $ do
-        result <- eval stdLib "type Maybe a = Just a | Nothing in Just 1"
+        result <- eval' stdLib "type Maybe a = Just a | Nothing in Just 1"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Maybe") [MTInt],
-              MyConsApp (MyConstructor $ mkTyCon "Just") (int 1)
+              MyConsApp
+                mempty
+                (MyConstructor mempty $ mkTyCon "Just")
+                (int 1)
             )
       it "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | Nothing False" $ do
-        result <- eval stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | Nothing False"
+        result <- eval' stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | Nothing False"
         result
           `shouldBe` Right
             (MTBool, bool False)
       it "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> True | Nothing 1" $ do
-        result <- eval stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> True | Nothing 1"
+        result <- eval' stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> True | Nothing 1"
         result `shouldSatisfy` isLeft
       it "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | otherwise False" $ do
-        result <- eval stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | otherwise False"
+        result <- eval' stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | otherwise False"
         result
           `shouldBe` Right
             (MTBool, bool False)
       it "type Stuff = Thing String Int in case Thing \"Hello\" 1 of Thing \\name -> \\num -> name" $ do
-        result <- eval stdLib "type Stuff = Thing String Int in case Thing \"Hello\" 1 of Thing \\name -> \\num -> name"
+        result <- eval' stdLib "type Stuff = Thing String Int in case Thing \"Hello\" 1 of Thing \\name -> \\num -> name"
         result
           `shouldBe` Right
             (MTString, str' "Hello")
       it "type Result e a = Failure e | Success a in case Failure \"oh no\" of Success \\a -> \"oh yes\" | Failure \\e -> e" $ do
-        result <- eval stdLib "type Result e a = Failure e | Success a in case Failure \"oh no\" of Success \\a -> \"oh yes\" | Failure \\e -> e"
+        result <- eval' stdLib "type Result e a = Failure e | Success a in case Failure \"oh no\" of Success \\a -> \"oh yes\" | Failure \\e -> e"
         result
           `shouldBe` Right
             (MTString, str' "oh no")
       it "type Blap a = Boop a Int in case Boop True 100 of Boop \\a -> \\b -> a" $ do
-        result <- eval stdLib "type Blap a = Boop a Int in case Boop True 100 of Boop \\a -> \\b -> a"
+        result <- eval' stdLib "type Blap a = Boop a Int in case Boop True 100 of Boop \\a -> \\b -> a"
         result `shouldBe` Right (MTBool, bool True)
       it "type Maybe a = Just a | Nothing in case Nothing of Nothing False" $ do
-        result <- eval stdLib "type Maybe a = Just a | Nothing in case Nothing of Nothing False"
+        result <- eval' stdLib "type Maybe a = Just a | Nothing in case Nothing of Nothing False"
         result `shouldSatisfy` isLeft
       it "type Thing = Thing String in let a = Thing \"string\" in case a of Thing \\s -> s" $ do
-        result <- eval stdLib "type Thing = Thing String in let a = Thing \"string\" in case a of Thing \\s -> s"
+        result <- eval' stdLib "type Thing = Thing String in let a = Thing \"string\" in case a of Thing \\s -> s"
         result `shouldBe` Right (MTString, str' "string")
       it "type Pair a b = Pair a b in case Pair \"dog\" 1 of Pair \a -> a" $ do
-        result <- eval stdLib "type Pair a b = Pair a b in case Pair \"dog\" 1 of Pair \a -> a"
+        result <- eval' stdLib "type Pair a b = Pair a b in case Pair \"dog\" 1 of Pair \a -> a"
         result `shouldSatisfy` isLeft
       it "type Tree a = Leaf a | Branch (Tree a) (Tree a) in Leaf 1" $ do
-        result <- eval stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree a) in Leaf 1"
-        result
-          `shouldBe` Right
-            ( MTData (mkTyCon "Tree") [MTInt],
-              MyConsApp (MyConstructor $ mkTyCon "Leaf") (int 1)
-            )
-      it "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Leaf 1" $ do
-        result <- eval stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Leaf 1"
-        result
-          `shouldSatisfy` isLeft
-      it "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Branch (Leaf 1) (Leaf True)" $ do
-        result <- eval stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Branch (Leaf 1) (Leaf True)"
-        result
-          `shouldSatisfy` isLeft
-      it "type Tree a = Empty | Branch (Tree a) a (Tree a) in Branch (Empty) 1 (Empty)" $ do
-        result <- eval stdLib "type Tree a = Empty | Branch (Tree a) a (Tree a) in Branch (Empty) 1 (Empty)"
+        result <- eval' stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree a) in Leaf 1"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Tree") [MTInt],
               MyConsApp
+                mempty
+                (MyConstructor mempty $ mkTyCon "Leaf")
+                (int 1)
+            )
+      it "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Leaf 1" $ do
+        result <- eval' stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Leaf 1"
+        result
+          `shouldSatisfy` isLeft
+      it "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Branch (Leaf 1) (Leaf True)" $ do
+        result <- eval' stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Branch (Leaf 1) (Leaf True)"
+        result
+          `shouldSatisfy` isLeft
+      it "type Tree a = Empty | Branch (Tree a) a (Tree a) in Branch (Empty) 1 (Empty)" $ do
+        result <- eval' stdLib "type Tree a = Empty | Branch (Tree a) a (Tree a) in Branch (Empty) 1 (Empty)"
+        result
+          `shouldBe` Right
+            ( MTData (mkTyCon "Tree") [MTInt],
+              MyConsApp
+                mempty
                 ( MyConsApp
+                    mempty
                     ( MyConsApp
-                        (MyConstructor $ mkTyCon "Branch")
-                        (MyConstructor $ mkTyCon "Empty")
+                        mempty
+                        (MyConstructor mempty $ mkTyCon "Branch")
+                        (MyConstructor mempty $ mkTyCon "Empty")
                     )
                     (int 1)
                 )
-                (MyConstructor $ mkTyCon "Empty")
+                (MyConstructor mempty $ mkTyCon "Empty")
             )
       it "type Maybe a = Just a | Nothing in case Just True of Just \\a -> a | Nothing \"what\"" $ do
-        result <- eval stdLib "type Maybe a = Just a | Nothing in case Just True of Just \\a -> a | Nothing \"what\""
+        result <- eval' stdLib "type Maybe a = Just a | Nothing in case Just True of Just \\a -> a | Nothing \"what\""
         result `shouldSatisfy` isLeft
       it "type Either e a = Left e | Right a in \\f -> \\g -> \\either -> case either of Left \\e -> g(e) | Right \\a -> f(a)" $ do
-        result <- eval stdLib "type Either e a = Left e | Right a in \\f -> \\g -> \\either -> case either of Left \\e -> g(e) | Right \\a -> f(a)"
+        result <- eval' stdLib "type Either e a = Left e | Right a in \\f -> \\g -> \\either -> case either of Left \\e -> g(e) | Right \\a -> f(a)"
         result `shouldSatisfy` isRight
       {-
             it "type Maybe a = Just a | Nothing in \\maybe -> case maybe of Just \\a -> a | Nothing \"poo\"" $ do
-              result <- eval stdLib "type Maybe a = Just a | Nothing in \\maybe -> case maybe of Just \\a -> a | Nothing \"poo\""
+              result <- eval' stdLib "type Maybe a = Just a | Nothing in \\maybe -> case maybe of Just \\a -> a | Nothing \"poo\""
               fst <$> result
                 `shouldBe` Right
                   ( MTFunction (MTData (mkTyCon "Maybe") []) MTString
@@ -318,60 +352,64 @@ spec =
       
       -}
       it "type Arr a = Empty | Item a (Arr a) in case (Item 1 (Item 2 Empty)) of Empty Empty | Item \\a -> \\rest -> rest" $ do
-        result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in case (Item 1 (Item 2 Empty)) of Empty Empty | Item \\a -> \\rest -> rest"
+        result <- eval' stdLib "type Arr a = Empty | Item a (Arr a) in case (Item 1 (Item 2 Empty)) of Empty Empty | Item \\a -> \\rest -> rest"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Arr") [MTInt],
               MyConsApp
+                mempty
                 ( MyConsApp
+                    mempty
                     ( MyConstructor
+                        mempty
                         (mkTyCon "Item")
                     )
                     (int 2)
                 )
-                (MyConstructor $ mkTyCon "Empty")
+                (MyConstructor mempty $ mkTyCon "Empty")
             )
       it "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)" $ do
-        result <- eval stdLib "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)"
+        result <- eval' stdLib "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)"
         result `shouldBe` Right (MTInt, int 10)
       it "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Suc Suc Zero)" $ do
-        result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Suc Suc Zero)"
+        result <- eval' stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Suc Suc Zero)"
         result `shouldBe` Right (MTInt, int 3)
       it "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> incrementInt(loop(as2)(b))) in loop(Suc Suc Suc Zero)(10)" $ do
-        result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> incrementInt(loop(as2)(b))) in loop(Suc Suc Suc Zero)(10)"
+        result <- eval' stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> incrementInt(loop(as2)(b))) in loop(Suc Suc Suc Zero)(10)"
         result `shouldBe` Right (MTInt, int 13)
       {-
             it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)" $ do
-              result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)"
+              result <- eval' stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)"
               result `shouldBe` Right (MTInt, int 3)
       -}
       it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty)" $ do
-        result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty)"
+        result <- eval' stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty)"
         result `shouldBe` Right (MTInt, int 0)
       it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Item 3 Empty)" $ do
-        result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Item 3 Empty)"
+        result <- eval' stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Item 3 Empty)"
         result `shouldBe` Right (MTInt, int 3)
       it "let some = \\a -> Some a in if True then some(1) else Nowt" $ do
-        result <- eval stdLib "let some = \\a -> Some a in if True then some(1) else Nowt"
+        result <- eval' stdLib "let some = \\a -> Some a in if True then some(1) else Nowt"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Option") [MTInt],
               MyConsApp
-                (MyConstructor (mkTyCon "Some"))
+                mempty
+                (MyConstructor mempty (mkTyCon "Some"))
                 (int 1)
             )
       it "\\a -> case a of Some \\as -> True | Nowt 100" $ do
-        result <- eval stdLib "\\a -> case a of Some \\as -> True | Nowt 100"
+        result <- eval' stdLib "\\a -> case a of Some \\as -> True | Nowt 100"
         fst <$> result
           `shouldSatisfy` isLeft
       it "\\a -> case a of Some \\as -> as | Nowt 100" $ do
-        result <- eval stdLib "\\a -> case a of Some \\as -> as | Nowt 100"
+        result <- eval' stdLib "\\a -> case a of Some \\as -> as | Nowt 100"
         fst <$> result
           `shouldBe` Right
             (MTFunction (MTData (mkTyCon "Option") [MTInt]) MTInt)
       it "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some 1)" $ do
-        result <- eval stdLib "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some 1)"
+        result <- eval' stdLib "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some 1)"
         result `shouldSatisfy` isLeft
       it "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some \"Dog\")" $ do
-        result <- eval stdLib "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some \"Dog\")"
+        result <- eval' stdLib "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some \"Dog\")"
         result `shouldBe` Right (MTString, str' "Dog")

--- a/test/Test/Substitutor.hs
+++ b/test/Test/Substitutor.hs
@@ -13,24 +13,27 @@ import Test.Data.Project
 import Test.Helpers
 import Test.Hspec
 
-trueStoreExpr :: StoreExpression
-trueStoreExpr = StoreExpression (bool True) mempty mempty
+trueStoreExpr :: Monoid ann => StoreExpression ann
+trueStoreExpr =
+  StoreExpression (bool True) mempty mempty
 
-falseStoreExpr :: StoreExpression
+falseStoreExpr :: Monoid ann => StoreExpression ann
 falseStoreExpr =
   StoreExpression
-    (MyVar (mkName "true"))
+    (MyVar mempty (mkName "true"))
     (Bindings $ M.singleton (mkName "true") (ExprHash 1))
     mempty
 
-constExpr :: StoreExpression
+constExpr :: Monoid ann => StoreExpression ann
 constExpr =
   StoreExpression
     ( MyLambda
+        mempty
         (mkName "a")
         ( MyLambda
+            mempty
             (mkName "b")
-            (MyVar (mkName "a"))
+            (MyVar mempty (mkName "a"))
         )
     )
     mempty
@@ -46,17 +49,18 @@ maybeDecl =
           (mkTyCon "Nothing", [])
         ]
 
-maybeExpr :: StoreExpression
+maybeExpr :: Monoid ann => StoreExpression ann
 maybeExpr =
   StoreExpression
     ( MyData
+        mempty
         maybeDecl
-        (MyRecord mempty)
+        (MyRecord mempty mempty)
     )
     mempty
     mempty
 
-storeWithBothIn :: Store
+storeWithBothIn :: (Monoid ann, Show ann) => Store ann
 storeWithBothIn =
   Store
     ( M.fromList
@@ -71,106 +75,115 @@ storeWithBothIn =
 spec :: Spec
 spec = do
   describe "Substitutor" $ do
-    describe "No deps, no problem" $
-      it "Just unwraps everything" $
-        do
-          let ans = substitute mempty trueStoreExpr
-          seSwaps ans `shouldBe` mempty
-          seExpr ans `shouldBe` bool True
-          seScope ans `shouldBe` mempty
-    describe "Leaves lambda variable alone" $
-      it "Leaves x unchanged" $
-        do
-          let expr = MyLambda (mkName "x") (MyVar (mkName "x"))
-              expected = MyLambda (named "x") (MyVar (named "x"))
-              ans = substitute mempty (StoreExpression expr mempty mempty)
-          ans `shouldBe` SubstitutedExpression mempty expected mempty
-    describe "Leaves built-ins alone" $
-      it "Leaves randomInt unchanged" $
-        do
-          let expr = MyVar (mkName "randomInt")
-              expected = MyVar (BuiltIn (mkName "randomInt"))
-              ans = substitute mempty (StoreExpression expr mempty mempty)
-          ans `shouldBe` SubstitutedExpression mempty expected mempty
-    describe "One level of dep" $
-      it "Renames the dep to var0" $
-        do
-          let hash = ExprHash 1
-              expr = MyVar (Name "exciting")
-              bindings' = Bindings $ M.singleton (Name "exciting") hash
-              storeExpr = StoreExpression expr bindings' mempty
-              store' = Store (M.singleton hash trueStoreExpr)
-              ans = substitute store' storeExpr
-          seSwaps ans
-            `shouldBe` M.singleton (NumberedVar 0) (Name "exciting")
-          seExpr ans
-            `shouldBe` MyVar (NumberedVar 0)
-          seScope ans
-            `shouldBe` Scope (M.singleton (NumberedVar 0) (bool True))
-    describe "Only creates one new var if a function is used twice" $
-      it "let id = \\x -> x in { first: id(1), second: id(2) }" $
-        do
-          let hash = ExprHash 3
-              expr =
-                MyRecord $
-                  M.fromList
-                    [ (mkName "first", MyApp (MyVar (mkName "id")) (int 1)),
-                      (mkName "second", MyApp (MyVar (mkName "id")) (int 2))
-                    ]
-              bindings' = Bindings $ M.singleton (mkName "id") hash
-              storeExpr = StoreExpression expr bindings' mempty
-              store' = Store (M.singleton hash idExpr)
-              expectedId = MyLambda (named "i") (MyVar (named "i"))
-          let ans = substitute store' storeExpr
-          seSwaps ans
-            `shouldBe` M.fromList
-              [ (NumberedVar 0, Name "id")
-              ]
-          seExpr ans
-            `shouldBe` MyRecord
-              ( M.fromList
-                  [ (mkName "first", MyApp (MyVar (NumberedVar 0)) (int 1)),
-                    (mkName "second", MyApp (MyVar (NumberedVar 0)) (int 2))
-                  ]
-              )
-          seScope ans
-            `shouldBe` Scope
-              ( M.fromList
-                  [ (NumberedVar 0, expectedId)
-                  ]
-              )
-  describe "Combine two levels" $
-    it "Combines trueStoreExpr and falseStoreExpr" $
-      do
-        let hash = ExprHash 2
-            expr = MyVar (mkName "true")
-            bindings' = Bindings (M.singleton (mkName "true") hash)
+    describe "No deps, no problem"
+      $ it "Just unwraps everything"
+      $ do
+        let ans = substitute mempty trueStoreExpr
+        seSwaps ans `shouldBe` mempty
+        seExpr ans `shouldBe` bool True
+        seScope ans `shouldBe` mempty
+    describe "Leaves lambda variable alone"
+      $ it "Leaves x unchanged"
+      $ do
+        let expr =
+              MyLambda
+                mempty
+                (mkName "x")
+                (MyVar mempty (mkName "x"))
+            expected =
+              MyLambda
+                mempty
+                (named "x")
+                (MyVar mempty (named "x"))
+            ans = substitute mempty (StoreExpression expr mempty mempty)
+        ans `shouldBe` SubstitutedExpression mempty expected mempty
+    describe "Leaves built-ins alone"
+      $ it "Leaves randomInt unchanged"
+      $ do
+        let expr = MyVar mempty (mkName "randomInt")
+            expected = MyVar mempty (BuiltIn (mkName "randomInt"))
+            ans = substitute mempty (StoreExpression expr mempty mempty)
+        ans `shouldBe` SubstitutedExpression mempty expected mempty
+    describe "One level of dep"
+      $ it "Renames the dep to var0"
+      $ do
+        let hash = ExprHash 1
+            expr = MyVar mempty (Name "exciting")
+            bindings' = Bindings $ M.singleton (Name "exciting") hash
             storeExpr = StoreExpression expr bindings' mempty
-            store' = storeWithBothIn
+            store' = Store (M.singleton hash trueStoreExpr)
+            ans = substitute store' storeExpr
+        seSwaps ans
+          `shouldBe` M.singleton (NumberedVar 0) (Name "exciting")
+        seExpr ans
+          `shouldBe` MyVar mempty (NumberedVar 0)
+        seScope ans
+          `shouldBe` Scope (M.singleton (NumberedVar 0) (bool True))
+    describe "Only creates one new var if a function is used twice"
+      $ it "let id = \\x -> x in { first: id(1), second: id(2) }"
+      $ do
+        let hash = ExprHash 3
+            expr =
+              MyRecord mempty $
+                M.fromList
+                  [ (mkName "first", MyApp mempty (MyVar mempty (mkName "id")) (int 1)),
+                    (mkName "second", MyApp mempty (MyVar mempty (mkName "id")) (int 2))
+                  ]
+            bindings' = Bindings $ M.singleton (mkName "id") hash
+            storeExpr = StoreExpression expr bindings' mempty
+            store' = Store (M.singleton hash idExpr)
+            expectedId = MyLambda mempty (named "i") (MyVar mempty (named "i"))
         let ans = substitute store' storeExpr
         seSwaps ans
           `shouldBe` M.fromList
-            [ (NumberedVar 0, Name "true")
+            [ (NumberedVar 0, Name "id")
             ]
-        seExpr ans `shouldBe` MyVar (NumberedVar 0)
+        seExpr ans
+          `shouldBe` MyRecord
+            mempty
+            ( M.fromList
+                [ (mkName "first", MyApp mempty (MyVar mempty (NumberedVar 0)) (int 1)),
+                  (mkName "second", MyApp mempty (MyVar mempty (NumberedVar 0)) (int 2))
+                ]
+            )
         seScope ans
           `shouldBe` Scope
             ( M.fromList
-                [ (NumberedVar 0, bool True)
+                [ (NumberedVar 0, expectedId)
                 ]
             )
-  describe "Extracts types" $
-    it "Good job" $
-      do
-        let hash = ExprHash 5
-            expr = MyLiteral MyUnit
-            storeExpr =
-              StoreExpression
-                expr
-                mempty
-                (TypeBindings $ M.singleton (mkTyCon "Maybe") hash)
-            store' = storeWithBothIn
-            ans = substitute store' storeExpr
-        seSwaps ans `shouldBe` mempty
-        seExpr ans `shouldBe` MyData maybeDecl (MyLiteral MyUnit)
-        seScope ans `shouldBe` mempty
+  describe "Combine two levels"
+    $ it "Combines trueStoreExpr and falseStoreExpr"
+    $ do
+      let hash = ExprHash 2
+          expr = MyVar mempty (mkName "true")
+          bindings' = Bindings (M.singleton (mkName "true") hash)
+          storeExpr = StoreExpression expr bindings' mempty
+          store' = storeWithBothIn
+      let ans = substitute store' storeExpr
+      seSwaps ans
+        `shouldBe` M.fromList
+          [ (NumberedVar 0, Name "true")
+          ]
+      seExpr ans `shouldBe` MyVar mempty (NumberedVar 0)
+      seScope ans
+        `shouldBe` Scope
+          ( M.fromList
+              [ (NumberedVar 0, bool True)
+              ]
+          )
+  describe "Extracts types"
+    $ it "Good job"
+    $ do
+      let hash = ExprHash 5
+          expr = MyLiteral mempty MyUnit
+          storeExpr =
+            StoreExpression
+              expr
+              mempty
+              (TypeBindings $ M.singleton (mkTyCon "Maybe") hash)
+          store' = storeWithBothIn
+          ans = substitute store' storeExpr
+      seSwaps ans `shouldBe` mempty
+      seExpr ans `shouldBe` MyData mempty maybeDecl (MyLiteral mempty MyUnit)
+      seScope ans `shouldBe` mempty

--- a/test/Test/Unify.hs
+++ b/test/Test/Unify.hs
@@ -15,7 +15,7 @@ import Language.Mimsa.Types
 import Test.Helpers
 import Test.Hspec
 
-runUnifier :: (MonoType, MonoType) -> Either TypeError Substitutions
+runUnifier :: (MonoType, MonoType) -> Either (TypeError ()) Substitutions
 runUnifier (a, b) =
   fst either'
   where

--- a/test/Test/Usages.hs
+++ b/test/Test/Usages.hs
@@ -17,4 +17,4 @@ spec =
     it "Returns empty when passed nothing" $
       findUsages mempty (ExprHash 6) `shouldBe` Right mempty
     it "Finds all uses of Compose in Stdlib" $
-      findUsages stdLib (ExprHash 6) `shouldBe` Right mempty
+      findUsages (stdLib :: Project ()) (ExprHash 6) `shouldBe` Right mempty


### PR DESCRIPTION
Before we can have nice type errors we need to store more information in the `Expr` type about where in the source code they came from. This will be done when there is an unused variable in `Expr` and things still work as they were.