### PR TITLE
Encode line positions in Expr for better type errors

### DIFF
--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 256fe1caf18b5762ed37a2117cd6f0d3ab4e089efb6347919b8a651897a4e88d
+-- hash: 12a9d2cab3de88cda27f0c39fdaec430459cedab8e03e694d1ce91aaa8c55331
 
 name:           mimsa
 version:        0.1.0.0
@@ -39,7 +39,13 @@ library
       Language.Mimsa.Library
       Language.Mimsa.Logging
       Language.Mimsa.Parser
+      Language.Mimsa.Parser.Helpers
+      Language.Mimsa.Parser.Identifiers
       Language.Mimsa.Parser.Language
+      Language.Mimsa.Parser.Literal
+      Language.Mimsa.Parser.RecordAccess
+      Language.Mimsa.Parser.TypeDecl
+      Language.Mimsa.Parser.Types
       Language.Mimsa.Printer
       Language.Mimsa.Project
       Language.Mimsa.Project.Default

--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4b2a3f5993d44d7cb94e6ec94e883d672e889bba0bd2d0dfa9c41aedb0b7b11a
+-- hash: 6520c4c092e23ec39ece981391487d48f838d83f3a785eff9d8ede4f66651d7e
 
 name:           mimsa
 version:        0.1.0.0
@@ -74,6 +74,7 @@ library
       Language.Mimsa.Tui.Styles
       Language.Mimsa.Typechecker
       Language.Mimsa.Typechecker.DataTypes
+      Language.Mimsa.Typechecker.DisplayError
       Language.Mimsa.Typechecker.Environment
       Language.Mimsa.Typechecker.Generalise
       Language.Mimsa.Typechecker.Infer

--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 12a9d2cab3de88cda27f0c39fdaec430459cedab8e03e694d1ce91aaa8c55331
+-- hash: 4b2a3f5993d44d7cb94e6ec94e883d672e889bba0bd2d0dfa9c41aedb0b7b11a
 
 name:           mimsa
 version:        0.1.0.0
@@ -194,6 +194,7 @@ test-suite mimsa-test
       Test.Substitutor
       Test.Syntax
       Test.Typechecker
+      Test.TypeError
       Test.Unify
       Test.Usages
       Paths_mimsa

--- a/src/Language/Mimsa.hs
+++ b/src/Language/Mimsa.hs
@@ -2,7 +2,7 @@ module Language.Mimsa
   ( startInference,
     doInference,
     Expr (..),
-    MonoType (..),
+    MonoType,
     Name,
     mkName,
     StringType (..),

--- a/src/Language/Mimsa/Actions.hs
+++ b/src/Language/Mimsa/Actions.hs
@@ -111,10 +111,9 @@ resolveStoreExpression store' storeExpr = do
   pure (ResolvedExpression exprType storeExpr newExpr scope swaps)
 
 getTypecheckedStoreExpression ::
-  (Monoid ann, Eq ann) =>
-  Project ann ->
-  Expr Name ann ->
-  Either (Error ann) (ResolvedExpression ann)
+  Project Annotation ->
+  Expr Name Annotation ->
+  Either (Error Annotation) (ResolvedExpression Annotation)
 getTypecheckedStoreExpression env expr = do
   storeExpr <-
     first ResolverErr $
@@ -125,10 +124,9 @@ getTypecheckedStoreExpression env expr = do
   resolveStoreExpression (store env) storeExpr
 
 evaluateText ::
-  (Eq ann, Monoid ann) =>
-  Project ann ->
+  Project Annotation ->
   Text ->
-  Either (Error ann) (ResolvedExpression ann)
+  Either (Error Annotation) (ResolvedExpression Annotation)
 evaluateText env input = do
   expr <- first OtherError $ parseExprAndFormatError input
   getTypecheckedStoreExpression env expr

--- a/src/Language/Mimsa/Backend/Backend.hs
+++ b/src/Language/Mimsa/Backend/Backend.hs
@@ -7,7 +7,6 @@ module Language.Mimsa.Backend.Backend
   )
 where
 
-import qualified Data.Aeson as JSON
 import Data.Coerce
 import Data.Foldable (traverse_)
 import qualified Data.Map as M
@@ -47,7 +46,7 @@ createOutputFolder = do
   createDirectoryIfMissing True path
   pure (path <> "/")
 
-transpileStoreExpression :: (JSON.ToJSON ann) => Backend -> StoreExpression ann -> IO FilePath
+transpileStoreExpression :: Backend -> StoreExpression ann -> IO FilePath
 transpileStoreExpression be se = do
   _ <- createOutputFolder
   let filename = outputFilename be (getStoreExpressionHash se)
@@ -78,7 +77,7 @@ getOutputList store' se = case recursiveResolve store' se of
   Right as -> S.fromList as
   Left _ -> mempty
 
-goCompile :: (Ord ann, JSON.ToJSON ann) => Backend -> Store ann -> StoreExpression ann -> IO ()
+goCompile :: (Ord ann) => Backend -> Store ann -> StoreExpression ann -> IO ()
 goCompile be store' se = do
   let list = getOutputList store' se
   traverse_ (transpileStoreExpression be) list

--- a/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -8,6 +8,7 @@ where
 -- let's run our code, at least for the repl
 -- run == simplify, essentially
 import Control.Monad.Except
+import Data.Functor
 import qualified Data.Map as M
 import Language.Mimsa.Interpreter.PatternMatch
 import Language.Mimsa.Interpreter.SwapName
@@ -107,7 +108,8 @@ interpretOperator Equals a b = do
   plainA <- interpretWithScope a
   plainB <- interpretWithScope b
   let respondWith = pure . MyLiteral mempty . MyBool
-  if plainA == plainB
+      removeAnn expr = expr $> ()
+  if removeAnn plainA == removeAnn plainB
     then respondWith True
     else respondWith False
 

--- a/src/Language/Mimsa/Library.hs
+++ b/src/Language/Mimsa/Library.hs
@@ -50,22 +50,22 @@ getLibraryFunction _ = Nothing
 
 logFn :: (Monoid ann) => ForeignFunc ann
 logFn =
-  let tyA = MTVar (NamedVar (Name "a"))
-   in OneArg (tyA, MTPrim MTUnit) logExpr
+  let tyA = MTVar mempty (NamedVar (Name "a"))
+   in OneArg (tyA, MTPrim mempty MTUnit) logExpr
   where
     logExpr i = do
       T.putStrLn (prettyPrint i)
       pure (MyLiteral mempty MyUnit)
 
 randomInt :: Monoid ann => ForeignFunc ann
-randomInt = NoArgs (MTPrim MTInt) action
+randomInt = NoArgs (MTPrim mempty MTInt) action
   where
     action = MyLiteral mempty . MyInt <$> randomIO
 
 randomIntFrom :: Monoid ann => ForeignFunc ann
 randomIntFrom =
   OneArg
-    (MTPrim MTInt, MTPrim MTInt)
+    (MTPrim mempty MTInt, MTPrim mempty MTInt)
     ( \(MyLiteral _ (MyInt i)) -> do
         val <- randomIO
         pure (MyLiteral mempty (MyInt (max val i)))
@@ -74,7 +74,7 @@ randomIntFrom =
 addIntPair :: Monoid ann => ForeignFunc ann
 addIntPair =
   OneArg
-    (MTPair (MTPrim MTInt) (MTPrim MTInt), MTPrim MTInt)
+    (MTPair mempty (MTPrim mempty MTInt) (MTPrim mempty MTInt), MTPrim mempty MTInt)
     ( \( MyPair
            _
            (MyLiteral _ (MyInt a))
@@ -84,4 +84,4 @@ addIntPair =
 
 getFFType :: ForeignFunc ann -> MonoType
 getFFType (NoArgs out _) = out
-getFFType (OneArg (in1, out) _) = MTFunction in1 out
+getFFType (OneArg (in1, out) _) = MTFunction mempty in1 out

--- a/src/Language/Mimsa/Library.hs
+++ b/src/Language/Mimsa/Library.hs
@@ -51,21 +51,21 @@ getLibraryFunction _ = Nothing
 logFn :: (Monoid ann) => ForeignFunc ann
 logFn =
   let tyA = MTVar (NamedVar (Name "a"))
-   in OneArg (tyA, MTUnit) logExpr
+   in OneArg (tyA, MTPrim MTUnit) logExpr
   where
     logExpr i = do
       T.putStrLn (prettyPrint i)
       pure (MyLiteral mempty MyUnit)
 
 randomInt :: Monoid ann => ForeignFunc ann
-randomInt = NoArgs MTInt action
+randomInt = NoArgs (MTPrim MTInt) action
   where
     action = MyLiteral mempty . MyInt <$> randomIO
 
 randomIntFrom :: Monoid ann => ForeignFunc ann
 randomIntFrom =
   OneArg
-    (MTInt, MTInt)
+    (MTPrim MTInt, MTPrim MTInt)
     ( \(MyLiteral _ (MyInt i)) -> do
         val <- randomIO
         pure (MyLiteral mempty (MyInt (max val i)))
@@ -74,7 +74,7 @@ randomIntFrom =
 addIntPair :: Monoid ann => ForeignFunc ann
 addIntPair =
   OneArg
-    (MTPair MTInt MTInt, MTInt)
+    (MTPair (MTPrim MTInt) (MTPrim MTInt), MTPrim MTInt)
     ( \( MyPair
            _
            (MyLiteral _ (MyInt a))

--- a/src/Language/Mimsa/Library.hs
+++ b/src/Language/Mimsa/Library.hs
@@ -24,7 +24,6 @@ libraryFunctions =
     M.fromList
       [ (FuncName "randomInt", randomInt),
         (FuncName "randomIntFrom", randomIntFrom),
-        (FuncName "eqPair", eqPair),
         (FuncName "log", logFn),
         (FuncName "addIntPair", addIntPair)
       ]
@@ -71,17 +70,6 @@ randomIntFrom =
         val <- randomIO
         pure (MyLiteral mempty (MyInt (max val i)))
     )
-
-eqPair :: (Eq ann, Monoid ann) => ForeignFunc ann
-eqPair =
-  let tyA = MTVar (NamedVar (Name "a"))
-   in OneArg
-        (MTPair tyA tyA, MTBool)
-        equality
-  where
-    equality pair' =
-      let (MyPair _ x y) = pair'
-       in pure $ MyLiteral mempty (MyBool (x == y))
 
 addIntPair :: Monoid ann => ForeignFunc ann
 addIntPair =

--- a/src/Language/Mimsa/Parser/Helpers.hs
+++ b/src/Language/Mimsa/Parser/Helpers.hs
@@ -7,17 +7,13 @@ import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import Language.Mimsa.Parser.Types
-import Language.Mimsa.Types.AST.Annotation
+import Language.Mimsa.Types.AST
 import Text.Megaparsec
 import Text.Megaparsec.Char
 
 -- run a parser and then run Megaparsec pretty printer on the error
 parseAndFormat :: Parser a -> Text -> Either Text a
 parseAndFormat p = first (T.pack . errorBundlePretty) . parse p "repl"
-
-getParserLocation :: Parser Annotation
-getParserLocation =
-  Location <$> getOffset
 
 -- looks for Parser a followed by 1 or more spaces
 thenSpace :: Parser a -> Parser a
@@ -34,6 +30,16 @@ between2 a b parser = do
   val <- parser
   _ <- char b
   pure val
+
+-----
+
+-- helper for adding location to a parser
+withLocation :: (Annotation -> a -> b) -> Parser a -> Parser b
+withLocation withP p = do
+  start <- getOffset
+  value <- p
+  end <- getOffset
+  pure (withP (Location start end) value)
 
 -----
 

--- a/src/Language/Mimsa/Parser/Helpers.hs
+++ b/src/Language/Mimsa/Parser/Helpers.hs
@@ -7,12 +7,17 @@ import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import Language.Mimsa.Parser.Types
+import Language.Mimsa.Types.AST.Annotation
 import Text.Megaparsec
 import Text.Megaparsec.Char
 
 -- run a parser and then run Megaparsec pretty printer on the error
 parseAndFormat :: Parser a -> Text -> Either Text a
 parseAndFormat p = first (T.pack . errorBundlePretty) . parse p "repl"
+
+getParserLocation :: Parser Annotation
+getParserLocation =
+  Location <$> getOffset
 
 -- looks for Parser a followed by 1 or more spaces
 thenSpace :: Parser a -> Parser a

--- a/src/Language/Mimsa/Parser/Helpers.hs
+++ b/src/Language/Mimsa/Parser/Helpers.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Parser.Helpers where
+
+import Data.Bifunctor (first)
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import Language.Mimsa.Parser.Types
+import Text.Megaparsec
+import Text.Megaparsec.Char
+
+-- run a parser and then run Megaparsec pretty printer on the error
+parseAndFormat :: Parser a -> Text -> Either Text a
+parseAndFormat p = first (T.pack . errorBundlePretty) . parse p "repl"
+
+-- looks for Parser a followed by 1 or more spaces
+thenSpace :: Parser a -> Parser a
+thenSpace parser = do
+  _ <- space
+  val <- parser
+  _ <- space1
+  pure val
+
+-- parses between two chars
+between2 :: Char -> Char -> Parser a -> Parser a
+between2 a b parser = do
+  _ <- char a
+  val <- parser
+  _ <- char b
+  pure val
+
+-----
+
+inBrackets :: Parser a -> Parser a
+inBrackets = between2 '(' ')'
+
+-----
+
+orInBrackets :: Parser a -> Parser a
+orInBrackets parser = try parser <|> try (inBrackets parser)
+
+-----
+
+maybePred :: (Show a) => Parser a -> (a -> Maybe b) -> Parser b
+maybePred parser predicate' = try $ do
+  a <- parser
+  case predicate' a of
+    Just b -> pure b
+    _ -> fail $ T.unpack $ "Predicate did not hold for " <> T.pack (show a)
+
+-----
+
+inProtected :: Text -> Maybe Text
+inProtected tx =
+  if S.member tx protectedNames
+    then Nothing
+    else Just tx
+
+---
+
+literalWithSpace :: Text -> Parser ()
+literalWithSpace tx = () <$ withOptionalSpace (string tx)
+
+withOptionalSpace :: Parser a -> Parser a
+withOptionalSpace p = do
+  _ <- space
+  a <- p
+  _ <- space
+  pure a
+-----

--- a/src/Language/Mimsa/Parser/Identifiers.hs
+++ b/src/Language/Mimsa/Parser/Identifiers.hs
@@ -25,10 +25,7 @@ import Text.Megaparsec
 ----
 
 varParser :: Parser ParserExpr
-varParser =
-  MyVar
-    <$> getParserLocation
-    <*> nameParser
+varParser = withLocation MyVar nameParser
 
 ---
 
@@ -44,7 +41,7 @@ nameParser =
 ---
 
 constructorParser :: Parser ParserExpr
-constructorParser = MyConstructor mempty <$> tyConParser
+constructorParser = withLocation MyConstructor tyConParser
 
 tyConParser :: Parser TyCon
 tyConParser =

--- a/src/Language/Mimsa/Parser/Identifiers.hs
+++ b/src/Language/Mimsa/Parser/Identifiers.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Parser.Identifiers
+  ( varParser,
+    nameParser,
+    tyConParser,
+    constructorParser,
+  )
+where
+
+import Control.Monad ((>=>))
+import Data.Char as Char
+import Data.Text (Text)
+import Language.Mimsa.Parser.Helpers
+import Language.Mimsa.Parser.Types
+import Language.Mimsa.Types
+  ( Name,
+    TyCon,
+    safeMkName,
+    safeMkTyCon,
+  )
+import Language.Mimsa.Types.AST
+import Text.Megaparsec
+
+----
+
+varParser :: Parser ParserExpr
+varParser = MyVar mempty <$> nameParser
+
+---
+
+identifier :: Parser Text
+identifier = takeWhile1P (Just "variable name") Char.isAlphaNum
+
+nameParser :: Parser Name
+nameParser =
+  maybePred
+    identifier
+    (inProtected >=> safeMkName)
+
+---
+
+constructorParser :: Parser ParserExpr
+constructorParser = MyConstructor mempty <$> tyConParser
+
+tyConParser :: Parser TyCon
+tyConParser =
+  maybePred
+    identifier
+    (inProtected >=> safeMkTyCon)
+-----

--- a/src/Language/Mimsa/Parser/Identifiers.hs
+++ b/src/Language/Mimsa/Parser/Identifiers.hs
@@ -25,7 +25,10 @@ import Text.Megaparsec
 ----
 
 varParser :: Parser ParserExpr
-varParser = MyVar mempty <$> nameParser
+varParser =
+  MyVar
+    <$> getParserLocation
+    <*> nameParser
 
 ---
 

--- a/src/Language/Mimsa/Parser/Literal.hs
+++ b/src/Language/Mimsa/Parser/Literal.hs
@@ -7,6 +7,7 @@ where
 
 import Data.Functor (($>))
 import qualified Data.Text as T
+import Language.Mimsa.Parser.Helpers
 import Language.Mimsa.Parser.Types
 import Language.Mimsa.Types.AST
 import Text.Megaparsec
@@ -28,23 +29,23 @@ integerParser = L.signed space L.decimal
 ---
 
 boolParser :: Parser ParserExpr
-boolParser = trueParser <|> falseParser
+boolParser = withLocation MyLiteral (trueParser <|> falseParser)
 
-trueParser :: Parser ParserExpr
-trueParser = string "True" $> MyLiteral mempty (MyBool True)
+trueParser :: Parser Literal
+trueParser = string "True" $> MyBool True
 
-falseParser :: Parser ParserExpr
-falseParser = string "False" $> MyLiteral mempty (MyBool False)
+falseParser :: Parser Literal
+falseParser = string "False" $> MyBool False
 
 -----
 
 unitParser :: Parser ParserExpr
-unitParser = string "Unit" $> MyLiteral mempty MyUnit
+unitParser = withLocation MyLiteral (string "Unit" $> MyUnit)
 
 -----
 
 intParser :: Parser ParserExpr
-intParser = MyLiteral mempty . MyInt <$> integerParser
+intParser = withLocation MyLiteral (MyInt <$> integerParser)
 
 -----
 
@@ -53,8 +54,11 @@ stringLiteral = char '\"' *> manyTill L.charLiteral (char '\"')
 
 stringParser :: Parser ParserExpr
 stringParser =
-  MyLiteral mempty . MyString
-    . StringType
-    . T.pack
-    <$> stringLiteral
+  withLocation
+    MyLiteral
+    ( MyString
+        . StringType
+        . T.pack
+        <$> stringLiteral
+    )
 -----

--- a/src/Language/Mimsa/Parser/Literal.hs
+++ b/src/Language/Mimsa/Parser/Literal.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Parser.Literal
+  ( literalParser,
+  )
+where
+
+import Data.Functor (($>))
+import qualified Data.Text as T
+import Language.Mimsa.Parser.Types
+import Language.Mimsa.Types.AST
+import Text.Megaparsec
+import Text.Megaparsec.Char
+import qualified Text.Megaparsec.Char.Lexer as L
+
+literalParser :: Parser ParserExpr
+literalParser =
+  try boolParser
+    <|> try unitParser
+    <|> try intParser
+    <|> try stringParser
+
+----
+
+integerParser :: Parser Int
+integerParser = L.signed space L.decimal
+
+---
+
+boolParser :: Parser ParserExpr
+boolParser = trueParser <|> falseParser
+
+trueParser :: Parser ParserExpr
+trueParser = string "True" $> MyLiteral mempty (MyBool True)
+
+falseParser :: Parser ParserExpr
+falseParser = string "False" $> MyLiteral mempty (MyBool False)
+
+-----
+
+unitParser :: Parser ParserExpr
+unitParser = string "Unit" $> MyLiteral mempty MyUnit
+
+-----
+
+intParser :: Parser ParserExpr
+intParser = MyLiteral mempty . MyInt <$> integerParser
+
+-----
+
+stringLiteral :: Parser String
+stringLiteral = char '\"' *> manyTill L.charLiteral (char '\"')
+
+stringParser :: Parser ParserExpr
+stringParser =
+  MyLiteral mempty . MyString
+    . StringType
+    . T.pack
+    <$> stringLiteral
+-----

--- a/src/Language/Mimsa/Parser/RecordAccess.hs
+++ b/src/Language/Mimsa/Parser/RecordAccess.hs
@@ -5,6 +5,7 @@ module Language.Mimsa.Parser.RecordAccess
   )
 where
 
+import Language.Mimsa.Parser.Helpers
 import Language.Mimsa.Parser.Identifiers
 import Language.Mimsa.Parser.Types
 import Language.Mimsa.Types (Name)
@@ -14,38 +15,14 @@ import Text.Megaparsec.Char
 
 recordAccessParser :: Parser ParserExpr
 recordAccessParser =
-  try recordAccessParser3
-    <|> try recordAccessParser2
-    <|> try recordAccessParser1
-
-recordAccessParser1 :: Parser ParserExpr
-recordAccessParser1 = do
-  expr <- varParser
-  name <- dotName
-  _ <- space
-  pure (MyRecordAccess mempty expr name)
+  let combine location (record, names) =
+        foldl (MyRecordAccess location) record names
+   in withLocation combine $ do
+        record <- varParser
+        names <- some (withOptionalSpace dotName)
+        pure (record, names)
 
 dotName :: Parser Name
 dotName = do
   _ <- string "."
   nameParser
-
-recordAccessParser2 :: Parser ParserExpr
-recordAccessParser2 = do
-  expr <- varParser
-  name <- dotName
-  name2 <- dotName
-  _ <- space
-  pure (MyRecordAccess mempty (MyRecordAccess mempty expr name) name2)
-
-recordAccessParser3 :: Parser ParserExpr
-recordAccessParser3 = do
-  expr <- varParser
-  _ <- string "."
-  name <- nameParser
-  _ <- string "."
-  name2 <- nameParser
-  _ <- string "."
-  name3 <- nameParser
-  _ <- space
-  pure (MyRecordAccess mempty (MyRecordAccess mempty (MyRecordAccess mempty expr name) name2) name3)

--- a/src/Language/Mimsa/Parser/RecordAccess.hs
+++ b/src/Language/Mimsa/Parser/RecordAccess.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Parser.RecordAccess
+  ( recordAccessParser,
+  )
+where
+
+import Language.Mimsa.Parser.Identifiers
+import Language.Mimsa.Parser.Types
+import Language.Mimsa.Types (Name)
+import Language.Mimsa.Types.AST
+import Text.Megaparsec
+import Text.Megaparsec.Char
+
+recordAccessParser :: Parser ParserExpr
+recordAccessParser =
+  try recordAccessParser3
+    <|> try recordAccessParser2
+    <|> try recordAccessParser1
+
+recordAccessParser1 :: Parser ParserExpr
+recordAccessParser1 = do
+  expr <- varParser
+  name <- dotName
+  _ <- space
+  pure (MyRecordAccess mempty expr name)
+
+dotName :: Parser Name
+dotName = do
+  _ <- string "."
+  nameParser
+
+recordAccessParser2 :: Parser ParserExpr
+recordAccessParser2 = do
+  expr <- varParser
+  name <- dotName
+  name2 <- dotName
+  _ <- space
+  pure (MyRecordAccess mempty (MyRecordAccess mempty expr name) name2)
+
+recordAccessParser3 :: Parser ParserExpr
+recordAccessParser3 = do
+  expr <- varParser
+  _ <- string "."
+  name <- nameParser
+  _ <- string "."
+  name2 <- nameParser
+  _ <- string "."
+  name3 <- nameParser
+  _ <- space
+  pure (MyRecordAccess mempty (MyRecordAccess mempty (MyRecordAccess mempty expr name) name2) name3)

--- a/src/Language/Mimsa/Parser/TypeDecl.hs
+++ b/src/Language/Mimsa/Parser/TypeDecl.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Parser.TypeDecl
+  ( typeDeclParser,
+  )
+where
+
+import Data.Map (Map)
+import qualified Data.Map as M
+import Language.Mimsa.Parser.Helpers
+import Language.Mimsa.Parser.Identifiers
+import Language.Mimsa.Parser.Types
+import Language.Mimsa.Types (TyCon, TypeName (..))
+import Language.Mimsa.Types.AST
+import Text.Megaparsec
+import Text.Megaparsec.Char
+
+typeDeclParser :: Parser DataType
+typeDeclParser =
+  try typeDeclParserWithCons
+    <|> try typeDeclParserEmpty
+
+-- it's your "type Void in ..."
+typeDeclParserEmpty :: Parser DataType
+typeDeclParserEmpty = do
+  _ <- thenSpace (string "type")
+  tyName <- tyConParser
+  pure (DataType tyName mempty mempty)
+
+-- it's your more complex cases
+typeDeclParserWithCons :: Parser DataType
+typeDeclParserWithCons = do
+  _ <- thenSpace (string "type")
+  tyName <- thenSpace tyConParser
+  tyArgs <- try $ many (thenSpace nameParser)
+  _ <- thenSpace (string "=")
+  constructors <-
+    try manyTypeConstructors
+      <|> try oneTypeConstructor
+  pure $ DataType tyName tyArgs constructors
+
+--------
+
+manyTypeConstructors :: Parser (Map TyCon [TypeName])
+manyTypeConstructors = do
+  tyCons <-
+    sepBy
+      (withOptionalSpace oneTypeConstructor)
+      (literalWithSpace "|")
+  pure (mconcat tyCons)
+
+-----
+
+oneTypeConstructor :: Parser (Map TyCon [TypeName])
+oneTypeConstructor = do
+  name <- tyConParser
+  args <-
+    try
+      ( do
+          _ <- space1
+          sepBy (withOptionalSpace typeNameParser) space
+      )
+      <|> pure mempty
+  pure (M.singleton name args)
+
+-----
+
+typeNameParser :: Parser TypeName
+typeNameParser =
+  try emptyConsParser
+    <|> try varNameParser
+    <|> try (inBrackets parameterisedConsParser)
+
+-- Simple type like String
+emptyConsParser :: Parser TypeName
+emptyConsParser = ConsName <$> tyConParser <*> pure mempty
+
+--
+parameterisedConsParser :: Parser TypeName
+parameterisedConsParser = do
+  c <- thenSpace tyConParser
+  params <- try (sepBy (withOptionalSpace typeNameParser) space1) <|> pure mempty
+  pure $ ConsName c params
+
+varNameParser :: Parser TypeName
+varNameParser = VarName <$> nameParser

--- a/src/Language/Mimsa/Parser/Types.hs
+++ b/src/Language/Mimsa/Parser/Types.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Parser.Types
+  ( Parser,
+    ParseErrorType,
+    ParserExpr,
+    protectedNames,
+  )
+where
+
+import Data.Set (Set)
+import qualified Data.Set as S
+import Data.Text (Text)
+import Data.Void
+import Language.Mimsa.Types (Name)
+import Language.Mimsa.Types.AST
+import Text.Megaparsec
+
+type Parser = Parsec Void Text
+
+type ParseErrorType = ParseErrorBundle Text Void
+
+type ParserExpr = Expr Name Annotation
+
+protectedNames :: Set Text
+protectedNames =
+  S.fromList
+    [ "let",
+      "in",
+      "if",
+      "then",
+      "else",
+      "case",
+      "of",
+      "type",
+      "otherwise",
+      "True",
+      "False",
+      "Unit"
+    ]

--- a/src/Language/Mimsa/Project/Persistence.hs
+++ b/src/Language/Mimsa/Project/Persistence.hs
@@ -29,11 +29,10 @@ hush :: Either IOError a -> Maybe a
 hush (Right a) = pure a
 hush _ = Nothing
 
-type LoadProject = Project ()
-
 -- load environment.json and any hashed exprs mentioned in it
 -- should probably consider loading the exprs lazily as required in future
-loadProject :: PersistApp LoadProject
+loadProject ::
+  PersistApp (Project ())
 loadProject = do
   project' <- liftIO $ try $ BS.readFile envPath
   case hush project' >>= JSON.decode of

--- a/src/Language/Mimsa/Project/Persistence.hs
+++ b/src/Language/Mimsa/Project/Persistence.hs
@@ -48,7 +48,7 @@ loadProject = do
       pure $ projectFromSaved (store' <> typeStore') sp
     _ -> throwError $ "Could not decode file at " <> T.pack envPath
 
-saveProject :: Project ann -> PersistApp ()
+saveProject :: Project () -> PersistApp ()
 saveProject env = do
   let jsonStr = JSON.encode (projectToSaved env)
   liftIO $ BS.writeFile envPath jsonStr
@@ -56,10 +56,9 @@ saveProject env = do
 --
 
 loadBoundExpressions ::
-  (JSON.ToJSON ann, JSON.FromJSON ann) =>
   [ServerUrl] ->
   Set ExprHash ->
-  PersistApp (Store ann)
+  PersistApp (Store ())
 loadBoundExpressions urls hashes = do
   items' <-
     traverse
@@ -72,10 +71,9 @@ loadBoundExpressions urls hashes = do
     (Store (M.fromList items'))
 
 recursiveLoadBoundExpressions ::
-  (JSON.ToJSON ann, JSON.FromJSON ann) =>
   [ServerUrl] ->
   Set ExprHash ->
-  PersistApp (Store ann)
+  PersistApp (Store ())
 recursiveLoadBoundExpressions urls hashes = do
   store' <- loadBoundExpressions urls hashes
   let newHashes =

--- a/src/Language/Mimsa/Project/Versions.hs
+++ b/src/Language/Mimsa/Project/Versions.hs
@@ -1,4 +1,10 @@
-module Language.Mimsa.Project.Versions (findVersions, findStoreExpressionByName) where
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Project.Versions
+  ( findVersions,
+    findStoreExpressionByName,
+  )
+where
 
 import Control.Monad.Except
 import Data.Bifunctor (first)
@@ -23,10 +29,9 @@ import Language.Mimsa.Types.VersionedMap
 -- find which versions of a given binding are in use
 
 findVersions ::
-  (Eq ann, Monoid ann) =>
-  Project ann ->
+  Project Annotation ->
   Name ->
-  Either (Error ann) (NonEmpty (Int, Expr Variable ann, MonoType, Set Usage))
+  Either (Error Annotation) (NonEmpty (Int, Expr Variable Annotation, MonoType, Set Usage))
 findVersions project name = do
   versioned <- first UsageErr (findInProject project name)
   as <- traverse (getExprDetails project) versioned
@@ -59,12 +64,14 @@ findStoreExpressionByName env name =
     _ -> Nothing
 
 getExprDetails ::
-  (Eq ann, Monoid ann) =>
-  Project ann ->
+  Project Annotation ->
   ExprHash ->
-  Either (Error ann) (Expr Variable ann, MonoType, Set Usage)
+  Either (Error Annotation) (Expr Variable Annotation, MonoType, Set Usage)
 getExprDetails project exprHash = do
-  usages <- first UsageErr (findUsages project exprHash)
-  storeExpr <- first UsageErr (getStoreExpression project exprHash)
-  (ResolvedExpression mt _ expr' _ _) <- resolveStoreExpression (store project) storeExpr
+  usages <-
+    first UsageErr (findUsages project exprHash)
+  storeExpr <-
+    first UsageErr (getStoreExpression project exprHash)
+  (ResolvedExpression mt _ expr' _ _) <-
+    resolveStoreExpression (store project) "" storeExpr
   pure (expr', mt, usages)

--- a/src/Language/Mimsa/Repl.hs
+++ b/src/Language/Mimsa/Repl.hs
@@ -35,7 +35,7 @@ repl = do
     _ -> do
       T.putStrLn "Failed to load project, loading default project"
       pure defaultProject
-  _ <- doReplAction env Help
+  _ <- doReplAction env "" Help
   runInputT defaultSettings (loop env)
   where
     loop ::
@@ -60,6 +60,6 @@ parseCommand env input =
       T.putStrLn e
       pure env
     Right replAction -> do
-      newExprs <- doReplAction env replAction
+      newExprs <- doReplAction env input replAction
       _ <- runExceptT $ saveProject newExprs
       pure newExprs

--- a/src/Language/Mimsa/Repl.hs
+++ b/src/Language/Mimsa/Repl.hs
@@ -57,5 +57,5 @@ parseCommand env input =
       pure env
     Right replAction -> do
       newExprs <- doReplAction env replAction
-      _ <- runExceptT $ saveProject newExprs
+      _ <- runExceptT $ saveProject (newExprs $> ())
       pure newExprs

--- a/src/Language/Mimsa/Repl/Actions.hs
+++ b/src/Language/Mimsa/Repl/Actions.hs
@@ -8,7 +8,6 @@ module Language.Mimsa.Repl.Actions
 where
 
 import Control.Monad.IO.Class (liftIO)
-import qualified Data.Aeson as JSON
 import Data.Bifunctor (first)
 import Data.Foldable (traverse_)
 import qualified Data.List.NonEmpty as NE

--- a/src/Language/Mimsa/Repl/Actions.hs
+++ b/src/Language/Mimsa/Repl/Actions.hs
@@ -34,16 +34,9 @@ import Language.Mimsa.Tui (goTui)
 import Language.Mimsa.Types
 
 doReplAction ::
-  ( JSON.ToJSON ann,
-    Eq ann,
-    Ord ann,
-    Monoid ann,
-    Printer ann,
-    Show ann
-  ) =>
-  Project ann ->
-  ReplAction ann ->
-  IO (Project ann)
+  Project Annotation ->
+  ReplAction Annotation ->
+  IO (Project Annotation)
 doReplAction env Help = do
   doHelp
   pure env
@@ -100,10 +93,9 @@ doHelp = do
 ----------
 
 doInfo ::
-  (Eq ann, Monoid ann) =>
-  Project ann ->
-  Expr Name ann ->
-  ReplM ann ()
+  Project Annotation ->
+  Expr Name Annotation ->
+  ReplM Annotation ()
 doInfo env expr = do
   (ResolvedExpression type' _ _ _ _) <- liftRepl $ getTypecheckedStoreExpression env expr
   replPrint $
@@ -114,10 +106,9 @@ doInfo env expr = do
 ----------
 
 doTree ::
-  (JSON.ToJSON ann, Eq ann, Monoid ann) =>
-  Project ann ->
-  Expr Name ann ->
-  ReplM ann ()
+  Project Annotation ->
+  Expr Name Annotation ->
+  ReplM Annotation ()
 doTree env expr = do
   (ResolvedExpression _ storeExpr _ _ _) <- liftRepl $ getTypecheckedStoreExpression env expr
   let graph = createDepGraph (mkName "expression") (store env) storeExpr
@@ -146,7 +137,7 @@ doVersions env name = do
 
 ------
 
-doListBindings :: (Eq ann, Monoid ann) => Project ann -> ReplM ann ()
+doListBindings :: Project Annotation -> ReplM Annotation ()
 doListBindings env = do
   let showBind (name, StoreExpression expr _ _) =
         case getTypecheckedStoreExpression env expr of
@@ -170,10 +161,9 @@ doListBindings env = do
 ----------
 
 doEvaluate ::
-  (Eq ann, Monoid ann) =>
-  Project ann ->
-  Expr Name ann ->
-  ReplM ann ()
+  Project Annotation ->
+  Expr Name Annotation ->
+  ReplM Annotation ()
 doEvaluate env expr = do
   (ResolvedExpression type' _ expr' scope' swaps) <-
     liftRepl $ getTypecheckedStoreExpression env expr
@@ -187,10 +177,9 @@ doEvaluate env expr = do
 ---------
 
 doOutputJS ::
-  (Eq ann, Ord ann, Monoid ann, JSON.ToJSON ann) =>
-  Project ann ->
-  Expr Name ann ->
-  ReplM ann ()
+  Project Annotation ->
+  Expr Name Annotation ->
+  ReplM Annotation ()
 doOutputJS env expr = do
   (ResolvedExpression _ storeExpr' _ _ _) <-
     liftRepl $ getTypecheckedStoreExpression env expr

--- a/src/Language/Mimsa/Repl/Actions.hs
+++ b/src/Language/Mimsa/Repl/Actions.hs
@@ -34,41 +34,42 @@ import Language.Mimsa.Types
 
 doReplAction ::
   Project Annotation ->
+  Text ->
   ReplAction Annotation ->
   IO (Project Annotation)
-doReplAction env Help = do
+doReplAction env _ Help = do
   doHelp
   pure env
-doReplAction env ListBindings = do
-  _ <- runReplM $ doListBindings env
+doReplAction env input ListBindings = do
+  _ <- runReplM $ doListBindings env input
   pure env
-doReplAction env Tui =
+doReplAction env _ Tui =
   goTui env
-doReplAction env (Versions name) = do
+doReplAction env _ (Versions name) = do
   _ <- runReplM $ doVersions env name
   pure env
-doReplAction env (Watch name) = do
+doReplAction env _ (Watch name) = do
   newEnv' <- runReplM $ doWatch env name
   case newEnv' of
     Just env' -> pure env'
     _ -> pure env
-doReplAction env (Evaluate expr) = do
-  _ <- runReplM $ doEvaluate env expr
+doReplAction env input (Evaluate expr) = do
+  _ <- runReplM $ doEvaluate env input expr
   pure env
-doReplAction env (Tree expr) = do
-  _ <- runReplM $ doTree env expr
+doReplAction env input (Tree expr) = do
+  _ <- runReplM $ doTree env input expr
   pure env
-doReplAction env (Info expr) = do
-  _ <- runReplM $ doInfo env expr
+doReplAction env input (Info expr) = do
+  _ <- runReplM $ doInfo env input expr
   pure env
-doReplAction env (Bind name expr) = do
-  newEnv <- runReplM $ doBind env name expr
+doReplAction env input (Bind name expr) = do
+  newEnv <- runReplM $ doBind env input name expr
   pure (fromMaybe env newEnv)
-doReplAction env (BindType dt) = do
-  newEnv <- runReplM $ doBindType env dt
+doReplAction env input (BindType dt) = do
+  newEnv <- runReplM $ doBindType env input dt
   pure (fromMaybe env newEnv)
-doReplAction env (OutputJS expr) = do
-  _ <- runReplM (doOutputJS env expr)
+doReplAction env input (OutputJS expr) = do
+  _ <- runReplM (doOutputJS env input expr)
   pure env
 
 ----------
@@ -93,10 +94,11 @@ doHelp = do
 
 doInfo ::
   Project Annotation ->
+  Text ->
   Expr Name Annotation ->
   ReplM Annotation ()
-doInfo env expr = do
-  (ResolvedExpression type' _ _ _ _) <- liftRepl $ getTypecheckedStoreExpression env expr
+doInfo env input expr = do
+  (ResolvedExpression type' _ _ _ _) <- liftRepl $ getTypecheckedStoreExpression input env expr
   replPrint $
     prettyPrint expr
       <> "/n:: "
@@ -106,16 +108,17 @@ doInfo env expr = do
 
 doTree ::
   Project Annotation ->
+  Text ->
   Expr Name Annotation ->
   ReplM Annotation ()
-doTree env expr = do
-  (ResolvedExpression _ storeExpr _ _ _) <- liftRepl $ getTypecheckedStoreExpression env expr
+doTree env input expr = do
+  (ResolvedExpression _ storeExpr _ _ _) <- liftRepl $ getTypecheckedStoreExpression input env expr
   let graph = createDepGraph (mkName "expression") (store env) storeExpr
   replPrint graph
 
 -------
 
-doVersions :: (Eq ann, Monoid ann) => Project ann -> Name -> ReplM ann ()
+doVersions :: Project Annotation -> Name -> ReplM Annotation ()
 doVersions env name = do
   versions <- liftRepl $ findVersions env name
   let showIt (i, mt, expr', usages) = do
@@ -136,10 +139,10 @@ doVersions env name = do
 
 ------
 
-doListBindings :: Project Annotation -> ReplM Annotation ()
-doListBindings env = do
+doListBindings :: Project Annotation -> Text -> ReplM Annotation ()
+doListBindings env input = do
   let showBind (name, StoreExpression expr _ _) =
-        case getTypecheckedStoreExpression env expr of
+        case getTypecheckedStoreExpression input env expr of
           Right (ResolvedExpression type' _ _ _ _) ->
             replPrint (prettyPrint name <> " :: " <> prettyPrint type')
           _ -> pure ()
@@ -161,11 +164,12 @@ doListBindings env = do
 
 doEvaluate ::
   Project Annotation ->
+  Text ->
   Expr Name Annotation ->
   ReplM Annotation ()
-doEvaluate env expr = do
+doEvaluate env input expr = do
   (ResolvedExpression type' _ expr' scope' swaps) <-
-    liftRepl $ getTypecheckedStoreExpression env expr
+    liftRepl $ getTypecheckedStoreExpression input env expr
   simplified <- liftIO $ interpret scope' swaps expr'
   simplified' <- liftRepl (first InterpreterErr simplified)
   replPrint $
@@ -177,10 +181,11 @@ doEvaluate env expr = do
 
 doOutputJS ::
   Project Annotation ->
+  Text ->
   Expr Name Annotation ->
   ReplM Annotation ()
-doOutputJS env expr = do
+doOutputJS env input expr = do
   (ResolvedExpression _ storeExpr' _ _ _) <-
-    liftRepl $ getTypecheckedStoreExpression env expr
+    liftRepl $ getTypecheckedStoreExpression input env expr
   liftIO $ goCompile CommonJS (store env) storeExpr'
   replPrint ("Output to output/index.js" :: Text)

--- a/src/Language/Mimsa/Repl/ExpressionBind.hs
+++ b/src/Language/Mimsa/Repl/ExpressionBind.hs
@@ -8,6 +8,7 @@ module Language.Mimsa.Repl.ExpressionBind
 where
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Text (Text)
 import Language.Mimsa.Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Repl.Types
@@ -16,11 +17,12 @@ import Language.Mimsa.Types
 
 doBind ::
   Project Annotation ->
+  Text ->
   Name ->
   Expr Name Annotation ->
   ReplM Annotation (Project Annotation)
-doBind env name expr = do
-  (ResolvedExpression type' storeExpr _ _ _) <- liftRepl $ getTypecheckedStoreExpression env expr
+doBind env input name expr = do
+  (ResolvedExpression type' storeExpr _ _ _) <- liftRepl $ getTypecheckedStoreExpression input env expr
   replPrint $
     "Bound " <> prettyPrint name <> ".\n\n" <> prettyPrint expr
       <> "\n::\n"
@@ -29,11 +31,12 @@ doBind env name expr = do
 
 doBindType ::
   Project Annotation ->
+  Text ->
   DataType ->
   ReplM Annotation (Project Annotation)
-doBindType env dt = do
+doBindType env input dt = do
   let expr = MyData mempty dt (MyRecord mempty mempty)
-  (ResolvedExpression _ storeExpr _ _ _) <- liftRepl $ getTypecheckedStoreExpression env expr
+  (ResolvedExpression _ storeExpr _ _ _) <- liftRepl $ getTypecheckedStoreExpression input env expr
   replPrint $
     "Bound type " <> prettyPrint dt
   bindTypeExpression env storeExpr

--- a/src/Language/Mimsa/Repl/ExpressionBind.hs
+++ b/src/Language/Mimsa/Repl/ExpressionBind.hs
@@ -16,11 +16,10 @@ import Language.Mimsa.Store (saveExpr)
 import Language.Mimsa.Types
 
 doBind ::
-  (Eq ann, Monoid ann, JSON.ToJSON ann) =>
-  Project ann ->
+  Project Annotation ->
   Name ->
-  Expr Name ann ->
-  ReplM ann (Project ann)
+  Expr Name Annotation ->
+  ReplM Annotation (Project Annotation)
 doBind env name expr = do
   (ResolvedExpression type' storeExpr _ _ _) <- liftRepl $ getTypecheckedStoreExpression env expr
   replPrint $
@@ -30,10 +29,9 @@ doBind env name expr = do
   bindStoreExpression env storeExpr name
 
 doBindType ::
-  (Eq ann, Monoid ann, JSON.ToJSON ann) =>
-  Project ann ->
+  Project Annotation ->
   DataType ->
-  ReplM ann (Project ann)
+  ReplM Annotation (Project Annotation)
 doBindType env dt = do
   let expr = MyData mempty dt (MyRecord mempty mempty)
   (ResolvedExpression _ storeExpr _ _ _) <- liftRepl $ getTypecheckedStoreExpression env expr
@@ -53,11 +51,11 @@ bindTypeExpression env storeExpr = do
 
 -- save an expression in the store and bind it to name
 bindStoreExpression ::
-  (MonadIO m, JSON.ToJSON ann) =>
-  Project ann ->
-  StoreExpression ann ->
+  (MonadIO m) =>
+  Project Annotation ->
+  StoreExpression Annotation ->
   Name ->
-  m (Project ann)
+  m (Project Annotation)
 bindStoreExpression env storeExpr name = do
   hash <- liftIO (saveExpr storeExpr)
   let newEnv = fromItem name storeExpr hash

--- a/src/Language/Mimsa/Repl/ExpressionBind.hs
+++ b/src/Language/Mimsa/Repl/ExpressionBind.hs
@@ -8,7 +8,6 @@ module Language.Mimsa.Repl.ExpressionBind
 where
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import qualified Data.Aeson as JSON
 import Language.Mimsa.Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Repl.Types
@@ -40,7 +39,7 @@ doBindType env dt = do
   bindTypeExpression env storeExpr
 
 bindTypeExpression ::
-  (MonadIO m, JSON.ToJSON ann) =>
+  (MonadIO m) =>
   Project ann ->
   StoreExpression ann ->
   m (Project ann)

--- a/src/Language/Mimsa/Repl/ExpressionWatch.hs
+++ b/src/Language/Mimsa/Repl/ExpressionWatch.hs
@@ -62,10 +62,11 @@ onFileChange env name = do
   text <-
     liftIO $ T.readFile $ "./" <> scratchFilename
   replPrint (T.pack scratchFilename <> " updated!")
+  let input = T.strip text
   expr <-
-    liftRepl $ first ParseErr (parseExprAndFormatError (T.strip text))
+    liftRepl $ first ParseErr (parseExprAndFormatError input)
   (ResolvedExpression type' storeExpr _ _ _) <-
-    liftRepl $ getTypecheckedStoreExpression env expr
+    liftRepl $ getTypecheckedStoreExpression input env expr
   replPrint $
     "+ Using the following from scope: "
       <> prettyPrint (storeBindings storeExpr)

--- a/src/Language/Mimsa/Repl/ExpressionWatch.hs
+++ b/src/Language/Mimsa/Repl/ExpressionWatch.hs
@@ -6,7 +6,6 @@ module Language.Mimsa.Repl.ExpressionWatch
 where
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import qualified Data.Aeson as JSON
 import Data.Bifunctor (first)
 import Data.IORef
 import qualified Data.Text as T

--- a/src/Language/Mimsa/Repl/ExpressionWatch.hs
+++ b/src/Language/Mimsa/Repl/ExpressionWatch.hs
@@ -36,15 +36,9 @@ writeExpression env name =
     Nothing -> pure ()
 
 doWatch ::
-  ( Eq ann,
-    Monoid ann,
-    Show ann,
-    Printer ann,
-    JSON.ToJSON ann
-  ) =>
-  Project ann ->
+  Project Annotation ->
   Name ->
-  ReplM ann (Project ann)
+  ReplM Annotation (Project Annotation)
 doWatch env name = do
   writeExpression env name
   ioEnv <- liftIO $ newIORef env
@@ -62,10 +56,9 @@ doWatch env name = do
   liftIO $ readIORef ioEnv
 
 onFileChange ::
-  (Eq ann, Monoid ann, JSON.ToJSON ann) =>
-  Project ann ->
+  Project Annotation ->
   Name ->
-  ReplM ann (Project ann)
+  ReplM Annotation (Project Annotation)
 onFileChange env name = do
   text <-
     liftIO $ T.readFile $ "./" <> scratchFilename

--- a/src/Language/Mimsa/Repl/Parser.hs
+++ b/src/Language/Mimsa/Repl/Parser.hs
@@ -7,10 +7,11 @@ where
 
 import Language.Mimsa.Parser
 import Language.Mimsa.Repl.Types
+import Language.Mimsa.Types.AST
 import Text.Megaparsec
 import Text.Megaparsec.Char
 
-replParser :: (Monoid ann) => Parser (ReplAction ann)
+replParser :: Parser (ReplAction Annotation)
 replParser =
   try helpParser
     <|> try infoParser
@@ -24,53 +25,53 @@ replParser =
     <|> try versionsParser
     <|> outputJSParser
 
-helpParser :: Parser (ReplAction ann)
+helpParser :: Parser (ReplAction Annotation)
 helpParser = Help <$ string ":help"
 
-infoParser :: (Monoid ann) => Parser (ReplAction ann)
+infoParser :: Parser (ReplAction Annotation)
 infoParser = do
   _ <- thenSpace (string ":info")
   Info <$> expressionParser
 
-evalParser :: (Monoid ann) => Parser (ReplAction ann)
+evalParser :: Parser (ReplAction Annotation)
 evalParser =
   Evaluate
     <$> expressionParser
 
-treeParser :: (Monoid ann) => Parser (ReplAction ann)
+treeParser :: Parser (ReplAction Annotation)
 treeParser = do
   _ <- thenSpace (string ":tree")
   Tree <$> expressionParser
 
-bindParser :: (Monoid ann) => Parser (ReplAction ann)
+bindParser :: Parser (ReplAction Annotation)
 bindParser = do
   _ <- thenSpace (string ":bind")
   name <- thenSpace nameParser
   _ <- thenSpace (string "=")
   Bind name <$> expressionParser
 
-bindTypeParser :: Parser (ReplAction ann)
+bindTypeParser :: Parser (ReplAction Annotation)
 bindTypeParser = do
   _ <- thenSpace (string ":bindType")
   BindType <$> typeDeclParser
 
-listBindingsParser :: Parser (ReplAction ann)
+listBindingsParser :: Parser (ReplAction Annotation)
 listBindingsParser = ListBindings <$ string ":list"
 
-watchParser :: Parser (ReplAction ann)
+watchParser :: Parser (ReplAction Annotation)
 watchParser = do
   _ <- thenSpace (string ":watch")
   Watch <$> nameParser
 
-tuiParser :: Parser (ReplAction ann)
+tuiParser :: Parser (ReplAction Annotation)
 tuiParser = Tui <$ string ":tui"
 
-versionsParser :: Parser (ReplAction ann)
+versionsParser :: Parser (ReplAction Annotation)
 versionsParser = do
   _ <- thenSpace (string ":versions")
   Versions <$> nameParser
 
-outputJSParser :: (Monoid ann) => Parser (ReplAction ann)
+outputJSParser :: Parser (ReplAction Annotation)
 outputJSParser = do
   _ <- thenSpace (string ":outputJS")
   OutputJS <$> expressionParser

--- a/src/Language/Mimsa/Store/DepGraph.hs
+++ b/src/Language/Mimsa/Store/DepGraph.hs
@@ -2,7 +2,6 @@
 
 module Language.Mimsa.Store.DepGraph where
 
-import qualified Data.Aeson as JSON
 import Data.Map ((!))
 import qualified Data.Map as M
 import Data.Text (Text)
@@ -47,7 +46,7 @@ showFuncLine i info children = spaces <> prettyPrint info <> children'
                 <$> (a : as)
             )
 
-createDepGraph :: (JSON.ToJSON ann) => Name -> Store ann -> StoreExpression ann -> DepGraph
+createDepGraph :: Name -> Store ann -> StoreExpression ann -> DepGraph
 createDepGraph name (Store store') storeExpr' = Func depInfo leaves
   where
     depInfo = DepInfo (name, getStoreExpressionHash storeExpr')

--- a/src/Language/Mimsa/Tui.hs
+++ b/src/Language/Mimsa/Tui.hs
@@ -19,7 +19,7 @@ import Language.Mimsa.Tui.State
 import Language.Mimsa.Tui.Styles
 import Language.Mimsa.Types
 
-drawUI :: (Eq ann, Monoid ann) => TuiState ann -> [Widget ()]
+drawUI :: TuiState Annotation -> [Widget ()]
 drawUI tuiState =
   case uiState tuiState of
     TuiError err -> [drawError err]
@@ -29,10 +29,9 @@ drawUI tuiState =
       pure (drawBindingsList store' name deps l)
 
 drawBindingsList ::
-  (Eq ann, Monoid ann) =>
-  Store ann ->
+  Store Annotation ->
   Name ->
-  ResolvedDeps ann ->
+  ResolvedDeps Annotation ->
   L.List () Name ->
   Widget ()
 drawBindingsList store' name deps l = twoColumnLayout "Current scope" left right
@@ -56,7 +55,7 @@ drawError (MissingStoreItems missing) =
            )
     )
 
-drawExpressionInfo :: ExpressionInfo ann -> Widget ()
+drawExpressionInfo :: ExpressionInfo Annotation -> Widget ()
 drawExpressionInfo exprInfo = ui
   where
     label = withAttr "title" . str . T.unpack . prettyPrint . eiName $ exprInfo
@@ -78,7 +77,7 @@ drawExpressionInfo exprInfo = ui
           drawPretty (eiDeps exprInfo)
         ]
 
-theApp :: (Eq ann, Monoid ann) => M.App (TuiState ann) e ()
+theApp :: M.App (TuiState Annotation) e ()
 theApp =
   M.App
     { M.appDraw = drawUI,
@@ -88,7 +87,7 @@ theApp =
       M.appAttrMap = const stylesAttrMap
     }
 
-goTui :: (Eq ann, Monoid ann) => Project ann -> IO (Project ann)
+goTui :: Project Annotation -> IO (Project Annotation)
 goTui project' =
   do
     _ <- M.defaultMain theApp (initialState project')

--- a/src/Language/Mimsa/Tui/Evaluate.hs
+++ b/src/Language/Mimsa/Tui/Evaluate.hs
@@ -1,4 +1,9 @@
-module Language.Mimsa.Tui.Evaluate (getExpressionForBinding) where
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Tui.Evaluate
+  ( getExpressionForBinding,
+  )
+where
 
 import qualified Brick.Widgets.List as L
 import qualified Data.Map as M
@@ -7,25 +12,24 @@ import Language.Mimsa.Store
 import Language.Mimsa.Types
 
 evaluateStoreExprToInfo ::
-  (Eq ann, Monoid ann) =>
-  Store ann ->
-  StoreExpression ann ->
-  Maybe (MonoType, Expr Name ann)
+  Store Annotation ->
+  StoreExpression Annotation ->
+  Maybe (MonoType, Expr Name Annotation)
 evaluateStoreExprToInfo store' storeExpr =
-  case resolveStoreExpression store' storeExpr of
-    Right (ResolvedExpression mt _ _ _ _) -> Just (mt, storeExpression storeExpr)
-    _ -> Nothing
+  let source = "" -- no nice error messages
+   in case resolveStoreExpression store' source storeExpr of
+        Right (ResolvedExpression mt _ _ _ _) -> Just (mt, storeExpression storeExpr)
+        _ -> Nothing
 
 hush :: Either e a -> Maybe a
 hush (Right a) = Just a
 hush _ = Nothing
 
 getExpressionForBinding ::
-  (Eq ann, Monoid ann) =>
-  Store ann ->
-  ResolvedDeps ann ->
+  Store Annotation ->
+  ResolvedDeps Annotation ->
   L.List () Name ->
-  Maybe (ExpressionInfo ann)
+  Maybe (ExpressionInfo Annotation)
 getExpressionForBinding store' (ResolvedDeps deps) l = do
   (_, name) <- L.listSelectedElement l
   (_, storeExpr') <- M.lookup name deps

--- a/src/Language/Mimsa/Tui/State.hs
+++ b/src/Language/Mimsa/Tui/State.hs
@@ -22,10 +22,9 @@ import Language.Mimsa.Types
 -- we don't want this to do much so binning it in exchange for an Elm style
 -- reducer pattern
 appEvent ::
-  (Eq ann, Monoid ann) =>
-  TuiState ann ->
+  TuiState Annotation ->
   BT.BrickEvent () e ->
-  BT.EventM () (BT.Next (TuiState ann))
+  BT.EventM () (BT.Next (TuiState Annotation))
 appEvent tuiState (BT.VtyEvent e) = do
   let tuiAction = case e of
         V.EvKey V.KEsc [] -> Exit
@@ -52,7 +51,7 @@ data TuiAction
   | GoDown
   | Unknown
 
-reducer :: (Eq ann, Monoid ann) => Project ann -> TuiAction -> UIState ann -> Maybe (UIState ann)
+reducer :: Project Annotation -> TuiAction -> UIState Annotation -> Maybe (UIState Annotation)
 reducer _ Exit _ = Nothing
 reducer _ GoUp (ViewBindings items) =
   let mapF (BindingsList n deps l) = BindingsList n deps (L.listMoveUp l)

--- a/src/Language/Mimsa/Typechecker/DataTypes.hs
+++ b/src/Language/Mimsa/Typechecker/DataTypes.hs
@@ -22,8 +22,8 @@ defaultEnv = Environment mempty dts
 builtInTypes :: Map TyCon MonoType
 builtInTypes =
   M.fromList
-    [ (mkTyCon "String", MTPrim MTString),
-      (mkTyCon "Int", MTPrim MTInt),
-      (mkTyCon "Boolean", MTPrim MTBool),
-      (mkTyCon "Unit", MTPrim MTUnit)
+    [ (mkTyCon "String", MTPrim mempty MTString),
+      (mkTyCon "Int", MTPrim mempty MTInt),
+      (mkTyCon "Boolean", MTPrim mempty MTBool),
+      (mkTyCon "Unit", MTPrim mempty MTUnit)
     ]

--- a/src/Language/Mimsa/Typechecker/DataTypes.hs
+++ b/src/Language/Mimsa/Typechecker/DataTypes.hs
@@ -9,13 +9,9 @@ where
 import Data.Map (Map)
 import qualified Data.Map as M
 import Language.Mimsa.Types.AST (DataType (DataType))
-import Language.Mimsa.Types.Environment
-  ( Environment (Environment),
-  )
+import Language.Mimsa.Types.Environment (Environment (Environment))
 import Language.Mimsa.Types.Identifiers (TyCon, mkTyCon)
 import Language.Mimsa.Types.MonoType
-  ( MonoType (MTBool, MTInt, MTString, MTUnit),
-  )
 
 defaultEnv :: Environment
 defaultEnv = Environment mempty dts
@@ -26,8 +22,8 @@ defaultEnv = Environment mempty dts
 builtInTypes :: Map TyCon MonoType
 builtInTypes =
   M.fromList
-    [ (mkTyCon "String", MTString),
-      (mkTyCon "Int", MTInt),
-      (mkTyCon "Boolean", MTBool),
-      (mkTyCon "Unit", MTUnit)
+    [ (mkTyCon "String", MTPrim MTString),
+      (mkTyCon "Int", MTPrim MTInt),
+      (mkTyCon "Boolean", MTPrim MTBool),
+      (mkTyCon "Unit", MTPrim MTUnit)
     ]

--- a/src/Language/Mimsa/Typechecker/DisplayError.hs
+++ b/src/Language/Mimsa/Typechecker/DisplayError.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Typechecker.DisplayError
+  ( displayError,
+  )
+where
+
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import Language.Mimsa.Types.Error.TypeError
+import Text.Megaparsec
+
+displayError :: Text -> TypeError -> Text
+displayError input typeError =
+  T.pack $ errorBundlePretty $ createErrorBundle input typeError
+
+toFancy :: TypeError -> ParseError Text TypeError
+toFancy typeErr =
+  let (start, _) = getErrorPos typeErr
+   in FancyError start (S.singleton (ErrorCustom typeErr))
+
+createErrorBundle :: Text -> TypeError -> ParseErrorBundle Text TypeError
+createErrorBundle input typeError =
+  let initialState =
+        PosState
+          { pstateInput = input,
+            pstateOffset = 0,
+            pstateSourcePos = initialPos "repl",
+            pstateTabWidth = defaultTabWidth,
+            pstateLinePrefix = ""
+          }
+   in ParseErrorBundle
+        { bundleErrors = NE.fromList [toFancy typeError],
+          bundlePosState = initialState
+        }

--- a/src/Language/Mimsa/Typechecker/Environment.hs
+++ b/src/Language/Mimsa/Typechecker/Environment.hs
@@ -3,23 +3,22 @@ module Language.Mimsa.Typechecker.Environment where
 import Control.Monad.Except
 import qualified Data.Map as M
 import Language.Mimsa.Typechecker.TcMonad (TcMonad)
-import Language.Mimsa.Types
-  ( DataType (DataType),
-    Environment (getDataTypes),
-    TyCon,
-    TypeError (ConflictingConstructors, TypeConstructorNotInScope),
-  )
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Environment
+import Language.Mimsa.Types.Error
+import Language.Mimsa.Types.Identifiers
 
 -- given a constructor name, return the type it lives in
 lookupConstructor ::
   Environment ->
+  Annotation ->
   TyCon ->
   TcMonad DataType
-lookupConstructor env name =
+lookupConstructor env ann name =
   case M.toList $ M.filter (containsConstructor name) (getDataTypes env) of
     [(_, a)] -> pure a -- we only want a single match
-    (_ : _) -> throwError (ConflictingConstructors name)
-    _ -> throwError (TypeConstructorNotInScope env name)
+    (_ : _) -> throwError (ConflictingConstructors ann name)
+    _ -> throwError (TypeConstructorNotInScope env ann name)
 
 -- does this data type contain the given constructor?
 containsConstructor :: TyCon -> DataType -> Bool

--- a/src/Language/Mimsa/Typechecker/Environment.hs
+++ b/src/Language/Mimsa/Typechecker/Environment.hs
@@ -14,7 +14,7 @@ import Language.Mimsa.Types
 lookupConstructor ::
   Environment ->
   TyCon ->
-  TcMonad ann DataType
+  TcMonad DataType
 lookupConstructor env name =
   case M.toList $ M.filter (containsConstructor name) (getDataTypes env) of
     [(_, a)] -> pure a -- we only want a single match

--- a/src/Language/Mimsa/Typechecker/Generalise.hs
+++ b/src/Language/Mimsa/Typechecker/Generalise.hs
@@ -8,12 +8,12 @@ import Language.Mimsa.Types.Scheme
 import Language.Mimsa.Types.Substitutions
 
 freeVars :: MonoType -> [Variable]
-freeVars (MTVar b) = [b]
-freeVars (MTFunction t1 t2) = freeVars t1 <> freeVars t2
-freeVars (MTPair a b) = freeVars a <> freeVars b
-freeVars (MTRecord as) = mconcat (freeVars . snd <$> M.toList as)
-freeVars (MTPrim _) = mempty
-freeVars (MTData _ _) = mempty
+freeVars (MTVar _ b) = [b]
+freeVars (MTFunction _ t1 t2) = freeVars t1 <> freeVars t2
+freeVars (MTPair _ a b) = freeVars a <> freeVars b
+freeVars (MTRecord _ as) = mconcat (freeVars . snd <$> M.toList as)
+freeVars (MTPrim _ _) = mempty
+freeVars MTData {} = mempty
 
 generalise :: Substitutions -> MonoType -> Scheme
 generalise (Substitutions subst) ty = Scheme free ty

--- a/src/Language/Mimsa/Typechecker/Generalise.hs
+++ b/src/Language/Mimsa/Typechecker/Generalise.hs
@@ -12,10 +12,7 @@ freeVars (MTVar b) = [b]
 freeVars (MTFunction t1 t2) = freeVars t1 <> freeVars t2
 freeVars (MTPair a b) = freeVars a <> freeVars b
 freeVars (MTRecord as) = mconcat (freeVars . snd <$> M.toList as)
-freeVars MTInt = mempty
-freeVars MTString = mempty
-freeVars MTBool = mempty
-freeVars MTUnit = mempty
+freeVars (MTPrim _) = mempty
 freeVars (MTData _ _) = mempty
 
 generalise :: Substitutions -> MonoType -> Scheme

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -449,8 +449,8 @@ infer env inferExpr =
       inferRecordAccess env ann a name
     (MyLetPair _ binder1 binder2 expr body) ->
       inferLetPairBinding env binder1 binder2 expr body
-    (MyLambda _ binder body) -> do
-      tyBinder <- getUnknown
+    (MyLambda ann binder body) -> do
+      tyBinder <- getUnknown ann
       let tmpCtx =
             createEnv binder (Scheme [] tyBinder)
               <> env
@@ -477,7 +477,7 @@ infer env inferExpr =
       storeDataDeclaration env dataType expr
     (MyConstructor _ name) ->
       inferDataConstructor env name
-    (MyConsApp _ cons val) ->
-      inferApplication env cons val
+    (MyConsApp ann cons val) ->
+      inferApplication env ann cons val
     (MyCaseMatch ann expr' matches catchAll) ->
       inferCaseMatch env ann expr' matches catchAll

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -180,7 +180,7 @@ inferLetPairBinding env binder1 binder2 expr body = do
       tyB <- getUnknown
       pure (tyA, tyB)
     (MTPair a b) -> pure (a, b)
-    a -> throwError $ CaseMatchExpectedPair a
+    a -> throwError $ CaseMatchExpectedPair (getAnnotation expr) a
   let schemeA = Scheme mempty (applySubst s1 tyA)
       schemeB = Scheme mempty (applySubst s1 tyB)
       newEnv = createEnv binder1 schemeA <> createEnv binder2 schemeB <> env

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -81,10 +81,10 @@ instantiate (Scheme vars ty) = do
 --------------
 
 inferLiteral :: Literal -> TcMonad (Substitutions, MonoType)
-inferLiteral (MyInt _) = pure (mempty, MTInt)
-inferLiteral (MyBool _) = pure (mempty, MTBool)
-inferLiteral (MyString _) = pure (mempty, MTString)
-inferLiteral MyUnit = pure (mempty, MTUnit)
+inferLiteral (MyInt _) = pure (mempty, MTPrim MTInt)
+inferLiteral (MyBool _) = pure (mempty, MTPrim MTBool)
+inferLiteral (MyString _) = pure (mempty, MTPrim MTString)
+inferLiteral MyUnit = pure (mempty, MTPrim MTUnit)
 
 inferBuiltIn ::
   Annotation ->
@@ -390,7 +390,7 @@ inferOperator env Equals a b = do
     MTFunction _ _ -> throwError $ NoFunctionEquality tyA tyB
     _ -> do
       s3 <- unify tyA tyB -- Equals wants them to be the same
-      pure (s3 <> s2 <> s1, MTBool)
+      pure (s3 <> s2 <> s1, MTPrim MTBool)
 
 inferRecordAccess ::
   Environment ->
@@ -459,7 +459,7 @@ infer env inferExpr =
       (s2, tyThen) <- infer (applySubstCtx s1 env) thenCase
       (s3, tyElse) <- infer (applySubstCtx (s2 <> s1) env) elseCase
       s4 <- unify tyThen tyElse
-      s5 <- unify tyCond MTBool
+      s5 <- unify tyCond (MTPrim MTBool)
       let subs = s5 <> s4 <> s3 <> s2 <> s1
       pure
         ( subs,

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -304,12 +304,13 @@ inferSumExpressionType env consTypes sumExpr =
 
 inferCaseMatch ::
   Environment ->
+  Annotation ->
   Expr Variable Annotation ->
   NonEmpty (TyCon, Expr Variable Annotation) ->
   Maybe (Expr Variable Annotation) ->
   TcMonad (Substitutions, MonoType)
-inferCaseMatch env sumExpr matches catchAll = do
-  dataType <- checkCompleteness env matches catchAll
+inferCaseMatch env ann sumExpr matches catchAll = do
+  dataType <- checkCompleteness env ann matches catchAll
   (tyData, constructTypes) <- inferConstructorTypes env dataType
   (s1, tySum) <-
     inferSumExpressionType
@@ -476,5 +477,5 @@ infer env inferExpr =
       inferDataConstructor env name
     (MyConsApp _ cons val) ->
       inferApplication env cons val
-    (MyCaseMatch _ expr' matches catchAll) ->
-      inferCaseMatch env expr' matches catchAll
+    (MyCaseMatch ann expr' matches catchAll) ->
+      inferCaseMatch env ann expr' matches catchAll

--- a/src/Language/Mimsa/Typechecker/Patterns.hs
+++ b/src/Language/Mimsa/Typechecker/Patterns.hs
@@ -18,7 +18,7 @@ checkCompleteness ::
   TcMonad DataType
 checkCompleteness env ann opts catchAll = do
   -- find data type for each match
-  items <- traverse (\(name, _) -> lookupConstructor env name) opts
+  items <- traverse (\(name, _) -> lookupConstructor env ann name) opts
   let optionNames = fst <$> NE.toList opts
   -- check they are all the same one
   dataType <- case nub (NE.toList items) of

--- a/src/Language/Mimsa/Typechecker/Patterns.hs
+++ b/src/Language/Mimsa/Typechecker/Patterns.hs
@@ -21,7 +21,7 @@ checkCompleteness ::
   Environment ->
   NonEmpty (TyCon, Expr Variable ann) ->
   Maybe (Expr Variable ann) ->
-  TcMonad ann DataType
+  TcMonad DataType
 checkCompleteness env opts catchAll = do
   -- find data type for each match
   items <- traverse (\(name, _) -> lookupConstructor env name) opts
@@ -35,7 +35,7 @@ checkCompleteness env opts catchAll = do
     _ -> allPatternsExist optionNames dataType
   pure dataType
 
-allPatternsExist :: [TyCon] -> DataType -> TcMonad ann ()
+allPatternsExist :: [TyCon] -> DataType -> TcMonad ()
 allPatternsExist optNames' (DataType _ _ dataTypes) = do
   -- check each one of optNames exists in dataTypes
   let dtNames = S.fromList (M.keys dataTypes)

--- a/src/Language/Mimsa/Typechecker/Patterns.hs
+++ b/src/Language/Mimsa/Typechecker/Patterns.hs
@@ -9,20 +9,14 @@ import qualified Data.Set as S
 import Language.Mimsa.Typechecker.Environment (lookupConstructor)
 import Language.Mimsa.Typechecker.TcMonad (TcMonad)
 import Language.Mimsa.Types
-  ( DataType (DataType),
-    Environment,
-    Expr,
-    TyCon,
-    TypeError (IncompletePatternMatch, MixedUpPatterns),
-    Variable,
-  )
 
 checkCompleteness ::
   Environment ->
+  Annotation ->
   NonEmpty (TyCon, Expr Variable ann) ->
   Maybe (Expr Variable ann) ->
   TcMonad DataType
-checkCompleteness env opts catchAll = do
+checkCompleteness env ann opts catchAll = do
   -- find data type for each match
   items <- traverse (\(name, _) -> lookupConstructor env name) opts
   let optionNames = fst <$> NE.toList opts
@@ -32,15 +26,15 @@ checkCompleteness env opts catchAll = do
     _ -> throwError (MixedUpPatterns optionNames)
   case catchAll of
     Just _ -> pure ()
-    _ -> allPatternsExist optionNames dataType
+    _ -> allPatternsExist ann optionNames dataType
   pure dataType
 
-allPatternsExist :: [TyCon] -> DataType -> TcMonad ()
-allPatternsExist optNames' (DataType _ _ dataTypes) = do
+allPatternsExist :: Annotation -> [TyCon] -> DataType -> TcMonad ()
+allPatternsExist ann optNames' (DataType _ _ dataTypes) = do
   -- check each one of optNames exists in dataTypes
   let dtNames = S.fromList (M.keys dataTypes)
       optNames = S.fromList optNames'
   let (_matched, unmatched) = S.partition (`S.member` optNames) dtNames
   if S.size unmatched > 0
-    then throwError (IncompletePatternMatch (S.toList unmatched))
+    then throwError (IncompletePatternMatch ann (S.toList unmatched))
     else pure ()

--- a/src/Language/Mimsa/Typechecker/TcMonad.hs
+++ b/src/Language/Mimsa/Typechecker/TcMonad.hs
@@ -23,4 +23,4 @@ getNextUniVar = do
   pure nextUniVar
 
 getUnknown :: TcMonad MonoType
-getUnknown = MTVar . NumberedVar <$> getNextUniVar
+getUnknown = MTVar mempty . NumberedVar <$> getNextUniVar

--- a/src/Language/Mimsa/Typechecker/TcMonad.hs
+++ b/src/Language/Mimsa/Typechecker/TcMonad.hs
@@ -5,22 +5,22 @@ import Control.Monad.Reader
 import Control.Monad.State (State, get, put, runState)
 import Language.Mimsa.Types
 
-type TcMonad a = ExceptT (TypeError a) (ReaderT Swaps (State Int))
+type TcMonad = ExceptT TypeError (ReaderT Swaps (State Int))
 
 runTcMonad ::
   Swaps ->
-  TcMonad ann a ->
-  Either (TypeError ann) a
+  TcMonad a ->
+  Either TypeError a
 runTcMonad swaps value =
   fst either'
   where
     either' = runState (runReaderT (runExceptT value) swaps) 1
 
-getNextUniVar :: TcMonad ann Int
+getNextUniVar :: TcMonad Int
 getNextUniVar = do
   nextUniVar <- get
   put (nextUniVar + 1)
   pure nextUniVar
 
-getUnknown :: TcMonad ann MonoType
+getUnknown :: TcMonad MonoType
 getUnknown = MTVar . NumberedVar <$> getNextUniVar

--- a/src/Language/Mimsa/Typechecker/TcMonad.hs
+++ b/src/Language/Mimsa/Typechecker/TcMonad.hs
@@ -22,5 +22,5 @@ getNextUniVar = do
   put (nextUniVar + 1)
   pure nextUniVar
 
-getUnknown :: TcMonad MonoType
-getUnknown = MTVar mempty . NumberedVar <$> getNextUniVar
+getUnknown :: Annotation -> TcMonad MonoType
+getUnknown ann = MTVar ann . NumberedVar <$> getNextUniVar

--- a/src/Language/Mimsa/Typechecker/Unify.hs
+++ b/src/Language/Mimsa/Typechecker/Unify.hs
@@ -56,11 +56,11 @@ unify tyA tyB =
     (MTFunction _ l r, MTFunction _ l' r') ->
       unifyPairs (l, r) (l', r')
     (MTPair _ a b, MTPair _ a' b') -> unifyPairs (a, b) (a', b')
-    (MTRecord _ as, MTRecord _ bs) -> do
+    (MTRecord ann as, MTRecord ann' bs) -> do
       let allKeys = S.toList $ M.keysSet as <> M.keysSet bs
       let getRecordTypes k = do
-            tyLeft <- getTypeOrFresh k as
-            tyRight <- getTypeOrFresh k bs
+            tyLeft <- getTypeOrFresh ann k as
+            tyRight <- getTypeOrFresh ann' k bs
             unify tyLeft tyRight
       s <- traverse getRecordTypes allKeys
       pure (mconcat s)
@@ -74,8 +74,8 @@ unify tyA tyB =
     (a, b) ->
       throwError $ UnificationError a b
 
-getTypeOrFresh :: Name -> Map Name MonoType -> TcMonad MonoType
-getTypeOrFresh name map' =
+getTypeOrFresh :: Annotation -> Name -> Map Name MonoType -> TcMonad MonoType
+getTypeOrFresh ann name map' =
   case M.lookup name map' of
     Just found -> pure found
-    _ -> getUnknown
+    _ -> getUnknown ann

--- a/src/Language/Mimsa/Typechecker/Unify.hs
+++ b/src/Language/Mimsa/Typechecker/Unify.hs
@@ -8,6 +8,7 @@ where
 
 import Control.Monad.Except
 import Control.Monad.Reader
+import Data.Functor (($>))
 import Data.Map (Map)
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -16,19 +17,19 @@ import Language.Mimsa.Types
 
 freeTypeVars :: MonoType -> S.Set Variable
 freeTypeVars ty = case ty of
-  MTVar var ->
+  MTVar _ var ->
     S.singleton var
-  MTFunction t1 t2 ->
+  MTFunction _ t1 t2 ->
     S.union (freeTypeVars t1) (freeTypeVars t2)
-  MTPair t1 t2 -> S.union (freeTypeVars t1) (freeTypeVars t2)
-  MTRecord as -> foldr S.union mempty (freeTypeVars <$> as)
-  MTData _ as -> foldr S.union mempty (freeTypeVars <$> as)
-  MTPrim _ -> S.empty
+  MTPair _ t1 t2 -> S.union (freeTypeVars t1) (freeTypeVars t2)
+  MTRecord _ as -> foldr S.union mempty (freeTypeVars <$> as)
+  MTData _ _ as -> foldr S.union mempty (freeTypeVars <$> as)
+  MTPrim _ _ -> S.empty
 
 -- | Creates a fresh unification variable and binds it to the given type
 varBind :: Variable -> MonoType -> TcMonad Substitutions
 varBind var ty
-  | ty == MTVar var = pure mempty
+  | typeEquals ty (MTVar mempty var) = pure mempty
   | S.member var (freeTypeVars ty) = do
     swaps <- ask
     throwError $
@@ -45,14 +46,17 @@ unifyPairs (a, b) (a', b') = do
   s2 <- unify (applySubst s1 b) (applySubst s1 b')
   pure (s2 <> s1)
 
+typeEquals :: MonoType -> MonoType -> Bool
+typeEquals mtA mtB = (mtA $> ()) == (mtB $> ())
+
 unify :: MonoType -> MonoType -> TcMonad Substitutions
 unify tyA tyB =
   case (tyA, tyB) of
-    (a, b) | a == b -> pure mempty
-    (MTFunction l r, MTFunction l' r') ->
+    (a, b) | typeEquals a b -> pure mempty
+    (MTFunction _ l r, MTFunction _ l' r') ->
       unifyPairs (l, r) (l', r')
-    (MTPair a b, MTPair a' b') -> unifyPairs (a, b) (a', b')
-    (MTRecord as, MTRecord bs) -> do
+    (MTPair _ a b, MTPair _ a' b') -> unifyPairs (a, b) (a', b')
+    (MTRecord _ as, MTRecord _ bs) -> do
       let allKeys = S.toList $ M.keysSet as <> M.keysSet bs
       let getRecordTypes k = do
             tyLeft <- getTypeOrFresh k as
@@ -60,13 +64,13 @@ unify tyA tyB =
             unify tyLeft tyRight
       s <- traverse getRecordTypes allKeys
       pure (mconcat s)
-    (MTData a tyAs, MTData b tyBs)
+    (MTData _ a tyAs, MTData _ b tyBs)
       | a == b -> do
         let pairs = zip tyAs tyBs
         s <- traverse (uncurry unify) pairs
         pure (mconcat s)
-    (MTVar u, t) -> varBind u t
-    (t, MTVar u) -> varBind u t
+    (MTVar _ u, t) -> varBind u t
+    (t, MTVar _ u) -> varBind u t
     (a, b) ->
       throwError $ UnificationError a b
 

--- a/src/Language/Mimsa/Typechecker/Unify.hs
+++ b/src/Language/Mimsa/Typechecker/Unify.hs
@@ -23,11 +23,7 @@ freeTypeVars ty = case ty of
   MTPair t1 t2 -> S.union (freeTypeVars t1) (freeTypeVars t2)
   MTRecord as -> foldr S.union mempty (freeTypeVars <$> as)
   MTData _ as -> foldr S.union mempty (freeTypeVars <$> as)
-  MTString -> S.empty
-  MTInt -> S.empty
-  MTBool -> S.empty
-  MTUnit ->
-    S.empty
+  MTPrim _ -> S.empty
 
 -- | Creates a fresh unification variable and binds it to the given type
 varBind :: Variable -> MonoType -> TcMonad Substitutions

--- a/src/Language/Mimsa/Typechecker/Unify.hs
+++ b/src/Language/Mimsa/Typechecker/Unify.hs
@@ -30,7 +30,7 @@ freeTypeVars ty = case ty of
     S.empty
 
 -- | Creates a fresh unification variable and binds it to the given type
-varBind :: Variable -> MonoType -> TcMonad ann Substitutions
+varBind :: Variable -> MonoType -> TcMonad Substitutions
 varBind var ty
   | ty == MTVar var = pure mempty
   | S.member var (freeTypeVars ty) = do
@@ -43,13 +43,13 @@ varBind var ty
 unifyPairs ::
   (MonoType, MonoType) ->
   (MonoType, MonoType) ->
-  TcMonad ann Substitutions
+  TcMonad Substitutions
 unifyPairs (a, b) (a', b') = do
   s1 <- unify a a'
   s2 <- unify (applySubst s1 b) (applySubst s1 b')
   pure (s2 <> s1)
 
-unify :: MonoType -> MonoType -> TcMonad ann Substitutions
+unify :: MonoType -> MonoType -> TcMonad Substitutions
 unify tyA tyB =
   case (tyA, tyB) of
     (a, b) | a == b -> pure mempty
@@ -74,7 +74,7 @@ unify tyA tyB =
     (a, b) ->
       throwError $ UnificationError a b
 
-getTypeOrFresh :: Name -> Map Name MonoType -> TcMonad ann MonoType
+getTypeOrFresh :: Name -> Map Name MonoType -> TcMonad MonoType
 getTypeOrFresh name map' =
   case M.lookup name map' of
     Just found -> pure found

--- a/src/Language/Mimsa/Types/AST/Annotation.hs
+++ b/src/Language/Mimsa/Types/AST/Annotation.hs
@@ -9,12 +9,12 @@ import Language.Mimsa.Printer
 
 data Annotation
   = None
-  | Location Int
+  | Location Int Int
   deriving (Eq, Ord, Show, Generic)
 
 instance Semigroup Annotation where
-  Location a <> Location a' = Location (min a a')
-  Location a <> None = Location a
+  Location a b <> Location a' b' = Location (min a a') (max b b')
+  Location a b <> None = Location a b
   None <> a = a
 
 instance Monoid Annotation where
@@ -22,4 +22,4 @@ instance Monoid Annotation where
 
 instance Printer Annotation where
   prettyDoc None = "-"
-  prettyDoc (Location a) = pretty a
+  prettyDoc (Location a b) = pretty a <> " - " <> pretty b

--- a/src/Language/Mimsa/Types/AST/Annotation.hs
+++ b/src/Language/Mimsa/Types/AST/Annotation.hs
@@ -1,5 +1,26 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 module Language.Mimsa.Types.AST.Annotation where
+
+import qualified Data.Aeson as JSON
+import GHC.Generics
+import Language.Mimsa.Printer
 
 data Annotation
   = None
-  | Location Int
+  | Location Int Int
+  deriving (Eq, Ord, Show, Generic, JSON.ToJSON, JSON.FromJSON)
+
+instance Semigroup Annotation where
+  Location a b <> Location a' b' = Location (min a a') (max b b')
+  Location a b <> None = Location a b
+  None <> a = a
+
+instance Monoid Annotation where
+  mempty = None
+
+instance Printer Annotation where
+  prettyDoc None = "-"
+  prettyDoc (Location a b) = prettyDoc a <> " - " <> prettyDoc b

--- a/src/Language/Mimsa/Types/AST/Annotation.hs
+++ b/src/Language/Mimsa/Types/AST/Annotation.hs
@@ -1,21 +1,20 @@
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Language.Mimsa.Types.AST.Annotation where
 
-import qualified Data.Aeson as JSON
+import Data.Text.Prettyprint.Doc
 import GHC.Generics
 import Language.Mimsa.Printer
 
 data Annotation
   = None
-  | Location Int Int
-  deriving (Eq, Ord, Show, Generic, JSON.ToJSON, JSON.FromJSON)
+  | Location Int
+  deriving (Eq, Ord, Show, Generic)
 
 instance Semigroup Annotation where
-  Location a b <> Location a' b' = Location (min a a') (max b b')
-  Location a b <> None = Location a b
+  Location a <> Location a' = Location (min a a')
+  Location a <> None = Location a
   None <> a = a
 
 instance Monoid Annotation where
@@ -23,4 +22,4 @@ instance Monoid Annotation where
 
 instance Printer Annotation where
   prettyDoc None = "-"
-  prettyDoc (Location a b) = prettyDoc a <> " - " <> prettyDoc b
+  prettyDoc (Location a) = pretty a

--- a/src/Language/Mimsa/Types/AST/Expr.hs
+++ b/src/Language/Mimsa/Types/AST/Expr.hs
@@ -7,6 +7,7 @@
 module Language.Mimsa.Types.AST.Expr
   ( Expr (..),
     toEmptyAnnotation,
+    getAnnotation,
   )
 where
 
@@ -48,6 +49,23 @@ toEmptyAnnotation ::
   Expr var a ->
   Expr var b
 toEmptyAnnotation = fmap (const mempty)
+
+getAnnotation :: Expr var ann -> ann
+getAnnotation (MyLiteral ann _) = ann
+getAnnotation (MyVar ann _) = ann
+getAnnotation (MyLet ann _ _ _) = ann
+getAnnotation (MyLetPair ann _ _ _ _) = ann
+getAnnotation (MyInfix ann _ _ _) = ann
+getAnnotation (MyLambda ann _ _) = ann
+getAnnotation (MyApp ann _ _) = ann
+getAnnotation (MyIf ann _ _ _) = ann
+getAnnotation (MyPair ann _ _) = ann
+getAnnotation (MyRecord ann _) = ann
+getAnnotation (MyRecordAccess ann _ _) = ann
+getAnnotation (MyData ann _ _) = ann
+getAnnotation (MyConstructor ann _) = ann
+getAnnotation (MyConsApp ann _ _) = ann
+getAnnotation (MyCaseMatch ann _ _ _) = ann
 
 instance (Show var, Printer var) => Printer (Expr var ann) where
   prettyDoc (MyLiteral _ l) = prettyDoc l

--- a/src/Language/Mimsa/Types/Error.hs
+++ b/src/Language/Mimsa/Types/Error.hs
@@ -10,13 +10,14 @@ where
 
 import Data.Text (Text)
 import Language.Mimsa.Printer
+import Language.Mimsa.Typechecker.DisplayError
 import Language.Mimsa.Types.Error.InterpreterError
 import Language.Mimsa.Types.Error.ResolverError
 import Language.Mimsa.Types.Error.TypeError
 import Language.Mimsa.Types.Usage
 
 data Error ann
-  = TypeErr (TypeError ann)
+  = TypeErr Text TypeError -- input, error
   | ResolverErr ResolverError
   | InterpreterErr (InterpreterError ann)
   | UsageErr UsageError
@@ -25,7 +26,7 @@ data Error ann
   deriving (Eq, Ord, Show)
 
 instance (Show ann, Printer ann) => Printer (Error ann) where
-  prettyPrint (TypeErr t) = "TypeError:\n" <> prettyPrint t
+  prettyPrint (TypeErr input typeErr) = displayError input typeErr
   prettyPrint (ResolverErr a) = "ResolverError:\n" <> prettyPrint a
   prettyPrint (InterpreterErr a) = "InterpreterError:\n" <> prettyPrint a
   prettyPrint (UsageErr a) = "UsageError:\n" <> prettyPrint a

--- a/src/Language/Mimsa/Types/Error/TypeError.hs
+++ b/src/Language/Mimsa/Types/Error/TypeError.hs
@@ -50,7 +50,7 @@ data TypeError
   | ConflictingConstructors TyCon
   | CannotApplyToType TyCon
   | DuplicateTypeDeclaration TyCon
-  | IncompletePatternMatch [TyCon]
+  | IncompletePatternMatch Annotation [TyCon]
   | MixedUpPatterns [TyCon]
   deriving (Eq, Ord, Show)
 
@@ -80,6 +80,7 @@ fromAnnotation _ = (0, 0)
 getErrorPos :: TypeError -> (Start, Length)
 getErrorPos (VariableNotInEnv _ ann _ _) = fromAnnotation ann
 getErrorPos (MissingBuiltIn ann _) = fromAnnotation ann
+getErrorPos (IncompletePatternMatch ann _) = fromAnnotation ann
 getErrorPos (CaseMatchExpectedPair ann _) =
   fromAnnotation ann
 getErrorPos (CannotCaseMatchOnType expr) =
@@ -168,7 +169,7 @@ renderTypeError (TypeVariableNotInDataType constructor name as) =
     "The following type variables were found:"
   ]
     <> (renderName <$> as)
-renderTypeError (IncompletePatternMatch names) =
+renderTypeError (IncompletePatternMatch _ names) =
   [ "Incomplete pattern match.",
     "Missing constructors:"
   ]

--- a/src/Language/Mimsa/Types/MonoType.hs
+++ b/src/Language/Mimsa/Types/MonoType.hs
@@ -2,6 +2,7 @@
 
 module Language.Mimsa.Types.MonoType
   ( MonoType (..),
+    Primitive (..),
   )
 where
 
@@ -11,15 +12,25 @@ import Data.Text.Prettyprint.Doc
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.Identifiers
 
-data MonoType
+data Primitive
   = MTInt
   | MTString
   | MTBool
   | MTUnit
+  deriving (Eq, Ord, Show)
+
+instance Printer Primitive where
+  prettyDoc MTUnit = "Unit"
+  prettyDoc MTInt = "Int"
+  prettyDoc MTString = "String"
+  prettyDoc MTBool = "Boolean"
+
+data MonoType
+  = MTPrim Primitive
+  | MTVar Variable
   | MTFunction MonoType MonoType -- argument, result
   | MTPair MonoType MonoType -- (a,b)
   | MTRecord (Map Name MonoType) -- { foo: a, bar: b }
-  | MTVar Variable
   | MTData TyCon [MonoType] -- name, typeVars
   deriving (Eq, Ord, Show)
 
@@ -27,10 +38,7 @@ instance Printer MonoType where
   prettyDoc = renderMonoType
 
 renderMonoType :: MonoType -> Doc ann
-renderMonoType MTUnit = "Unit"
-renderMonoType MTInt = "Int"
-renderMonoType MTString = "String"
-renderMonoType MTBool = "Boolean"
+renderMonoType (MTPrim a) = prettyDoc a
 renderMonoType (MTFunction a b) =
   parens (renderMonoType a <+> "->" <+> renderMonoType b)
 renderMonoType (MTPair a b) =

--- a/src/Language/Mimsa/Types/MonoType.hs
+++ b/src/Language/Mimsa/Types/MonoType.hs
@@ -5,6 +5,7 @@ module Language.Mimsa.Types.MonoType
   ( MonoType,
     Type (..),
     Primitive (..),
+    getAnnotationForType,
   )
 where
 
@@ -38,6 +39,14 @@ data Type ann
   | MTRecord ann (Map Name (Type ann)) -- { foo: a, bar: b }
   | MTData ann TyCon [Type ann] -- name, typeVars
   deriving (Eq, Ord, Show, Functor)
+
+getAnnotationForType :: Type ann -> ann
+getAnnotationForType (MTPrim ann _) = ann
+getAnnotationForType (MTVar ann _) = ann
+getAnnotationForType (MTFunction ann _ _) = ann
+getAnnotationForType (MTPair ann _ _) = ann
+getAnnotationForType (MTRecord ann _) = ann
+getAnnotationForType (MTData ann _ _) = ann
 
 instance Printer (Type ann) where
   prettyDoc = renderMonoType

--- a/src/Language/Mimsa/Types/Project.hs
+++ b/src/Language/Mimsa/Types/Project.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -23,14 +24,14 @@ newtype ServerUrl = ServerUrl {getServerUrl :: Text}
 
 -- our environment contains whichever hash/expr pairs we have flapping about
 -- and a list of mappings of names to those pieces
-data Project a
+data Project ann
   = Project
-      { store :: Store a,
+      { store :: Store ann,
         bindings :: VersionedBindings,
         typeBindings :: VersionedTypeBindings,
         serverUrl :: [ServerUrl]
       }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Functor)
 
 instance Semigroup (Project a) where
   Project a a1 a2 a3 <> Project b b1 b2 b3 =

--- a/src/Language/Mimsa/Types/Store.hs
+++ b/src/Language/Mimsa/Types/Store.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
@@ -8,5 +9,6 @@ import Language.Mimsa.Types.ExprHash
 import Language.Mimsa.Types.StoreExpression
 
 -- store is where we keep the big map of hashes to expresions
-newtype Store a = Store {getStore :: Map ExprHash (StoreExpression a)}
+newtype Store ann = Store {getStore :: Map ExprHash (StoreExpression ann)}
   deriving newtype (Eq, Ord, Show, Semigroup, Monoid)
+  deriving (Functor)

--- a/src/Language/Mimsa/Types/StoreExpression.hs
+++ b/src/Language/Mimsa/Types/StoreExpression.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 module Language.Mimsa.Types.StoreExpression where
@@ -19,4 +20,4 @@ data StoreExpression ann
         storeBindings :: Bindings,
         storeTypeBindings :: TypeBindings
       }
-  deriving (Eq, Ord, Show, Generic, JSON.ToJSON, JSON.FromJSON)
+  deriving (Eq, Ord, Show, Generic, JSON.ToJSON, JSON.FromJSON, Functor)

--- a/src/Language/Mimsa/Types/Substitutions.hs
+++ b/src/Language/Mimsa/Types/Substitutions.hs
@@ -46,7 +46,4 @@ applySubst subst ty = case ty of
       (applySubst subst b)
   MTRecord a -> MTRecord (applySubst subst <$> a)
   MTData a ty' -> MTData a (applySubst subst <$> ty')
-  MTInt -> MTInt
-  MTString -> MTString
-  MTBool -> MTBool
-  MTUnit -> MTUnit
+  MTPrim a -> MTPrim a

--- a/src/Language/Mimsa/Types/Substitutions.hs
+++ b/src/Language/Mimsa/Types/Substitutions.hs
@@ -34,16 +34,19 @@ substLookup subst i = M.lookup i (getSubstitutions subst)
 
 applySubst :: Substitutions -> MonoType -> MonoType
 applySubst subst ty = case ty of
-  MTVar var ->
+  MTVar ann var ->
     fromMaybe
-      (MTVar var)
+      (MTVar ann var)
       (substLookup subst var)
-  MTFunction arg res ->
-    MTFunction (applySubst subst arg) (applySubst subst res)
-  MTPair a b ->
+  MTFunction ann arg res ->
+    MTFunction ann (applySubst subst arg) (applySubst subst res)
+  MTPair ann a b ->
     MTPair
+      ann
       (applySubst subst a)
       (applySubst subst b)
-  MTRecord a -> MTRecord (applySubst subst <$> a)
-  MTData a ty' -> MTData a (applySubst subst <$> ty')
-  MTPrim a -> MTPrim a
+  MTRecord ann a ->
+    MTRecord ann (applySubst subst <$> a)
+  MTData ann a ty' ->
+    MTData ann a (applySubst subst <$> ty')
+  MTPrim ann a -> MTPrim ann a

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -16,6 +16,7 @@ import qualified Test.Repl as Repl
 import qualified Test.Resolver as Resolver
 import qualified Test.Substitutor as Substitutor
 import qualified Test.Syntax as Syntax
+import qualified Test.TypeError as TypeError
 import qualified Test.Typechecker as Typechecker
 import qualified Test.Unify as Unify
 import qualified Test.Usages as Usages
@@ -32,3 +33,4 @@ main = hspec $ do
   Unify.spec
   Usages.spec
   JS.spec
+  TypeError.spec

--- a/test/Test/BackendJS.hs
+++ b/test/Test/BackendJS.hs
@@ -19,7 +19,7 @@ import Language.Mimsa.Types
 import Test.Data.Project
 import Test.Hspec
 
-eval :: Project () -> Text -> Either Text Javascript
+eval :: Project Annotation -> Text -> Either Text Javascript
 eval env input =
   case evaluateText env input of
     Left e -> Left $ prettyPrint e
@@ -27,7 +27,7 @@ eval env input =
       pure $
         output (storeExpression storeExpr)
 
-evalModule :: Project () -> Text -> IO (Either Text Javascript)
+evalModule :: Project Annotation -> Text -> IO (Either Text Javascript)
 evalModule env input =
   case evaluateText env input of
     Left e -> pure $ Left $ prettyPrint e

--- a/test/Test/Data/Project.hs
+++ b/test/Test/Data/Project.hs
@@ -1,7 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Test.Data.Project where
+module Test.Data.Project
+  ( stdLib,
+    idExpr,
+  )
+where
 
+import Data.Functor
 import qualified Data.Map as M
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -61,8 +66,12 @@ aPairExpr = unsafeGetExpr "(1,2)"
 aRecordExpr :: StoreExpressionA
 aRecordExpr = unsafeGetExpr "{ a: 1, b: \"dog\" }"
 
+-- check removing annotation doesn't break stuff
 stdLib :: Project Annotation
-stdLib = Project store' bindings' typeBindings' mempty
+stdLib = (stdLib' $> ()) $> mempty
+
+stdLib' :: Project Annotation
+stdLib' = Project store' bindings' typeBindings' mempty
   where
     store' =
       Store $

--- a/test/Test/Data/Project.hs
+++ b/test/Test/Data/Project.hs
@@ -59,7 +59,7 @@ addInt :: StoreExpressionA
 addInt = unsafeGetExpr "\\a -> \\b -> addIntPair((a,b))"
 
 eqExpr :: StoreExpressionA
-eqExpr = unsafeGetExpr "\\a -> \\b -> eqPair((a,b))"
+eqExpr = unsafeGetExpr "\\a -> \\b -> a == b"
 
 optionExpr :: StoreExpressionA
 optionExpr = unsafeGetExpr "type Option a = Some a | Nowt in {}"

--- a/test/Test/Data/Project.hs
+++ b/test/Test/Data/Project.hs
@@ -25,6 +25,10 @@ import Language.Mimsa.Types.AST
 
 type StoreExpressionA = StoreExpression Annotation
 
+-- polymorphic export for use in other tests
+idExpr :: (Monoid ann) => StoreExpression ann
+idExpr = idExpr' $> mempty
+
 fstExpr :: StoreExpressionA
 fstExpr =
   unsafeGetExpr "\\tuple -> let (tupleFirst,tupleSecond) = tuple in tupleFirst"
@@ -42,8 +46,8 @@ compose :: StoreExpressionA
 compose =
   unsafeGetExpr "\\f -> \\g -> \\aValue -> f(g(aValue))"
 
-idExpr :: StoreExpressionA
-idExpr = unsafeGetExpr "\\i -> i"
+idExpr' :: StoreExpressionA
+idExpr' = unsafeGetExpr "\\i -> i"
 
 incrementInt :: StoreExpressionA
 incrementInt =

--- a/test/Test/Data/Project.hs
+++ b/test/Test/Data/Project.hs
@@ -16,49 +16,52 @@ import Language.Mimsa.Types
     mkName,
     mkTyCon,
   )
+import Language.Mimsa.Types.AST
 
-fstExpr :: (Monoid ann, Show ann) => StoreExpression ann
+type StoreExpressionA = StoreExpression Annotation
+
+fstExpr :: StoreExpressionA
 fstExpr =
   unsafeGetExpr "\\tuple -> let (tupleFirst,tupleSecond) = tuple in tupleFirst"
 
-sndExpr :: (Monoid ann, Show ann) => StoreExpression ann
+sndExpr :: StoreExpressionA
 sndExpr = unsafeGetExpr "\\tuple -> let (tupleFirst,tupleSecond) = tuple in tupleSecond"
 
-eqTenExpr :: (Monoid ann, Show ann) => StoreExpression ann
+eqTenExpr :: StoreExpressionA
 eqTenExpr =
   unsafeGetExpr'
     "\\i -> eq(10)(i)"
     (Bindings $ M.singleton (mkName "eq") (ExprHash 2))
 
-compose :: (Monoid ann, Show ann) => StoreExpression ann
+compose :: StoreExpressionA
 compose =
   unsafeGetExpr "\\f -> \\g -> \\aValue -> f(g(aValue))"
 
-idExpr :: (Monoid ann, Show ann) => StoreExpression ann
+idExpr :: StoreExpressionA
 idExpr = unsafeGetExpr "\\i -> i"
 
-incrementInt :: (Monoid ann, Show ann) => StoreExpression ann
+incrementInt :: StoreExpressionA
 incrementInt =
   unsafeGetExpr'
     "\\a -> addInt(1)(a)"
     (Bindings $ M.singleton (mkName "addInt") (ExprHash 18))
 
-addInt :: (Monoid ann, Show ann) => StoreExpression ann
+addInt :: StoreExpressionA
 addInt = unsafeGetExpr "\\a -> \\b -> addIntPair((a,b))"
 
-eqExpr :: (Monoid ann, Show ann) => StoreExpression ann
+eqExpr :: StoreExpressionA
 eqExpr = unsafeGetExpr "\\a -> \\b -> eqPair((a,b))"
 
-optionExpr :: (Monoid ann, Show ann) => StoreExpression ann
+optionExpr :: StoreExpressionA
 optionExpr = unsafeGetExpr "type Option a = Some a | Nowt in {}"
 
-aPairExpr :: (Monoid ann, Show ann) => StoreExpression ann
+aPairExpr :: StoreExpressionA
 aPairExpr = unsafeGetExpr "(1,2)"
 
-aRecordExpr :: (Monoid ann, Show ann) => StoreExpression ann
+aRecordExpr :: StoreExpressionA
 aRecordExpr = unsafeGetExpr "{ a: 1, b: \"dog\" }"
 
-stdLib :: (Monoid ann, Show ann) => Project ann
+stdLib :: Project Annotation
 stdLib = Project store' bindings' typeBindings' mempty
   where
     store' =
@@ -97,11 +100,11 @@ stdLib = Project store' bindings' typeBindings' mempty
             (mkTyCon "Nowt", pure $ ExprHash 4)
           ]
 
-unsafeGetExpr' :: (Monoid ann, Show ann) => Text -> Bindings -> StoreExpression ann
+unsafeGetExpr' :: Text -> Bindings -> StoreExpression Annotation
 unsafeGetExpr' input bindings' =
   case parseExpr input of
     Right expr' -> StoreExpression expr' bindings' mempty
     a -> error $ "Error evaluating " <> T.unpack input <> ": " <> show a
 
-unsafeGetExpr :: (Monoid ann, Show ann) => Text -> StoreExpression ann
+unsafeGetExpr :: Text -> StoreExpression Annotation
 unsafeGetExpr input = unsafeGetExpr' input mempty

--- a/test/Test/Helpers.hs
+++ b/test/Test/Helpers.hs
@@ -16,8 +16,8 @@ str' :: (Monoid ann) => Text -> Expr a ann
 str' = str . StringType
 
 --
-unknown :: Int -> MonoType
-unknown = MTVar . NumberedVar
+unknown :: (Monoid ann) => Int -> Type ann
+unknown = MTVar mempty . NumberedVar
 
 ---
 

--- a/test/Test/Interpreter.hs
+++ b/test/Test/Interpreter.hs
@@ -182,33 +182,6 @@ spec =
                 )
         result <- interpret' mempty mempty f
         result `shouldBe` Right (int 1)
-      it "Uses var names in lambdas that conflict with the ones inside our built-in function without breaking" $ do
-        let ifFunc =
-              MyLambda
-                mempty
-                (named "x")
-                ( MyLambda
-                    mempty
-                    (named "y")
-                    ( MyIf
-                        mempty
-                        ( MyApp
-                            mempty
-                            (MyVar mempty (builtIn "eqPair"))
-                            ( MyPair
-                                mempty
-                                (MyVar mempty (named "x"))
-                                (MyVar mempty (named "y"))
-                            )
-                        )
-                        (int 1)
-                        (int 0)
-                    )
-                )
-            f = MyApp mempty (MyApp mempty ifFunc (int 1)) (int 2)
-            scope' = mempty
-        result <- interpret' scope' mempty f
-        result `shouldBe` Right (int 0)
       it "Runs the internals of reduce function" $ do
         let reduceFunc =
               MyLet

--- a/test/Test/Prettier.hs
+++ b/test/Test/Prettier.hs
@@ -13,25 +13,43 @@ import Test.Hspec
 
 spec :: Spec
 spec =
-  describe "Prettier" $
-    describe "MonoType" $
-      do
-        it "String" $
-          T.putStrLn (prettyPrint MTString)
-        it "Function" $
-          T.putStrLn (prettyPrint $ MTFunction (MTFunction MTInt MTString) MTBool)
-        it "Record" $
-          T.putStrLn
-            ( prettyPrint
-                ( MTRecord $
-                    M.fromList
-                      [ (mkName "dog", MTUnit),
-                        (mkName "horse", MTString),
-                        (mkName "maybeDog", MTData (mkTyCon "Maybe") [MTString])
-                      ]
+  describe "Prettier"
+    $ describe "MonoType"
+    $ do
+      it "String" $
+        T.putStrLn (prettyPrint MTString)
+      it "Function" $
+        T.putStrLn
+          ( prettyPrint $
+              MTFunction
+                (MTFunction (MTPrim MTInt) (MTPrim MTString))
+                (MTPrim MTBool)
+          )
+      it "Record" $
+        T.putStrLn
+          ( prettyPrint
+              ( MTRecord $
+                  M.fromList
+                    [ (mkName "dog", MTPrim MTUnit),
+                      (mkName "horse", MTPrim MTString),
+                      (mkName "maybeDog", MTData (mkTyCon "Maybe") [MTPrim MTString])
+                    ]
+              )
+          )
+      it "Pair" $
+        T.putStrLn
+          ( prettyPrint $
+              MTPair
+                (MTFunction (MTPrim MTInt) (MTPrim MTInt))
+                (MTPrim MTString)
+          )
+      it "Variables" $
+        T.putStrLn
+          ( prettyPrint $
+              MTFunction
+                ( MTVar
+                    $ NamedVar
+                    $ Name "catch"
                 )
-            )
-        it "Pair" $
-          T.putStrLn (prettyPrint $ MTPair (MTFunction MTInt MTInt) MTString)
-        it "Variables" $
-          T.putStrLn (prettyPrint $ MTFunction (MTVar $ NamedVar $ Name "catch") (MTVar $ NumberedVar 22))
+                (MTVar $ NumberedVar 22)
+          )

--- a/test/Test/Prettier.hs
+++ b/test/Test/Prettier.hs
@@ -19,37 +19,51 @@ spec =
       it "String" $
         T.putStrLn (prettyPrint MTString)
       it "Function" $
-        T.putStrLn
-          ( prettyPrint $
+        let mt :: MonoType
+            mt =
               MTFunction
-                (MTFunction (MTPrim MTInt) (MTPrim MTString))
-                (MTPrim MTBool)
-          )
-      it "Record" $
-        T.putStrLn
-          ( prettyPrint
-              ( MTRecord $
-                  M.fromList
-                    [ (mkName "dog", MTPrim MTUnit),
-                      (mkName "horse", MTPrim MTString),
-                      (mkName "maybeDog", MTData (mkTyCon "Maybe") [MTPrim MTString])
-                    ]
+                mempty
+                (MTFunction mempty (MTPrim mempty MTInt) (MTPrim mempty MTString))
+                (MTPrim mempty MTBool)
+         in T.putStrLn
+              ( prettyPrint mt
               )
-          )
+      it "Record" $
+        let mt :: MonoType
+            mt =
+              MTRecord mempty $
+                M.fromList
+                  [ (mkName "dog", MTPrim mempty MTUnit),
+                    (mkName "horse", MTPrim mempty MTString),
+                    ( mkName "maybeDog",
+                      MTData
+                        mempty
+                        (mkTyCon "Maybe")
+                        [MTPrim mempty MTString]
+                    )
+                  ]
+         in T.putStrLn
+              ( prettyPrint mt
+              )
       it "Pair" $
-        T.putStrLn
-          ( prettyPrint $
+        let mt :: MonoType
+            mt =
               MTPair
-                (MTFunction (MTPrim MTInt) (MTPrim MTInt))
-                (MTPrim MTString)
-          )
+                mempty
+                (MTFunction mempty (MTPrim mempty MTInt) (MTPrim mempty MTInt))
+                (MTPrim mempty MTString)
+         in T.putStrLn
+              (prettyPrint mt)
       it "Variables" $
-        T.putStrLn
-          ( prettyPrint $
+        let mt :: MonoType
+            mt =
               MTFunction
-                ( MTVar
+                mempty
+                ( MTVar mempty
                     $ NamedVar
                     $ Name "catch"
                 )
-                (MTVar $ NumberedVar 22)
-          )
+                (MTVar mempty $ NumberedVar 22)
+         in T.putStrLn
+              ( prettyPrint mt
+              )

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -72,10 +72,10 @@ spec =
         result <- eval stdLib "let x = ((1,2)) in fst(x)"
         result
           `shouldBe` Right
-            (MTInt, int 1)
+            ((MTPrim MTInt), int 1)
       it "let good = { dog: True } in good.dog" $ do
         result <- eval stdLib "let good = ({ dog: True }) in good.dog"
-        result `shouldBe` Right (MTBool, bool True)
+        result `shouldBe` Right ((MTPrim MTBool), bool True)
       it "let prelude = { id: (\\i -> i) } in prelude.id" $ do
         result <- eval stdLib "let prelude = ({ id: (\\i -> i) }) in prelude.id"
         result
@@ -87,49 +87,49 @@ spec =
         result <- eval stdLib "let prelude = ({ id: (\\i -> i) }) in prelude.id(1)"
         result
           `shouldBe` Right
-            ( MTInt,
+            ( (MTPrim MTInt),
               int 1
             )
       it "let bigPrelude = ({ prelude: { id: (\\i -> i) } }) in bigPrelude.prelude.id(1)" $ do
         result <- eval stdLib "let bigPrelude = ({ prelude: { id: (\\i -> i) } }) in bigPrelude.prelude.id(1)"
         result
           `shouldBe` Right
-            ( MTInt,
+            ( (MTPrim MTInt),
               int 1
             )
       it "let compose = (\\f -> \\g -> \\a -> f(g(a))) in compose(incrementInt)(incrementInt)(67)" $ do
         result <- eval stdLib "let compose = (\\f -> \\g -> \\a -> f(g(a))) in compose(incrementInt)(incrementInt)(67)"
-        result `shouldBe` Right (MTInt, int 69)
+        result `shouldBe` Right ((MTPrim MTInt), int 69)
       it "let reuse = ({ first: id(1), second: id(2) }) in reuse.first" $ do
         result <- eval stdLib "let reuse = ({ first: id(1), second: id(2) }) in reuse.first"
-        result `shouldBe` Right (MTInt, int 1)
+        result `shouldBe` Right ((MTPrim MTInt), int 1)
       it "let id = \\a -> a in id(1)" $ do
         result <- eval mempty "let id = \\a -> a in id(1)"
-        result `shouldBe` Right (MTInt, int 1)
+        result `shouldBe` Right ((MTPrim MTInt), int 1)
       it "let reuse = ({ first: id(True), second: id(2) }) in reuse.first" $ do
         result <- eval stdLib "let reuse = ({ first: id(True), second: id(2) }) in reuse.first"
-        result `shouldBe` Right (MTBool, bool True)
+        result `shouldBe` Right ((MTPrim MTBool), bool True)
       it "let reuse = ({ first: id, second: id(2) }) in reuse.first(True)" $ do
         result <- eval stdLib "let reuse = ({ first: id, second: id(2) }) in reuse.first(True)"
-        result `shouldBe` Right (MTBool, bool True)
+        result `shouldBe` Right ((MTPrim MTBool), bool True)
       it "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(1), second: const2(True) }) in reuse.first(100))" $ do
         result <- eval stdLib "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(1), second: const2(True) }) in reuse.first(100))"
-        result `shouldBe` Right (MTInt, int 1)
+        result `shouldBe` Right ((MTPrim MTInt), int 1)
       it "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(True), second: const2(2) }) in reuse.second(100))" $ do
         result <- eval stdLib "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(True), second: const2(2) }) in reuse.second(100))"
-        result `shouldBe` Right (MTInt, int 2)
+        result `shouldBe` Right ((MTPrim MTInt), int 2)
       it "addInt(1)(2)" $ do
         result <- eval stdLib "addInt(1)(2)"
-        result `shouldBe` Right (MTInt, int 3)
+        result `shouldBe` Right ((MTPrim MTInt), int 3)
       it "(\\a -> a)(1)" $ do
         result <- eval stdLib "(\\a -> a)(1)"
-        result `shouldBe` Right (MTInt, int 1)
+        result `shouldBe` Right ((MTPrim MTInt), int 1)
       it "(\\b -> (\\a -> b))(0)(1)" $ do
         result <- eval stdLib "(\\b -> (\\a -> b))(0)(1)"
-        result `shouldBe` Right (MTInt, int 0)
+        result `shouldBe` Right ((MTPrim MTInt), int 0)
       it "addInt(1)(addInt(addInt(2)(4))(5))" $ do
         result <- eval stdLib "addInt(1)(addInt(addInt(2)(4))(5))"
-        result `shouldBe` Right (MTInt, int 12)
+        result `shouldBe` Right ((MTPrim MTInt), int 12)
       it "type LeBool = Vrai | Faux in Vrai" $ do
         result <- eval stdLib "type LeBool = Vrai | Faux in Vrai"
         result
@@ -185,7 +185,7 @@ spec =
             ( MTFunction
                 (MTData (mkTyCon "OhNat") [])
                 ( MTFunction
-                    MTString
+                    (MTPrim MTString)
                     (MTData (mkTyCon "OhNat") [])
                 ),
               MyConstructor mempty (mkTyCon "Suc")
@@ -202,7 +202,7 @@ spec =
             )
       it "type Void in 1" $ do
         result <- eval stdLib "type Void in 1"
-        result `shouldBe` Right (MTInt, int 1)
+        result `shouldBe` Right ((MTPrim MTInt), int 1)
       it "type String = Should | Error in Error" $ do
         result <- eval stdLib "type String = Should | Error in Error"
         result `shouldSatisfy` isLeft
@@ -211,9 +211,9 @@ spec =
         result
           `shouldBe` Right
             ( MTFunction
-                MTInt
+                (MTPrim MTInt)
                 ( MTFunction
-                    MTString
+                    (MTPrim MTString)
                     (MTData (mkTyCon "LongBoy") [])
                 ),
               MyConsApp
@@ -255,7 +255,7 @@ spec =
         result <- eval stdLib "type Maybe a = Just a | Nothing in Just 1"
         result
           `shouldBe` Right
-            ( MTData (mkTyCon "Maybe") [MTInt],
+            ( MTData (mkTyCon "Maybe") [(MTPrim MTInt)],
               MyConsApp
                 mempty
                 (MyConstructor mempty $ mkTyCon "Just")
@@ -265,7 +265,7 @@ spec =
         result <- eval stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | Nothing False"
         result
           `shouldBe` Right
-            (MTBool, bool False)
+            ((MTPrim MTBool), bool False)
       it "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> True | Nothing 1" $ do
         result <- eval stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> True | Nothing 1"
         result `shouldSatisfy` isLeft
@@ -273,26 +273,26 @@ spec =
         result <- eval stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | otherwise False"
         result
           `shouldBe` Right
-            (MTBool, bool False)
+            ((MTPrim MTBool), bool False)
       it "type Stuff = Thing String Int in case Thing \"Hello\" 1 of Thing \\name -> \\num -> name" $ do
         result <- eval stdLib "type Stuff = Thing String Int in case Thing \"Hello\" 1 of Thing \\name -> \\num -> name"
         result
           `shouldBe` Right
-            (MTString, str' "Hello")
+            ((MTPrim MTString), str' "Hello")
       it "type Result e a = Failure e | Success a in case Failure \"oh no\" of Success \\a -> \"oh yes\" | Failure \\e -> e" $ do
         result <- eval stdLib "type Result e a = Failure e | Success a in case Failure \"oh no\" of Success \\a -> \"oh yes\" | Failure \\e -> e"
         result
           `shouldBe` Right
-            (MTString, str' "oh no")
+            ((MTPrim MTString), str' "oh no")
       it "type Blap a = Boop a Int in case Boop True 100 of Boop \\a -> \\b -> a" $ do
         result <- eval stdLib "type Blap a = Boop a Int in case Boop True 100 of Boop \\a -> \\b -> a"
-        result `shouldBe` Right (MTBool, bool True)
+        result `shouldBe` Right ((MTPrim MTBool), bool True)
       it "type Maybe a = Just a | Nothing in case Nothing of Nothing False" $ do
         result <- eval stdLib "type Maybe a = Just a | Nothing in case Nothing of Nothing False"
         result `shouldSatisfy` isLeft
       it "type Thing = Thing String in let a = Thing \"string\" in case a of Thing \\s -> s" $ do
         result <- eval stdLib "type Thing = Thing String in let a = Thing \"string\" in case a of Thing \\s -> s"
-        result `shouldBe` Right (MTString, str' "string")
+        result `shouldBe` Right ((MTPrim MTString), str' "string")
       it "type Pair a b = Pair a b in case Pair \"dog\" 1 of Pair \a -> a" $ do
         result <- eval stdLib "type Pair a b = Pair a b in case Pair \"dog\" 1 of Pair \a -> a"
         result `shouldSatisfy` isLeft
@@ -300,7 +300,7 @@ spec =
         result <- eval stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree a) in Leaf 1"
         result
           `shouldBe` Right
-            ( MTData (mkTyCon "Tree") [MTInt],
+            ( MTData (mkTyCon "Tree") [(MTPrim MTInt)],
               MyConsApp
                 mempty
                 (MyConstructor mempty $ mkTyCon "Leaf")
@@ -318,7 +318,7 @@ spec =
         result <- eval stdLib "type Tree a = Empty | Branch (Tree a) a (Tree a) in Branch (Empty) 1 (Empty)"
         result
           `shouldBe` Right
-            ( MTData (mkTyCon "Tree") [MTInt],
+            ( MTData (mkTyCon "Tree") [(MTPrim MTInt)],
               MyConsApp
                 mempty
                 ( MyConsApp
@@ -343,7 +343,7 @@ spec =
               result <- eval stdLib "type Maybe a = Just a | Nothing in \\maybe -> case maybe of Just \\a -> a | Nothing \"poo\""
               fst <$> result
                 `shouldBe` Right
-                  ( MTFunction (MTData (mkTyCon "Maybe") []) MTString
+                  ( MTFunction (MTData (mkTyCon "Maybe") []) (MTPrim MTString)
                   )
       
       -}
@@ -351,7 +351,7 @@ spec =
         result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in case (Item 1 (Item 2 Empty)) of Empty Empty | Item \\a -> \\rest -> rest"
         result
           `shouldBe` Right
-            ( MTData (mkTyCon "Arr") [MTInt],
+            ( MTData (mkTyCon "Arr") [(MTPrim MTInt)],
               MyConsApp
                 mempty
                 ( MyConsApp
@@ -366,29 +366,29 @@ spec =
             )
       it "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)" $ do
         result <- eval stdLib "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)"
-        result `shouldBe` Right (MTInt, int 10)
+        result `shouldBe` Right ((MTPrim MTInt), int 10)
       it "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Suc Suc Zero)" $ do
         result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Suc Suc Zero)"
-        result `shouldBe` Right (MTInt, int 3)
+        result `shouldBe` Right ((MTPrim MTInt), int 3)
       it "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> incrementInt(loop(as2)(b))) in loop(Suc Suc Suc Zero)(10)" $ do
         result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> incrementInt(loop(as2)(b))) in loop(Suc Suc Suc Zero)(10)"
-        result `shouldBe` Right (MTInt, int 13)
+        result `shouldBe` Right ((MTPrim MTInt), int 13)
       {-
             it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)" $ do
               result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)"
-              result `shouldBe` Right (MTInt, int 3)
+              result `shouldBe` Right ((MTPrim MTInt), int 3)
       -}
       it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty)" $ do
         result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty)"
-        result `shouldBe` Right (MTInt, int 0)
+        result `shouldBe` Right ((MTPrim MTInt), int 0)
       it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Item 3 Empty)" $ do
         result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Item 3 Empty)"
-        result `shouldBe` Right (MTInt, int 3)
+        result `shouldBe` Right ((MTPrim MTInt), int 3)
       it "let some = \\a -> Some a in if True then some(1) else Nowt" $ do
         result <- eval stdLib "let some = \\a -> Some a in if True then some(1) else Nowt"
         result
           `shouldBe` Right
-            ( MTData (mkTyCon "Option") [MTInt],
+            ( MTData (mkTyCon "Option") [(MTPrim MTInt)],
               MyConsApp
                 mempty
                 (MyConstructor mempty (mkTyCon "Some"))
@@ -402,13 +402,13 @@ spec =
         result <- eval stdLib "\\a -> case a of Some \\as -> as | Nowt 100"
         fst <$> result
           `shouldBe` Right
-            (MTFunction (MTData (mkTyCon "Option") [MTInt]) MTInt)
+            (MTFunction (MTData (mkTyCon "Option") [(MTPrim MTInt)]) (MTPrim MTInt))
       it "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some 1)" $ do
         result <- eval stdLib "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some 1)"
         result `shouldSatisfy` isLeft
       it "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some \"Dog\")" $ do
         result <- eval stdLib "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some \"Dog\")"
-        result `shouldBe` Right (MTString, str' "Dog")
+        result `shouldBe` Right ((MTPrim MTString), str' "Dog")
       it "True == \"dog\"" $ do
         result <- eval stdLib "True == \"dog\""
         result `shouldSatisfy` isLeft
@@ -418,13 +418,13 @@ spec =
         result `shouldSatisfy` isLeft
       it "True == False" $ do
         result <- eval stdLib "True == False"
-        result `shouldBe` Right (MTBool, bool False)
+        result `shouldBe` Right ((MTPrim MTBool), bool False)
       it "True == True" $ do
         result <- eval stdLib "True == True"
-        result `shouldBe` Right (MTBool, bool True)
+        result `shouldBe` Right ((MTPrim MTBool), bool True)
       it "(Some 1) == Some 2" $ do
         result <- eval stdLib "(Some 1) == Some 2"
-        result `shouldBe` Right (MTBool, bool False)
+        result `shouldBe` Right ((MTPrim MTBool), bool False)
       it "let eq1 = \\a -> a == 1 in eq1(1)" $ do
         result <- eval stdLib "let eq1 = \\a -> a == 1 in eq1(1)"
-        result `shouldBe` Right (MTBool, bool True)
+        result `shouldBe` Right ((MTPrim MTBool), bool True)

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -72,10 +72,10 @@ spec =
         result <- eval stdLib "let x = ((1,2)) in fst(x)"
         result
           `shouldBe` Right
-            ((MTPrim MTInt), int 1)
+            (MTPrim MTInt, int 1)
       it "let good = { dog: True } in good.dog" $ do
         result <- eval stdLib "let good = ({ dog: True }) in good.dog"
-        result `shouldBe` Right ((MTPrim MTBool), bool True)
+        result `shouldBe` Right (MTPrim MTBool, bool True)
       it "let prelude = { id: (\\i -> i) } in prelude.id" $ do
         result <- eval stdLib "let prelude = ({ id: (\\i -> i) }) in prelude.id"
         result
@@ -87,49 +87,49 @@ spec =
         result <- eval stdLib "let prelude = ({ id: (\\i -> i) }) in prelude.id(1)"
         result
           `shouldBe` Right
-            ( (MTPrim MTInt),
+            ( MTPrim MTInt,
               int 1
             )
       it "let bigPrelude = ({ prelude: { id: (\\i -> i) } }) in bigPrelude.prelude.id(1)" $ do
         result <- eval stdLib "let bigPrelude = ({ prelude: { id: (\\i -> i) } }) in bigPrelude.prelude.id(1)"
         result
           `shouldBe` Right
-            ( (MTPrim MTInt),
+            ( MTPrim MTInt,
               int 1
             )
       it "let compose = (\\f -> \\g -> \\a -> f(g(a))) in compose(incrementInt)(incrementInt)(67)" $ do
         result <- eval stdLib "let compose = (\\f -> \\g -> \\a -> f(g(a))) in compose(incrementInt)(incrementInt)(67)"
-        result `shouldBe` Right ((MTPrim MTInt), int 69)
+        result `shouldBe` Right (MTPrim MTInt, int 69)
       it "let reuse = ({ first: id(1), second: id(2) }) in reuse.first" $ do
         result <- eval stdLib "let reuse = ({ first: id(1), second: id(2) }) in reuse.first"
-        result `shouldBe` Right ((MTPrim MTInt), int 1)
+        result `shouldBe` Right (MTPrim MTInt, int 1)
       it "let id = \\a -> a in id(1)" $ do
         result <- eval mempty "let id = \\a -> a in id(1)"
-        result `shouldBe` Right ((MTPrim MTInt), int 1)
+        result `shouldBe` Right (MTPrim MTInt, int 1)
       it "let reuse = ({ first: id(True), second: id(2) }) in reuse.first" $ do
         result <- eval stdLib "let reuse = ({ first: id(True), second: id(2) }) in reuse.first"
-        result `shouldBe` Right ((MTPrim MTBool), bool True)
+        result `shouldBe` Right (MTPrim MTBool, bool True)
       it "let reuse = ({ first: id, second: id(2) }) in reuse.first(True)" $ do
         result <- eval stdLib "let reuse = ({ first: id, second: id(2) }) in reuse.first(True)"
-        result `shouldBe` Right ((MTPrim MTBool), bool True)
+        result `shouldBe` Right (MTPrim MTBool, bool True)
       it "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(1), second: const2(True) }) in reuse.first(100))" $ do
         result <- eval stdLib "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(1), second: const2(True) }) in reuse.first(100))"
-        result `shouldBe` Right ((MTPrim MTInt), int 1)
+        result `shouldBe` Right (MTPrim MTInt, int 1)
       it "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(True), second: const2(2) }) in reuse.second(100))" $ do
         result <- eval stdLib "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(True), second: const2(2) }) in reuse.second(100))"
-        result `shouldBe` Right ((MTPrim MTInt), int 2)
+        result `shouldBe` Right (MTPrim MTInt, int 2)
       it "addInt(1)(2)" $ do
         result <- eval stdLib "addInt(1)(2)"
-        result `shouldBe` Right ((MTPrim MTInt), int 3)
+        result `shouldBe` Right (MTPrim MTInt, int 3)
       it "(\\a -> a)(1)" $ do
         result <- eval stdLib "(\\a -> a)(1)"
-        result `shouldBe` Right ((MTPrim MTInt), int 1)
+        result `shouldBe` Right (MTPrim MTInt, int 1)
       it "(\\b -> (\\a -> b))(0)(1)" $ do
         result <- eval stdLib "(\\b -> (\\a -> b))(0)(1)"
-        result `shouldBe` Right ((MTPrim MTInt), int 0)
+        result `shouldBe` Right (MTPrim MTInt, int 0)
       it "addInt(1)(addInt(addInt(2)(4))(5))" $ do
         result <- eval stdLib "addInt(1)(addInt(addInt(2)(4))(5))"
-        result `shouldBe` Right ((MTPrim MTInt), int 12)
+        result `shouldBe` Right (MTPrim MTInt, int 12)
       it "type LeBool = Vrai | Faux in Vrai" $ do
         result <- eval stdLib "type LeBool = Vrai | Faux in Vrai"
         result
@@ -202,7 +202,7 @@ spec =
             )
       it "type Void in 1" $ do
         result <- eval stdLib "type Void in 1"
-        result `shouldBe` Right ((MTPrim MTInt), int 1)
+        result `shouldBe` Right (MTPrim MTInt, int 1)
       it "type String = Should | Error in Error" $ do
         result <- eval stdLib "type String = Should | Error in Error"
         result `shouldSatisfy` isLeft
@@ -255,7 +255,7 @@ spec =
         result <- eval stdLib "type Maybe a = Just a | Nothing in Just 1"
         result
           `shouldBe` Right
-            ( MTData (mkTyCon "Maybe") [(MTPrim MTInt)],
+            ( MTData (mkTyCon "Maybe") [MTPrim MTInt],
               MyConsApp
                 mempty
                 (MyConstructor mempty $ mkTyCon "Just")
@@ -265,7 +265,7 @@ spec =
         result <- eval stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | Nothing False"
         result
           `shouldBe` Right
-            ((MTPrim MTBool), bool False)
+            (MTPrim MTBool, bool False)
       it "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> True | Nothing 1" $ do
         result <- eval stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> True | Nothing 1"
         result `shouldSatisfy` isLeft
@@ -273,26 +273,26 @@ spec =
         result <- eval stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | otherwise False"
         result
           `shouldBe` Right
-            ((MTPrim MTBool), bool False)
+            (MTPrim MTBool, bool False)
       it "type Stuff = Thing String Int in case Thing \"Hello\" 1 of Thing \\name -> \\num -> name" $ do
         result <- eval stdLib "type Stuff = Thing String Int in case Thing \"Hello\" 1 of Thing \\name -> \\num -> name"
         result
           `shouldBe` Right
-            ((MTPrim MTString), str' "Hello")
+            (MTPrim MTString, str' "Hello")
       it "type Result e a = Failure e | Success a in case Failure \"oh no\" of Success \\a -> \"oh yes\" | Failure \\e -> e" $ do
         result <- eval stdLib "type Result e a = Failure e | Success a in case Failure \"oh no\" of Success \\a -> \"oh yes\" | Failure \\e -> e"
         result
           `shouldBe` Right
-            ((MTPrim MTString), str' "oh no")
+            (MTPrim MTString, str' "oh no")
       it "type Blap a = Boop a Int in case Boop True 100 of Boop \\a -> \\b -> a" $ do
         result <- eval stdLib "type Blap a = Boop a Int in case Boop True 100 of Boop \\a -> \\b -> a"
-        result `shouldBe` Right ((MTPrim MTBool), bool True)
+        result `shouldBe` Right (MTPrim MTBool, bool True)
       it "type Maybe a = Just a | Nothing in case Nothing of Nothing False" $ do
         result <- eval stdLib "type Maybe a = Just a | Nothing in case Nothing of Nothing False"
         result `shouldSatisfy` isLeft
       it "type Thing = Thing String in let a = Thing \"string\" in case a of Thing \\s -> s" $ do
         result <- eval stdLib "type Thing = Thing String in let a = Thing \"string\" in case a of Thing \\s -> s"
-        result `shouldBe` Right ((MTPrim MTString), str' "string")
+        result `shouldBe` Right (MTPrim MTString, str' "string")
       it "type Pair a b = Pair a b in case Pair \"dog\" 1 of Pair \a -> a" $ do
         result <- eval stdLib "type Pair a b = Pair a b in case Pair \"dog\" 1 of Pair \a -> a"
         result `shouldSatisfy` isLeft
@@ -300,7 +300,7 @@ spec =
         result <- eval stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree a) in Leaf 1"
         result
           `shouldBe` Right
-            ( MTData (mkTyCon "Tree") [(MTPrim MTInt)],
+            ( MTData (mkTyCon "Tree") [MTPrim MTInt],
               MyConsApp
                 mempty
                 (MyConstructor mempty $ mkTyCon "Leaf")
@@ -318,7 +318,7 @@ spec =
         result <- eval stdLib "type Tree a = Empty | Branch (Tree a) a (Tree a) in Branch (Empty) 1 (Empty)"
         result
           `shouldBe` Right
-            ( MTData (mkTyCon "Tree") [(MTPrim MTInt)],
+            ( MTData (mkTyCon "Tree") [MTPrim MTInt],
               MyConsApp
                 mempty
                 ( MyConsApp
@@ -351,7 +351,7 @@ spec =
         result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in case (Item 1 (Item 2 Empty)) of Empty Empty | Item \\a -> \\rest -> rest"
         result
           `shouldBe` Right
-            ( MTData (mkTyCon "Arr") [(MTPrim MTInt)],
+            ( MTData (mkTyCon "Arr") [MTPrim MTInt],
               MyConsApp
                 mempty
                 ( MyConsApp
@@ -366,29 +366,29 @@ spec =
             )
       it "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)" $ do
         result <- eval stdLib "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)"
-        result `shouldBe` Right ((MTPrim MTInt), int 10)
+        result `shouldBe` Right (MTPrim MTInt, int 10)
       it "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Suc Suc Zero)" $ do
         result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Suc Suc Zero)"
-        result `shouldBe` Right ((MTPrim MTInt), int 3)
+        result `shouldBe` Right (MTPrim MTInt, int 3)
       it "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> incrementInt(loop(as2)(b))) in loop(Suc Suc Suc Zero)(10)" $ do
         result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> incrementInt(loop(as2)(b))) in loop(Suc Suc Suc Zero)(10)"
-        result `shouldBe` Right ((MTPrim MTInt), int 13)
+        result `shouldBe` Right (MTPrim MTInt, int 13)
       {-
             it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)" $ do
               result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)"
-              result `shouldBe` Right ((MTPrim MTInt), int 3)
+              result `shouldBe` Right (MTPrim MTInt, int 3)
       -}
       it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty)" $ do
         result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty)"
-        result `shouldBe` Right ((MTPrim MTInt), int 0)
+        result `shouldBe` Right (MTPrim MTInt, int 0)
       it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Item 3 Empty)" $ do
         result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Item 3 Empty)"
-        result `shouldBe` Right ((MTPrim MTInt), int 3)
+        result `shouldBe` Right (MTPrim MTInt, int 3)
       it "let some = \\a -> Some a in if True then some(1) else Nowt" $ do
         result <- eval stdLib "let some = \\a -> Some a in if True then some(1) else Nowt"
         result
           `shouldBe` Right
-            ( MTData (mkTyCon "Option") [(MTPrim MTInt)],
+            ( MTData (mkTyCon "Option") [MTPrim MTInt],
               MyConsApp
                 mempty
                 (MyConstructor mempty (mkTyCon "Some"))
@@ -402,13 +402,13 @@ spec =
         result <- eval stdLib "\\a -> case a of Some \\as -> as | Nowt 100"
         fst <$> result
           `shouldBe` Right
-            (MTFunction (MTData (mkTyCon "Option") [(MTPrim MTInt)]) (MTPrim MTInt))
+            (MTFunction (MTData (mkTyCon "Option") [MTPrim MTInt]) (MTPrim MTInt))
       it "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some 1)" $ do
         result <- eval stdLib "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some 1)"
         result `shouldSatisfy` isLeft
       it "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some \"Dog\")" $ do
         result <- eval stdLib "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some \"Dog\")"
-        result `shouldBe` Right ((MTPrim MTString), str' "Dog")
+        result `shouldBe` Right (MTPrim MTString, str' "Dog")
       it "True == \"dog\"" $ do
         result <- eval stdLib "True == \"dog\""
         result `shouldSatisfy` isLeft
@@ -418,13 +418,13 @@ spec =
         result `shouldSatisfy` isLeft
       it "True == False" $ do
         result <- eval stdLib "True == False"
-        result `shouldBe` Right ((MTPrim MTBool), bool False)
+        result `shouldBe` Right (MTPrim MTBool, bool False)
       it "True == True" $ do
         result <- eval stdLib "True == True"
-        result `shouldBe` Right ((MTPrim MTBool), bool True)
+        result `shouldBe` Right (MTPrim MTBool, bool True)
       it "(Some 1) == Some 2" $ do
         result <- eval stdLib "(Some 1) == Some 2"
-        result `shouldBe` Right ((MTPrim MTBool), bool False)
+        result `shouldBe` Right (MTPrim MTBool, bool False)
       it "let eq1 = \\a -> a == 1 in eq1(1)" $ do
         result <- eval stdLib "let eq1 = \\a -> a == 1 in eq1(1)"
-        result `shouldBe` Right ((MTPrim MTBool), bool True)
+        result `shouldBe` Right (MTPrim MTBool, bool True)

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -22,18 +22,10 @@ import Test.Data.Project
 import Test.Helpers
 import Test.Hspec
 
-eval' :: Project () -> Text -> IO (Either Text (MonoType, Expr Variable ()))
-eval' = eval
-
 eval ::
-  ( Eq ann,
-    Monoid ann,
-    Show ann,
-    Printer ann
-  ) =>
-  Project ann ->
+  Project Annotation ->
   Text ->
-  IO (Either Text (MonoType, Expr Variable ann))
+  IO (Either Text (MonoType, Expr Variable Annotation))
 eval env input =
   case prettyPrintingParses input of
     Left e -> pure (Left $ prettyPrint e)
@@ -53,7 +45,7 @@ prettyPrintingParses input = do
   expr1 <- parseExprAndFormatError input
   case parseExprAndFormatError (prettyPrint expr1) of
     Left e -> Left e
-    Right (expr2 :: Expr Name ()) ->
+    Right expr2 ->
       if expr1 /= expr2
         then
           Left
@@ -73,76 +65,76 @@ spec =
     $ describe "End to end parsing to evaluation"
     $ do
       it "let x = ((1,2)) in fst(x)" $ do
-        result <- eval' stdLib "let x = ((1,2)) in fst(x)"
+        result <- eval stdLib "let x = ((1,2)) in fst(x)"
         result
           `shouldBe` Right
             (MTInt, int 1)
       it "let good = { dog: True } in good.dog" $ do
-        result <- eval' stdLib "let good = ({ dog: True }) in good.dog"
+        result <- eval stdLib "let good = ({ dog: True }) in good.dog"
         result `shouldBe` Right (MTBool, bool True)
       it "let prelude = { id: (\\i -> i) } in prelude.id" $ do
-        result <- eval' stdLib "let prelude = ({ id: (\\i -> i) }) in prelude.id"
+        result <- eval stdLib "let prelude = ({ id: (\\i -> i) }) in prelude.id"
         result
           `shouldBe` Right
             ( MTFunction (unknown 4) (unknown 4),
               MyLambda mempty (named "i") (MyVar mempty (named "i"))
             )
       it "let prelude = ({ id: (\\i -> i) }) in prelude.id(1)" $ do
-        result <- eval' stdLib "let prelude = ({ id: (\\i -> i) }) in prelude.id(1)"
+        result <- eval stdLib "let prelude = ({ id: (\\i -> i) }) in prelude.id(1)"
         result
           `shouldBe` Right
             ( MTInt,
               int 1
             )
       it "let bigPrelude = ({ prelude: { id: (\\i -> i) } }) in bigPrelude.prelude.id(1)" $ do
-        result <- eval' stdLib "let bigPrelude = ({ prelude: { id: (\\i -> i) } }) in bigPrelude.prelude.id(1)"
+        result <- eval stdLib "let bigPrelude = ({ prelude: { id: (\\i -> i) } }) in bigPrelude.prelude.id(1)"
         result
           `shouldBe` Right
             ( MTInt,
               int 1
             )
       it "let compose = (\\f -> \\g -> \\a -> f(g(a))) in compose(incrementInt)(incrementInt)(67)" $ do
-        result <- eval' stdLib "let compose = (\\f -> \\g -> \\a -> f(g(a))) in compose(incrementInt)(incrementInt)(67)"
+        result <- eval stdLib "let compose = (\\f -> \\g -> \\a -> f(g(a))) in compose(incrementInt)(incrementInt)(67)"
         result `shouldBe` Right (MTInt, int 69)
       it "let reuse = ({ first: id(1), second: id(2) }) in reuse.first" $ do
-        result <- eval' stdLib "let reuse = ({ first: id(1), second: id(2) }) in reuse.first"
+        result <- eval stdLib "let reuse = ({ first: id(1), second: id(2) }) in reuse.first"
         result `shouldBe` Right (MTInt, int 1)
       it "let id = \\a -> a in id(1)" $ do
-        result <- eval' mempty "let id = \\a -> a in id(1)"
+        result <- eval mempty "let id = \\a -> a in id(1)"
         result `shouldBe` Right (MTInt, int 1)
       it "let reuse = ({ first: id(True), second: id(2) }) in reuse.first" $ do
-        result <- eval' stdLib "let reuse = ({ first: id(True), second: id(2) }) in reuse.first"
+        result <- eval stdLib "let reuse = ({ first: id(True), second: id(2) }) in reuse.first"
         result `shouldBe` Right (MTBool, bool True)
       it "let reuse = ({ first: id, second: id(2) }) in reuse.first(True)" $ do
-        result <- eval' stdLib "let reuse = ({ first: id, second: id(2) }) in reuse.first(True)"
+        result <- eval stdLib "let reuse = ({ first: id, second: id(2) }) in reuse.first(True)"
         result `shouldBe` Right (MTBool, bool True)
       it "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(1), second: const2(True) }) in reuse.first(100))" $ do
-        result <- eval' stdLib "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(1), second: const2(True) }) in reuse.first(100))"
+        result <- eval stdLib "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(1), second: const2(True) }) in reuse.first(100))"
         result `shouldBe` Right (MTInt, int 1)
       it "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(True), second: const2(2) }) in reuse.second(100))" $ do
-        result <- eval' stdLib "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(True), second: const2(2) }) in reuse.second(100))"
+        result <- eval stdLib "let const2 = \\a -> \\b -> a in (let reuse = ({ first: const2(True), second: const2(2) }) in reuse.second(100))"
         result `shouldBe` Right (MTInt, int 2)
       it "addInt(1)(2)" $ do
-        result <- eval' stdLib "addInt(1)(2)"
+        result <- eval stdLib "addInt(1)(2)"
         result `shouldBe` Right (MTInt, int 3)
       it "(\\a -> a)(1)" $ do
-        result <- eval' stdLib "(\\a -> a)(1)"
+        result <- eval stdLib "(\\a -> a)(1)"
         result `shouldBe` Right (MTInt, int 1)
       it "(\\b -> (\\a -> b))(0)(1)" $ do
-        result <- eval' stdLib "(\\b -> (\\a -> b))(0)(1)"
+        result <- eval stdLib "(\\b -> (\\a -> b))(0)(1)"
         result `shouldBe` Right (MTInt, int 0)
       it "addInt(1)(addInt(addInt(2)(4))(5))" $ do
-        result <- eval' stdLib "addInt(1)(addInt(addInt(2)(4))(5))"
+        result <- eval stdLib "addInt(1)(addInt(addInt(2)(4))(5))"
         result `shouldBe` Right (MTInt, int 12)
       it "type LeBool = Vrai | Faux in Vrai" $ do
-        result <- eval' stdLib "type LeBool = Vrai | Faux in Vrai"
+        result <- eval stdLib "type LeBool = Vrai | Faux in Vrai"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "LeBool") [],
               MyConstructor mempty (mkTyCon "Vrai")
             )
       it "type Nat = Zero | Suc Nat in Suc Zero" $ do
-        result <- eval' stdLib "type Nat = Zero | Suc Nat in Suc Zero"
+        result <- eval stdLib "type Nat = Zero | Suc Nat in Suc Zero"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Nat") [],
@@ -152,7 +144,7 @@ spec =
                 (MyConstructor mempty (mkTyCon "Zero"))
             )
       it "type Nat = Zero | Suc Nat in Suc Suc Zero" $ do
-        result <- eval' stdLib "type Nat = Zero | Suc Nat in Suc Suc Zero"
+        result <- eval stdLib "type Nat = Zero | Suc Nat in Suc Suc Zero"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Nat") [],
@@ -166,15 +158,15 @@ spec =
                 )
             )
       it "type Nat = Zero | Suc Nat in Suc 1" $ do
-        result <- eval' stdLib "type Nat = Zero | Suc Nat in Suc 1"
+        result <- eval stdLib "type Nat = Zero | Suc Nat in Suc 1"
         result
           `shouldSatisfy` isLeft
       it "type Nat = Zero | Suc Nat in Suc Dog" $ do
-        result <- eval' stdLib "type Nat = Zero | Suc Nat in Suc Dog"
+        result <- eval stdLib "type Nat = Zero | Suc Nat in Suc Dog"
         result
           `shouldSatisfy` isLeft
       it "type Nat = Zero | Suc Nat in Suc" $ do
-        result <- eval' stdLib "type Nat = Zero | Suc Nat in Suc"
+        result <- eval stdLib "type Nat = Zero | Suc Nat in Suc"
         result
           `shouldBe` Right
             ( MTFunction
@@ -183,7 +175,7 @@ spec =
               MyConstructor mempty (mkTyCon "Suc")
             )
       it "type OhNat = Zero | Suc OhNat String in Suc" $ do
-        result <- eval' stdLib "type OhNat = Zero | Suc OhNat String in Suc"
+        result <- eval stdLib "type OhNat = Zero | Suc OhNat String in Suc"
         result
           `shouldBe` Right
             ( MTFunction
@@ -195,7 +187,7 @@ spec =
               MyConstructor mempty (mkTyCon "Suc")
             )
       it "type Pet = Cat String | Dog String in Cat \"mimsa\"" $ do
-        result <- eval' stdLib "type Pet = Cat String | Dog String in Cat \"mimsa\""
+        result <- eval stdLib "type Pet = Cat String | Dog String in Cat \"mimsa\""
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Pet") [],
@@ -205,13 +197,13 @@ spec =
                 (str' "mimsa")
             )
       it "type Void in 1" $ do
-        result <- eval' stdLib "type Void in 1"
+        result <- eval stdLib "type Void in 1"
         result `shouldBe` Right (MTInt, int 1)
       it "type String = Should | Error in Error" $ do
-        result <- eval' stdLib "type String = Should | Error in Error"
+        result <- eval stdLib "type String = Should | Error in Error"
         result `shouldSatisfy` isLeft
       it "type LongBoy = Stuff String Int String in Stuff \"yes\"" $ do
-        result <- eval' stdLib "type LongBoy = Stuff String Int String in Stuff \"yes\""
+        result <- eval stdLib "type LongBoy = Stuff String Int String in Stuff \"yes\""
         result
           `shouldBe` Right
             ( MTFunction
@@ -226,7 +218,7 @@ spec =
                 (str' "yes")
             )
       it "type Tree = Leaf Int | Branch Tree Tree in Branch (Leaf 1) (Leaf 2)" $ do
-        result <- eval' stdLib "type Tree = Leaf Int | Branch Tree Tree in Branch (Leaf 1) (Leaf 2)"
+        result <- eval stdLib "type Tree = Leaf Int | Branch Tree Tree in Branch (Leaf 1) (Leaf 2)"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Tree") [],
@@ -240,7 +232,7 @@ spec =
                 (MyConsApp mempty (MyConstructor mempty $ mkTyCon "Leaf") (int 2))
             )
       it "type Maybe a = Just a | Nothing in Just" $ do
-        result <- eval' stdLib "type Maybe a = Just a | Nothing in Just"
+        result <- eval stdLib "type Maybe a = Just a | Nothing in Just"
         result
           `shouldBe` Right
             ( MTFunction
@@ -249,14 +241,14 @@ spec =
               MyConstructor mempty $ mkTyCon "Just"
             )
       it "type Maybe a = Just a | Nothing in Nothing" $ do
-        result <- eval' stdLib "type Maybe a = Just a | Nothing in Nothing"
+        result <- eval stdLib "type Maybe a = Just a | Nothing in Nothing"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Maybe") [MTVar (NumberedVar 1)],
               MyConstructor mempty $ mkTyCon "Nothing"
             )
       it "type Maybe a = Just a | Nothing in Just 1" $ do
-        result <- eval' stdLib "type Maybe a = Just a | Nothing in Just 1"
+        result <- eval stdLib "type Maybe a = Just a | Nothing in Just 1"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Maybe") [MTInt],
@@ -266,42 +258,42 @@ spec =
                 (int 1)
             )
       it "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | Nothing False" $ do
-        result <- eval' stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | Nothing False"
+        result <- eval stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | Nothing False"
         result
           `shouldBe` Right
             (MTBool, bool False)
       it "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> True | Nothing 1" $ do
-        result <- eval' stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> True | Nothing 1"
+        result <- eval stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> True | Nothing 1"
         result `shouldSatisfy` isLeft
       it "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | otherwise False" $ do
-        result <- eval' stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | otherwise False"
+        result <- eval stdLib "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | otherwise False"
         result
           `shouldBe` Right
             (MTBool, bool False)
       it "type Stuff = Thing String Int in case Thing \"Hello\" 1 of Thing \\name -> \\num -> name" $ do
-        result <- eval' stdLib "type Stuff = Thing String Int in case Thing \"Hello\" 1 of Thing \\name -> \\num -> name"
+        result <- eval stdLib "type Stuff = Thing String Int in case Thing \"Hello\" 1 of Thing \\name -> \\num -> name"
         result
           `shouldBe` Right
             (MTString, str' "Hello")
       it "type Result e a = Failure e | Success a in case Failure \"oh no\" of Success \\a -> \"oh yes\" | Failure \\e -> e" $ do
-        result <- eval' stdLib "type Result e a = Failure e | Success a in case Failure \"oh no\" of Success \\a -> \"oh yes\" | Failure \\e -> e"
+        result <- eval stdLib "type Result e a = Failure e | Success a in case Failure \"oh no\" of Success \\a -> \"oh yes\" | Failure \\e -> e"
         result
           `shouldBe` Right
             (MTString, str' "oh no")
       it "type Blap a = Boop a Int in case Boop True 100 of Boop \\a -> \\b -> a" $ do
-        result <- eval' stdLib "type Blap a = Boop a Int in case Boop True 100 of Boop \\a -> \\b -> a"
+        result <- eval stdLib "type Blap a = Boop a Int in case Boop True 100 of Boop \\a -> \\b -> a"
         result `shouldBe` Right (MTBool, bool True)
       it "type Maybe a = Just a | Nothing in case Nothing of Nothing False" $ do
-        result <- eval' stdLib "type Maybe a = Just a | Nothing in case Nothing of Nothing False"
+        result <- eval stdLib "type Maybe a = Just a | Nothing in case Nothing of Nothing False"
         result `shouldSatisfy` isLeft
       it "type Thing = Thing String in let a = Thing \"string\" in case a of Thing \\s -> s" $ do
-        result <- eval' stdLib "type Thing = Thing String in let a = Thing \"string\" in case a of Thing \\s -> s"
+        result <- eval stdLib "type Thing = Thing String in let a = Thing \"string\" in case a of Thing \\s -> s"
         result `shouldBe` Right (MTString, str' "string")
       it "type Pair a b = Pair a b in case Pair \"dog\" 1 of Pair \a -> a" $ do
-        result <- eval' stdLib "type Pair a b = Pair a b in case Pair \"dog\" 1 of Pair \a -> a"
+        result <- eval stdLib "type Pair a b = Pair a b in case Pair \"dog\" 1 of Pair \a -> a"
         result `shouldSatisfy` isLeft
       it "type Tree a = Leaf a | Branch (Tree a) (Tree a) in Leaf 1" $ do
-        result <- eval' stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree a) in Leaf 1"
+        result <- eval stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree a) in Leaf 1"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Tree") [MTInt],
@@ -311,15 +303,15 @@ spec =
                 (int 1)
             )
       it "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Leaf 1" $ do
-        result <- eval' stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Leaf 1"
+        result <- eval stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Leaf 1"
         result
           `shouldSatisfy` isLeft
       it "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Branch (Leaf 1) (Leaf True)" $ do
-        result <- eval' stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Branch (Leaf 1) (Leaf True)"
+        result <- eval stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Branch (Leaf 1) (Leaf True)"
         result
           `shouldSatisfy` isLeft
       it "type Tree a = Empty | Branch (Tree a) a (Tree a) in Branch (Empty) 1 (Empty)" $ do
-        result <- eval' stdLib "type Tree a = Empty | Branch (Tree a) a (Tree a) in Branch (Empty) 1 (Empty)"
+        result <- eval stdLib "type Tree a = Empty | Branch (Tree a) a (Tree a) in Branch (Empty) 1 (Empty)"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Tree") [MTInt],
@@ -337,14 +329,14 @@ spec =
                 (MyConstructor mempty $ mkTyCon "Empty")
             )
       it "type Maybe a = Just a | Nothing in case Just True of Just \\a -> a | Nothing \"what\"" $ do
-        result <- eval' stdLib "type Maybe a = Just a | Nothing in case Just True of Just \\a -> a | Nothing \"what\""
+        result <- eval stdLib "type Maybe a = Just a | Nothing in case Just True of Just \\a -> a | Nothing \"what\""
         result `shouldSatisfy` isLeft
       it "type Either e a = Left e | Right a in \\f -> \\g -> \\either -> case either of Left \\e -> g(e) | Right \\a -> f(a)" $ do
-        result <- eval' stdLib "type Either e a = Left e | Right a in \\f -> \\g -> \\either -> case either of Left \\e -> g(e) | Right \\a -> f(a)"
+        result <- eval stdLib "type Either e a = Left e | Right a in \\f -> \\g -> \\either -> case either of Left \\e -> g(e) | Right \\a -> f(a)"
         result `shouldSatisfy` isRight
       {-
             it "type Maybe a = Just a | Nothing in \\maybe -> case maybe of Just \\a -> a | Nothing \"poo\"" $ do
-              result <- eval' stdLib "type Maybe a = Just a | Nothing in \\maybe -> case maybe of Just \\a -> a | Nothing \"poo\""
+              result <- eval stdLib "type Maybe a = Just a | Nothing in \\maybe -> case maybe of Just \\a -> a | Nothing \"poo\""
               fst <$> result
                 `shouldBe` Right
                   ( MTFunction (MTData (mkTyCon "Maybe") []) MTString
@@ -352,7 +344,7 @@ spec =
       
       -}
       it "type Arr a = Empty | Item a (Arr a) in case (Item 1 (Item 2 Empty)) of Empty Empty | Item \\a -> \\rest -> rest" $ do
-        result <- eval' stdLib "type Arr a = Empty | Item a (Arr a) in case (Item 1 (Item 2 Empty)) of Empty Empty | Item \\a -> \\rest -> rest"
+        result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in case (Item 1 (Item 2 Empty)) of Empty Empty | Item \\a -> \\rest -> rest"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Arr") [MTInt],
@@ -369,27 +361,27 @@ spec =
                 (MyConstructor mempty $ mkTyCon "Empty")
             )
       it "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)" $ do
-        result <- eval' stdLib "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)"
+        result <- eval stdLib "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)"
         result `shouldBe` Right (MTInt, int 10)
       it "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Suc Suc Zero)" $ do
-        result <- eval' stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Suc Suc Zero)"
+        result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> case as of Zero 0 | Suc \\as2 -> incrementInt(loop(as2))) in loop(Suc Suc Suc Zero)"
         result `shouldBe` Right (MTInt, int 3)
       it "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> incrementInt(loop(as2)(b))) in loop(Suc Suc Suc Zero)(10)" $ do
-        result <- eval' stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> incrementInt(loop(as2)(b))) in loop(Suc Suc Suc Zero)(10)"
+        result <- eval stdLib "type Nat = Zero | Suc Nat in let loop = (\\as -> \\b -> case as of Zero b | Suc \\as2 -> incrementInt(loop(as2)(b))) in loop(Suc Suc Suc Zero)(10)"
         result `shouldBe` Right (MTInt, int 13)
       {-
             it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)" $ do
-              result <- eval' stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)"
+              result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(addInt(b)(a))(rest)) in reduceA(0)(Item 3 Empty)"
               result `shouldBe` Right (MTInt, int 3)
       -}
       it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty)" $ do
-        result <- eval' stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty)"
+        result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Empty)"
         result `shouldBe` Right (MTInt, int 0)
       it "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Item 3 Empty)" $ do
-        result <- eval' stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Item 3 Empty)"
+        result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in let reduceA = (\\f -> \\b -> \\as -> case as of Empty b | Item \\a -> \\rest -> reduceA(f)(f(b)(a))(rest)) in reduceA(addInt)(0)(Item 3 Empty)"
         result `shouldBe` Right (MTInt, int 3)
       it "let some = \\a -> Some a in if True then some(1) else Nowt" $ do
-        result <- eval' stdLib "let some = \\a -> Some a in if True then some(1) else Nowt"
+        result <- eval stdLib "let some = \\a -> Some a in if True then some(1) else Nowt"
         result
           `shouldBe` Right
             ( MTData (mkTyCon "Option") [MTInt],
@@ -399,36 +391,36 @@ spec =
                 (int 1)
             )
       it "\\a -> case a of Some \\as -> True | Nowt 100" $ do
-        result <- eval' stdLib "\\a -> case a of Some \\as -> True | Nowt 100"
+        result <- eval stdLib "\\a -> case a of Some \\as -> True | Nowt 100"
         fst <$> result
           `shouldSatisfy` isLeft
       it "\\a -> case a of Some \\as -> as | Nowt 100" $ do
-        result <- eval' stdLib "\\a -> case a of Some \\as -> as | Nowt 100"
+        result <- eval stdLib "\\a -> case a of Some \\as -> as | Nowt 100"
         fst <$> result
           `shouldBe` Right
             (MTFunction (MTData (mkTyCon "Option") [MTInt]) MTInt)
       it "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some 1)" $ do
-        result <- eval' stdLib "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some 1)"
+        result <- eval stdLib "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some 1)"
         result `shouldSatisfy` isLeft
       it "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some \"Dog\")" $ do
-        result <- eval' stdLib "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some \"Dog\")"
+        result <- eval stdLib "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some \"Dog\")"
         result `shouldBe` Right (MTString, str' "Dog")
       it "True == \"dog\"" $ do
-        result <- eval' stdLib "True == \"dog\""
+        result <- eval stdLib "True == \"dog\""
         result `shouldSatisfy` isLeft
       it "(\\a -> a) == (\\b -> b)" $ do
         -- no function equality
-        result <- eval' stdLib "(\\a -> a) == (\\b -> b)"
+        result <- eval stdLib "(\\a -> a) == (\\b -> b)"
         result `shouldSatisfy` isLeft
       it "True == False" $ do
-        result <- eval' stdLib "True == False"
+        result <- eval stdLib "True == False"
         result `shouldBe` Right (MTBool, bool False)
       it "True == True" $ do
-        result <- eval' stdLib "True == True"
+        result <- eval stdLib "True == True"
         result `shouldBe` Right (MTBool, bool True)
       it "(Some 1) == Some 2" $ do
-        result <- eval' stdLib "(Some 1) == Some 2"
+        result <- eval stdLib "(Some 1) == Some 2"
         result `shouldBe` Right (MTBool, bool False)
       it "let eq1 = \\a -> a == 1 in eq1(1)" $ do
-        result <- eval' stdLib "let eq1 = \\a -> a == 1 in eq1(1)"
+        result <- eval stdLib "let eq1 = \\a -> a == 1 in eq1(1)"
         result `shouldBe` Right (MTBool, bool True)

--- a/test/Test/Substitutor.hs
+++ b/test/Test/Substitutor.hs
@@ -61,7 +61,7 @@ maybeExpr =
     mempty
     mempty
 
-storeWithBothIn :: (Monoid ann, Show ann) => Store ann
+storeWithBothIn :: Store Annotation
 storeWithBothIn =
   Store
     ( M.fromList
@@ -74,9 +74,9 @@ storeWithBothIn =
     )
 
 testSubstitute ::
-  Store () ->
-  StoreExpression () ->
-  SubstitutedExpression ()
+  Store Annotation ->
+  StoreExpression Annotation ->
+  SubstitutedExpression Annotation
 testSubstitute = substitute
 
 spec :: Spec

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -21,6 +21,11 @@ testParse t = case parseExpr t of
   Right expr -> pure (toEmptyAnnotation expr)
   Left e -> Left $ errorBundlePretty e
 
+testParseWithAnn :: Text -> Either String (Expr Name Annotation)
+testParseWithAnn t = case parseExpr t of
+  Right expr -> pure expr
+  Left e -> Left $ errorBundlePretty e
+
 spec :: Spec
 spec = do
   describe "Language" $ do
@@ -438,3 +443,19 @@ spec = do
               )
               (int 5)
           )
+  describe "Test annotations" $ do
+    it "Parses a var with location information" $
+      testParseWithAnn "dog" `shouldBe` Right (MyVar (Location 0 3) (mkName "dog"))
+    xit "Parses a tyCon with location information" $
+      -- what the hell is going on here?
+      testParseWithAnn "Log" `shouldBe` Right (MyConstructor (Location 0 3) (mkTyCon "Log"))
+    it "Parses a true bool with location information" $
+      testParseWithAnn "True" `shouldBe` Right (MyLiteral (Location 0 4) (MyBool True))
+    it "Parses a false bool with location information" $
+      testParseWithAnn "False" `shouldBe` Right (MyLiteral (Location 0 5) (MyBool False))
+    it "Parses a unit with location information" $
+      testParseWithAnn "Unit" `shouldBe` Right (MyLiteral (Location 0 4) MyUnit)
+    it "Parses an integer with location information" $
+      testParseWithAnn "100" `shouldBe` Right (MyLiteral (Location 0 3) (MyInt 100))
+    it "Parses a string literal with location information" $
+      testParseWithAnn "\"horse\"" `shouldBe` Right (MyLiteral (Location 0 7) (MyString $ StringType "horse"))

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -18,25 +18,11 @@ import Text.Megaparsec
 -- specialisation of parseExpr
 testParse :: Text -> Either String (Expr Name ())
 testParse t = case parseExpr t of
-  Right a -> pure a
+  Right expr -> pure (toEmptyAnnotation expr)
   Left e -> Left $ errorBundlePretty e
-
-testParseName :: Text -> Either ParseErrorType Name
-testParseName = parse nameParser "file.mimsa"
-
-testParseVar :: Text -> Either ParseErrorType (Expr Name ())
-testParseVar = parse varParser "file.mimsa"
 
 spec :: Spec
 spec = do
-  describe "Name"
-    $ it "dog"
-    $ testParseName "dog" `shouldBe` Right (mkName "dog")
-  describe "Var" $ do
-    it "dog" $
-      testParseVar "dog" `shouldBe` Right (MyVar mempty (mkName "dog"))
-    it "2dog" $
-      testParseVar "2dog" `shouldSatisfy` isLeft
   describe "Language" $ do
     it "Parses True" $
       testParse "True" `shouldBe` Right (bool True)

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -446,8 +446,7 @@ spec = do
   describe "Test annotations" $ do
     it "Parses a var with location information" $
       testParseWithAnn "dog" `shouldBe` Right (MyVar (Location 0 3) (mkName "dog"))
-    xit "Parses a tyCon with location information" $
-      -- what the hell is going on here?
+    it "Parses a tyCon with location information" $
       testParseWithAnn "Log" `shouldBe` Right (MyConstructor (Location 0 3) (mkTyCon "Log"))
     it "Parses a true bool with location information" $
       testParseWithAnn "True" `shouldBe` Right (MyLiteral (Location 0 4) (MyBool True))
@@ -459,3 +458,125 @@ spec = do
       testParseWithAnn "100" `shouldBe` Right (MyLiteral (Location 0 3) (MyInt 100))
     it "Parses a string literal with location information" $
       testParseWithAnn "\"horse\"" `shouldBe` Right (MyLiteral (Location 0 7) (MyString $ StringType "horse"))
+    it "Parses record access with location information" $
+      testParseWithAnn "dog.tail"
+        `shouldBe` Right
+          ( MyRecordAccess
+              (Location 0 8)
+              (MyVar (Location 0 3) (mkName "dog"))
+              (mkName "tail")
+          )
+    it "Parses let-in with location information" $
+      testParseWithAnn "let a = 1 in a"
+        `shouldBe` Right
+          ( MyLet
+              (Location 0 14)
+              (mkName "a")
+              (MyLiteral (Location 8 9) (MyInt 1))
+              (MyVar (Location 13 14) (mkName "a"))
+          )
+    it "Parses let-newline with location information" $
+      testParseWithAnn "let a = 1; a"
+        `shouldBe` Right
+          ( MyLet
+              (Location 0 12)
+              (mkName "a")
+              (MyLiteral (Location 8 9) (MyInt 1))
+              (MyVar (Location 11 12) (mkName "a"))
+          )
+    it "Parses let pair with location information" $
+      testParseWithAnn "let (a,b) = dog in a"
+        `shouldBe` Right
+          ( MyLetPair
+              (Location 0 20)
+              (mkName "a")
+              (mkName "b")
+              (MyVar (Location 12 15) (mkName "dog"))
+              (MyVar (Location 19 20) (mkName "a"))
+          )
+    it "Parsers lambda with location information" $
+      testParseWithAnn "\\a -> a"
+        `shouldBe` Right
+          (MyLambda (Location 0 7) (mkName "a") (MyVar (Location 6 7) (mkName "a")))
+    it "Parses application with location information" $
+      testParseWithAnn "a(1)"
+        `shouldBe` Right
+          ( MyApp
+              (Location 0 4)
+              (MyVar (Location 0 1) (mkName "a"))
+              (MyLiteral (Location 2 3) (MyInt 1))
+          )
+    it "Parses record with location information" $
+      testParseWithAnn "{ a: True }"
+        `shouldBe` Right
+          ( MyRecord
+              (Location 0 11)
+              ( M.singleton
+                  (mkName "a")
+                  (MyLiteral (Location 5 9) (MyBool True))
+              )
+          )
+    it "Parsers if with location information" $
+      testParseWithAnn "if True then 1 else 2"
+        `shouldBe` Right
+          ( MyIf
+              (Location 0 21)
+              (MyLiteral (Location 3 7) (MyBool True))
+              (MyLiteral (Location 13 14) (MyInt 1))
+              (MyLiteral (Location 20 21) (MyInt 2))
+          )
+    it "Parsers pair with location information" $
+      testParseWithAnn "(1,2)"
+        `shouldBe` Right
+          ( MyPair
+              (Location 0 5)
+              (MyLiteral (Location 1 2) (MyInt 1))
+              (MyLiteral (Location 3 4) (MyInt 2))
+          )
+    it "Parses data declaration with location information" $
+      testParseWithAnn "type MyUnit = MyUnit in 1"
+        `shouldBe` Right
+          ( MyData
+              (Location 0 25)
+              ( DataType
+                  (mkTyCon "MyUnit")
+                  mempty
+                  (M.singleton (mkTyCon "MyUnit") mempty)
+              )
+              (MyLiteral (Location 24 25) (MyInt 1))
+          )
+    it "Parses constructor application with location information" $
+      testParseWithAnn "Just 1"
+        `shouldBe` Right
+          ( MyConsApp
+              (Location 0 6)
+              (MyConstructor (Location 0 4) (mkTyCon "Just"))
+              (MyLiteral (Location 5 6) (MyInt 1))
+          )
+    it "Parses case match with location information" $
+      testParseWithAnn "case a of Just \\as -> 1 | Nothing 0"
+        `shouldBe` Right
+          ( MyCaseMatch
+              (Location 0 35)
+              (MyVar (Location 5 6) (mkName "a"))
+              ( NE.fromList
+                  [ ( mkTyCon "Just",
+                      MyLambda
+                        (Location 15 23)
+                        (mkName "as")
+                        (MyLiteral (Location 22 23) (MyInt 1))
+                    ),
+                    (mkTyCon "Nothing", MyLiteral (Location 34 35) (MyInt 0))
+                  ]
+              )
+              Nothing
+          )
+    it "Parses infix equals with location information" $
+      testParseWithAnn "1 == 2"
+        `shouldBe` Right
+          ( MyInfix
+              (Location 0 6)
+              Equals
+              (MyLiteral (Location 0 1) (MyInt 1))
+              (MyLiteral (Location 5 6) (MyInt 2))
+          )

--- a/test/Test/TypeError.hs
+++ b/test/Test/TypeError.hs
@@ -7,12 +7,16 @@ module Test.TypeError
 where
 
 import Data.List (isInfixOf)
+import Data.Text (Text)
 import qualified Data.Text as T
-import qualified Data.Text.IO as T
 import Language.Mimsa.Printer
 import Language.Mimsa.Typechecker.DisplayError
 import Language.Mimsa.Types
 import Test.Hspec
+
+textContains :: Text -> Text -> Bool
+textContains needle haystack =
+  T.unpack needle `isInfixOf` T.unpack haystack
 
 spec :: Spec
 spec = do
@@ -21,11 +25,9 @@ spec = do
       let input = "if dog then 1 else 2"
           err = UnknownTypeError
       let result = displayError input err
-      T.putStrLn result
-      result `shouldSatisfy` (\a -> T.unpack (prettyPrint err) `isInfixOf` T.unpack a)
+      result `shouldSatisfy` textContains (prettyPrint err)
     it "Shows the location with CannotCaseMatchOnType" $ do
       let input = "case blah of Just \a -> a | Nothing False"
           err = CannotCaseMatchOnType (MyVar (Location 5 9) (NamedVar $ mkName "blah"))
           result = displayError input err
-      T.putStrLn result
-      result `shouldSatisfy` (\a -> "^^^^" `isInfixOf` T.unpack a)
+      result `shouldSatisfy` textContains "^^^^"

--- a/test/Test/TypeError.hs
+++ b/test/Test/TypeError.hs
@@ -9,6 +9,7 @@ where
 import Data.List (isInfixOf)
 import Data.Text (Text)
 import qualified Data.Text as T
+import Language.Mimsa.Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Typechecker.DisplayError
 import Language.Mimsa.Types
@@ -18,6 +19,16 @@ textContains :: Text -> Text -> Bool
 textContains needle haystack =
   T.unpack needle `isInfixOf` T.unpack haystack
 
+getTypeError :: Text -> Maybe Text
+getTypeError input =
+  case evaluateText mempty input of
+    Left e -> Just (prettyPrint e)
+    _ -> Nothing
+
+maybePred :: (a -> Bool) -> Maybe a -> Bool
+maybePred _ Nothing = False
+maybePred pred' (Just a) = pred' a
+
 spec :: Spec
 spec = do
   describe "TypeError" $ do
@@ -26,8 +37,9 @@ spec = do
           err = UnknownTypeError
       let result = displayError input err
       result `shouldSatisfy` textContains (prettyPrint err)
-    it "Shows the location with CannotCaseMatchOnType" $ do
-      let input = "case blah of Just \a -> a | Nothing False"
-          err = CannotCaseMatchOnType (MyVar (Location 5 9) (NamedVar $ mkName "blah"))
-          result = displayError input err
-      result `shouldSatisfy` textContains "^^^^"
+    it "Shows the location with CannotCaseMatchOnType" $
+      getTypeError "case blah of Just \a -> a | Nothing False"
+        `shouldSatisfy` maybePred (textContains "^^^^")
+    it "Shows the location with CaseMatchExpectedPair" $
+      getTypeError "let (a,b) = True in a"
+        `shouldSatisfy` maybePred (textContains "^^^^")

--- a/test/Test/TypeError.hs
+++ b/test/Test/TypeError.hs
@@ -50,3 +50,9 @@ spec = do
     it "Shows the location with IncompletePatternMatch" $
       getTypeError "case 1 of Some \\a -> a"
         `shouldSatisfy` maybePred (textContains "^^^^^^^^^^^^^^^^^^^^^^")
+    it "Shows the location with UnificationError" $
+      getTypeError "if 100 then 1 else 2"
+        `shouldSatisfy` maybePred (textContains "^^^")
+    it "Shows the location with MissingRecordMember" $
+      getTypeError "let a = {} in a.dog"
+        `shouldSatisfy` maybePred (textContains "^^^^^")

--- a/test/Test/TypeError.hs
+++ b/test/Test/TypeError.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.TypeError
+  ( spec,
+  )
+where
+
+import qualified Data.List.NonEmpty   as NE
+import qualified Data.Set             as S
+import           Data.Text            (Text)
+import           Language.Mimsa.Types
+import           Test.Hspec
+import           Text.Megaparsec
+
+showError :: Text -> Annotation -> String
+showError input ann = let errorBundle = createErrorBundle input ann in
+                          errorBundlePretty errorBundle
+
+instance ShowErrorComponent Annotation where
+  showErrorComponent None           = "Some sort of error"
+  showErrorComponent (Location _ _) = "Is this some sort of good boy?"
+  errorComponentLen None           = 0
+  errorComponentLen (Location a b) = b - a
+
+toFancy :: Annotation -> ParseError Text Annotation
+toFancy None = FancyError 0 (S.singleton (ErrorCustom None))
+toFancy (Location a b) = FancyError a (S.singleton (ErrorCustom $ Location a b))
+
+createErrorBundle :: Text -> Annotation -> ParseErrorBundle Text Annotation
+createErrorBundle input ann =
+    let initialState =
+            PosState
+              { pstateInput = input
+              , pstateOffset = 0
+              , pstateSourcePos = initialPos "repl"
+              , pstateTabWidth = defaultTabWidth
+              , pstateLinePrefix = ""
+              }
+            in ParseErrorBundle
+              { bundleErrors = NE.fromList [toFancy ann]
+                            -- ^ A collection of 'ParseError's that is sorted by parse error offsets
+              , bundlePosState = initialState
+                            -- ^ State that is used for line\/column calculation
+              }
+
+
+
+
+spec :: Spec
+spec = do
+  describe "TypeError" $ do
+    it "Displays the location of an error" $ do
+      let input = "if dog then 1 else 2"
+          location = Location 4 7
+      let result = showError input location
+      result `shouldBe` ""

--- a/test/Test/TypeError.hs
+++ b/test/Test/TypeError.hs
@@ -13,6 +13,7 @@ import Language.Mimsa.Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Typechecker.DisplayError
 import Language.Mimsa.Types
+import Test.Data.Project
 import Test.Hspec
 
 textContains :: Text -> Text -> Bool
@@ -21,7 +22,7 @@ textContains needle haystack =
 
 getTypeError :: Text -> Maybe Text
 getTypeError input =
-  case evaluateText mempty input of
+  case evaluateText stdLib input of
     Left e -> Just (prettyPrint e)
     _ -> Nothing
 
@@ -43,3 +44,9 @@ spec = do
     it "Shows the location with CaseMatchExpectedPair" $
       getTypeError "let (a,b) = True in a"
         `shouldSatisfy` maybePred (textContains "^^^^")
+    it "Shows the location with CannotMatchRecord" $
+      getTypeError "let dog = True in dog.tail"
+        `shouldSatisfy` maybePred (textContains "^^^^^^^^")
+    it "Shows the location with IncompletePatternMatch" $
+      getTypeError "case 1 of Some \\a -> a"
+        `shouldSatisfy` maybePred (textContains "^^^^^^^^^^^^^^^^^^^^^^")

--- a/test/Test/TypeError.hs
+++ b/test/Test/TypeError.hs
@@ -6,52 +6,26 @@ module Test.TypeError
   )
 where
 
-import qualified Data.List.NonEmpty   as NE
-import qualified Data.Set             as S
-import           Data.Text            (Text)
-import           Language.Mimsa.Types
-import           Test.Hspec
-import           Text.Megaparsec
-
-showError :: Text -> Annotation -> String
-showError input ann = let errorBundle = createErrorBundle input ann in
-                          errorBundlePretty errorBundle
-
-instance ShowErrorComponent Annotation where
-  showErrorComponent None           = "Some sort of error"
-  showErrorComponent (Location _ _) = "Is this some sort of good boy?"
-  errorComponentLen None           = 0
-  errorComponentLen (Location a b) = b - a
-
-toFancy :: Annotation -> ParseError Text Annotation
-toFancy None = FancyError 0 (S.singleton (ErrorCustom None))
-toFancy (Location a b) = FancyError a (S.singleton (ErrorCustom $ Location a b))
-
-createErrorBundle :: Text -> Annotation -> ParseErrorBundle Text Annotation
-createErrorBundle input ann =
-    let initialState =
-            PosState
-              { pstateInput = input
-              , pstateOffset = 0
-              , pstateSourcePos = initialPos "repl"
-              , pstateTabWidth = defaultTabWidth
-              , pstateLinePrefix = ""
-              }
-            in ParseErrorBundle
-              { bundleErrors = NE.fromList [toFancy ann]
-                            -- ^ A collection of 'ParseError's that is sorted by parse error offsets
-              , bundlePosState = initialState
-                            -- ^ State that is used for line\/column calculation
-              }
-
-
-
+import Data.List (isInfixOf)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import Language.Mimsa.Printer
+import Language.Mimsa.Typechecker.DisplayError
+import Language.Mimsa.Types
+import Test.Hspec
 
 spec :: Spec
 spec = do
   describe "TypeError" $ do
-    it "Displays the location of an error" $ do
+    it "Contains the error message" $ do
       let input = "if dog then 1 else 2"
-          location = Location 4 7
-      let result = showError input location
-      result `shouldBe` ""
+          err = UnknownTypeError
+      let result = displayError input err
+      T.putStrLn result
+      result `shouldSatisfy` (\a -> T.unpack (prettyPrint err) `isInfixOf` T.unpack a)
+    it "Shows the location with CannotCaseMatchOnType" $ do
+      let input = "case blah of Just \a -> a | Nothing False"
+          err = CannotCaseMatchOnType (MyVar (Location 5 9) (NamedVar $ mkName "blah"))
+          result = displayError input err
+      T.putStrLn result
+      result `shouldSatisfy` (\a -> "^^^^" `isInfixOf` T.unpack a)

--- a/test/Test/Typechecker.hs
+++ b/test/Test/Typechecker.hs
@@ -14,13 +14,7 @@ import Test.Helpers
 import Test.Hspec
 import Test.QuickCheck.Instances ()
 
-startInference' ::
-  Swaps ->
-  Expr Variable () ->
-  Either (TypeError ()) MonoType
-startInference' = startInference
-
-exprs :: (Monoid ann) => [(Expr Variable ann, Either (TypeError ann) MonoType)]
+exprs :: (Monoid ann) => [(Expr Variable ann, Either TypeError MonoType)]
 exprs =
   [ (int 1, Right MTInt),
     (bool True, Right MTBool),
@@ -206,7 +200,7 @@ spec =
       traverse_
         ( \(code, expected) ->
             --T.putStrLn (prettyPrint code)
-            startInference' mempty code `shouldBe` expected
+            startInference mempty code `shouldBe` expected
         )
         exprs
     it "Uses a polymorphic function twice with conflicting types" $ do
@@ -221,7 +215,7 @@ spec =
                   (MyApp mempty (MyVar mempty (named "id")) (bool True))
               )
       let expected = Right (MTPair MTInt MTBool)
-      startInference' mempty expr `shouldBe` expected
+      startInference mempty expr `shouldBe` expected
     it "We can use identity with two different datatypes in one expression" $ do
       let lambda =
             MyLambda
@@ -234,8 +228,8 @@ spec =
                   (MyApp mempty identity (int 2))
               )
       let expr = MyApp mempty lambda (bool True)
-      startInference' mempty lambda `shouldBe` Right (MTFunction MTBool MTInt)
-      startInference' mempty expr `shouldBe` Right MTInt
+      startInference mempty lambda `shouldBe` Right (MTFunction MTBool MTInt)
+      startInference mempty expr `shouldBe` Right MTInt
 {-  describe "Serialisation" $ do
 it "Round trip" $ do
   property $ \x -> JSON.decode (JSON.encode x) == (Just x :: Maybe Expr)

--- a/test/Test/Typechecker.hs
+++ b/test/Test/Typechecker.hs
@@ -141,8 +141,8 @@ exprs =
       Right $
         MTRecord
           ( M.fromList
-              [ (mkName "dog", (MTPrim MTInt)),
-                (mkName "cat", (MTPrim MTInt))
+              [ (mkName "dog", MTPrim MTInt),
+                (mkName "cat", MTPrim MTInt)
               ]
           )
     ),

--- a/test/Test/Typechecker.hs
+++ b/test/Test/Typechecker.hs
@@ -16,31 +16,31 @@ import Test.QuickCheck.Instances ()
 
 exprs :: (Monoid ann) => [(Expr Variable ann, Either TypeError MonoType)]
 exprs =
-  [ (int 1, Right MTInt),
-    (bool True, Right MTBool),
+  [ (int 1, Right (MTPrim MTInt)),
+    (bool True, Right (MTPrim MTBool)),
     ( str
         (StringType "hello"),
-      Right MTString
+      Right (MTPrim MTString)
     ),
     -- (MyVar (named "x"), Left "Unknown variable \"x\""),
-    (MyLet mempty (named "x") (int 42) (bool True), Right MTBool),
-    (MyLet mempty (named "x") (int 42) (MyVar mempty (named "x")), Right MTInt),
+    (MyLet mempty (named "x") (int 42) (bool True), Right (MTPrim MTBool)),
+    (MyLet mempty (named "x") (int 42) (MyVar mempty (named "x")), Right (MTPrim MTInt)),
     ( MyLet
         mempty
         (named "x")
         (bool True)
         (MyLet mempty (named "y") (int 42) (MyVar mempty (named "x"))),
-      Right MTBool
+      Right (MTPrim MTBool)
     ),
     ( MyLet
         mempty
         (named "x")
         (bool True)
         (MyLet mempty (named "x") (int 42) (MyVar mempty (named "x"))),
-      Right MTInt
+      Right (MTPrim MTInt)
     ),
     ( MyLambda mempty (named "x") (bool True),
-      Right $ MTFunction (unknown 1) MTBool
+      Right $ MTFunction (unknown 1) (MTPrim MTBool)
     ),
     ( identity,
       Right $ MTFunction (unknown 1) (unknown 1)
@@ -59,13 +59,13 @@ exprs =
             (bool True)
         )
         (int 1),
-      Right MTBool
+      Right (MTPrim MTBool)
     ),
     ( MyApp
         mempty
         identity
         (int 1),
-      Right MTInt
+      Right (MTPrim MTInt)
     ),
     ( MyApp
         mempty
@@ -75,7 +75,7 @@ exprs =
             (MyIf mempty (MyVar mempty (named "x")) (int 10) (int 10))
         )
         (int 100),
-      Left $ UnificationError MTBool MTInt
+      Left $ UnificationError (MTPrim MTBool) (MTPrim MTInt)
     ),
     ( MyLambda mempty (named "x") (MyApp mempty (MyVar mempty (named "x")) (MyVar mempty (named "x"))),
       Left $
@@ -87,9 +87,9 @@ exprs =
               (MTVar (tvFree 2))
           )
     ),
-    (MyPair mempty (int 1) (bool True), Right (MTPair MTInt MTBool)),
+    (MyPair mempty (int 1) (bool True), Right (MTPair (MTPrim MTInt) (MTPrim MTBool))),
     ( MyLetPair mempty (named "a") (named "b") (MyPair mempty (int 1) (bool True)) (MyVar mempty (named "a")),
-      Right MTInt
+      Right (MTPrim MTInt)
     ),
     ( MyLambda
         mempty
@@ -123,7 +123,7 @@ exprs =
             (MyPair mempty (int 1) (int 2))
             (MyApp mempty (MyVar mempty (named "fst")) (MyVar mempty (named "x")))
         ),
-      Right MTInt
+      Right (MTPrim MTInt)
     ),
     ( MyRecord
         mempty
@@ -141,8 +141,8 @@ exprs =
       Right $
         MTRecord
           ( M.fromList
-              [ (mkName "dog", MTInt),
-                (mkName "cat", MTInt)
+              [ (mkName "dog", (MTPrim MTInt)),
+                (mkName "cat", (MTPrim MTInt))
               ]
           )
     ),
@@ -159,7 +159,7 @@ exprs =
             (int 1)
             (int 2)
         ),
-      Right $ MTFunction (MTRecord $ M.singleton (mkName "dog") MTBool) MTInt
+      Right $ MTFunction (MTRecord $ M.singleton (mkName "dog") (MTPrim MTBool)) (MTPrim MTInt)
     ),
     ( MyLambda
         mempty
@@ -214,7 +214,7 @@ spec =
                   (MyApp mempty (MyVar mempty (named "id")) (int 1))
                   (MyApp mempty (MyVar mempty (named "id")) (bool True))
               )
-      let expected = Right (MTPair MTInt MTBool)
+      let expected = Right (MTPair (MTPrim MTInt) (MTPrim MTBool))
       startInference mempty expr `shouldBe` expected
     it "We can use identity with two different datatypes in one expression" $ do
       let lambda =
@@ -228,8 +228,8 @@ spec =
                   (MyApp mempty identity (int 2))
               )
       let expr = MyApp mempty lambda (bool True)
-      startInference mempty lambda `shouldBe` Right (MTFunction MTBool MTInt)
-      startInference mempty expr `shouldBe` Right MTInt
+      startInference mempty lambda `shouldBe` Right (MTFunction (MTPrim MTBool) (MTPrim MTInt))
+      startInference mempty expr `shouldBe` Right (MTPrim MTInt)
 {-  describe "Serialisation" $ do
 it "Round trip" $ do
   property $ \x -> JSON.decode (JSON.encode x) == (Just x :: Maybe Expr)

--- a/test/Test/Typechecker.hs
+++ b/test/Test/Typechecker.hs
@@ -192,6 +192,7 @@ exprs =
         ),
       Left $
         MissingRecordTypeMember
+          mempty
           (mkName "cat")
           ( M.singleton
               (mkName "dog")

--- a/test/Test/Unify.hs
+++ b/test/Test/Unify.hs
@@ -37,45 +37,45 @@ spec =
         `shouldBe` Right
           ( Substitutions $
               M.fromList
-                [ (NumberedVar 1, (MTPrim MTBool)),
-                  (NumberedVar 2, (MTPrim MTInt))
+                [ (NumberedVar 1, MTPrim MTBool),
+                  (NumberedVar 2, MTPrim MTInt)
                 ]
           )
     it "Combines two half records" $
       runUnifier
         ( MTRecord $
             M.fromList
-              [ (mkName "one", (MTPrim MTInt)),
+              [ (mkName "one", MTPrim MTInt),
                 (mkName "two", MTVar (tvFree 1))
               ],
           MTRecord $
             M.fromList
               [ (mkName "one", MTVar (tvFree 2)),
-                (mkName "two", (MTPrim MTBool))
+                (mkName "two", MTPrim MTBool)
               ]
         )
         `shouldBe` Right
           ( Substitutions $
               M.fromList
-                [ (NumberedVar 1, (MTPrim MTBool)),
-                  (NumberedVar 2, (MTPrim MTInt))
+                [ (NumberedVar 1, MTPrim MTBool),
+                  (NumberedVar 2, MTPrim MTInt)
                 ]
           )
     it "Combines two records" $
       runUnifier
         ( MTRecord $
             M.fromList
-              [ (mkName "one", (MTPrim MTInt))
+              [ (mkName "one", MTPrim MTInt)
               ],
           MTRecord $
             M.fromList
-              [ (mkName "two", (MTPrim MTBool))
+              [ (mkName "two", MTPrim MTBool)
               ]
         )
         `shouldBe` Right
           ( Substitutions $
               M.fromList
-                [ (NumberedVar 1, (MTPrim MTInt)),
-                  (NumberedVar 2, (MTPrim MTBool))
+                [ (NumberedVar 1, MTPrim MTInt),
+                  (NumberedVar 2, MTPrim MTBool)
                 ]
           )

--- a/test/Test/Unify.hs
+++ b/test/Test/Unify.hs
@@ -15,7 +15,7 @@ import Language.Mimsa.Types
 import Test.Helpers
 import Test.Hspec
 
-runUnifier :: (MonoType, MonoType) -> Either (TypeError ()) Substitutions
+runUnifier :: (MonoType, MonoType) -> Either TypeError Substitutions
 runUnifier (a, b) =
   fst either'
   where

--- a/test/Test/Unify.hs
+++ b/test/Test/Unify.hs
@@ -25,57 +25,57 @@ spec :: Spec
 spec =
   describe "Unify" $ do
     it "Two same things teach us nothing" $
-      runUnifier (MTUnit, MTUnit) `shouldBe` Right mempty
+      runUnifier (MTPrim MTUnit, MTPrim MTUnit) `shouldBe` Right mempty
     it "Combines a known with an unknown" $
-      runUnifier (MTVar (tvFree 1), MTInt)
-        `shouldBe` Right (Substitutions $ M.singleton (NumberedVar 1) MTInt)
+      runUnifier (MTVar (tvFree 1), MTPrim MTInt)
+        `shouldBe` Right (Substitutions $ M.singleton (NumberedVar 1) (MTPrim MTInt))
     it "Combines two half pairs" $
       runUnifier
-        ( MTPair (MTVar (tvFree 1)) MTInt,
-          MTPair MTBool (MTVar (tvFree 2))
+        ( MTPair (MTVar (tvFree 1)) (MTPrim MTInt),
+          MTPair (MTPrim MTBool) (MTVar (tvFree 2))
         )
         `shouldBe` Right
           ( Substitutions $
               M.fromList
-                [ (NumberedVar 1, MTBool),
-                  (NumberedVar 2, MTInt)
+                [ (NumberedVar 1, (MTPrim MTBool)),
+                  (NumberedVar 2, (MTPrim MTInt))
                 ]
           )
     it "Combines two half records" $
       runUnifier
         ( MTRecord $
             M.fromList
-              [ (mkName "one", MTInt),
+              [ (mkName "one", (MTPrim MTInt)),
                 (mkName "two", MTVar (tvFree 1))
               ],
           MTRecord $
             M.fromList
               [ (mkName "one", MTVar (tvFree 2)),
-                (mkName "two", MTBool)
+                (mkName "two", (MTPrim MTBool))
               ]
         )
         `shouldBe` Right
           ( Substitutions $
               M.fromList
-                [ (NumberedVar 1, MTBool),
-                  (NumberedVar 2, MTInt)
+                [ (NumberedVar 1, (MTPrim MTBool)),
+                  (NumberedVar 2, (MTPrim MTInt))
                 ]
           )
     it "Combines two records" $
       runUnifier
         ( MTRecord $
             M.fromList
-              [ (mkName "one", MTInt)
+              [ (mkName "one", (MTPrim MTInt))
               ],
           MTRecord $
             M.fromList
-              [ (mkName "two", MTBool)
+              [ (mkName "two", (MTPrim MTBool))
               ]
         )
         `shouldBe` Right
           ( Substitutions $
               M.fromList
-                [ (NumberedVar 1, MTInt),
-                  (NumberedVar 2, MTBool)
+                [ (NumberedVar 1, (MTPrim MTInt)),
+                  (NumberedVar 2, (MTPrim MTBool))
                 ]
           )

--- a/test/Test/Unify.hs
+++ b/test/Test/Unify.hs
@@ -25,57 +25,57 @@ spec :: Spec
 spec =
   describe "Unify" $ do
     it "Two same things teach us nothing" $
-      runUnifier (MTPrim MTUnit, MTPrim MTUnit) `shouldBe` Right mempty
+      runUnifier (MTPrim mempty MTUnit, MTPrim mempty MTUnit) `shouldBe` Right mempty
     it "Combines a known with an unknown" $
-      runUnifier (MTVar (tvFree 1), MTPrim MTInt)
-        `shouldBe` Right (Substitutions $ M.singleton (NumberedVar 1) (MTPrim MTInt))
+      runUnifier (MTVar mempty (tvFree 1), MTPrim mempty MTInt)
+        `shouldBe` Right (Substitutions $ M.singleton (NumberedVar 1) (MTPrim mempty MTInt))
     it "Combines two half pairs" $
       runUnifier
-        ( MTPair (MTVar (tvFree 1)) (MTPrim MTInt),
-          MTPair (MTPrim MTBool) (MTVar (tvFree 2))
+        ( MTPair mempty (MTVar mempty (tvFree 1)) (MTPrim mempty MTInt),
+          MTPair mempty (MTPrim mempty MTBool) (MTVar mempty (tvFree 2))
         )
         `shouldBe` Right
           ( Substitutions $
               M.fromList
-                [ (NumberedVar 1, MTPrim MTBool),
-                  (NumberedVar 2, MTPrim MTInt)
+                [ (NumberedVar 1, MTPrim mempty MTBool),
+                  (NumberedVar 2, MTPrim mempty MTInt)
                 ]
           )
     it "Combines two half records" $
       runUnifier
-        ( MTRecord $
+        ( MTRecord mempty $
             M.fromList
-              [ (mkName "one", MTPrim MTInt),
-                (mkName "two", MTVar (tvFree 1))
+              [ (mkName "one", MTPrim mempty MTInt),
+                (mkName "two", MTVar mempty (tvFree 1))
               ],
-          MTRecord $
+          MTRecord mempty $
             M.fromList
-              [ (mkName "one", MTVar (tvFree 2)),
-                (mkName "two", MTPrim MTBool)
+              [ (mkName "one", MTVar mempty (tvFree 2)),
+                (mkName "two", MTPrim mempty MTBool)
               ]
         )
         `shouldBe` Right
           ( Substitutions $
               M.fromList
-                [ (NumberedVar 1, MTPrim MTBool),
-                  (NumberedVar 2, MTPrim MTInt)
+                [ (NumberedVar 1, MTPrim mempty MTBool),
+                  (NumberedVar 2, MTPrim mempty MTInt)
                 ]
           )
     it "Combines two records" $
       runUnifier
-        ( MTRecord $
+        ( MTRecord mempty $
             M.fromList
-              [ (mkName "one", MTPrim MTInt)
+              [ (mkName "one", MTPrim mempty MTInt)
               ],
-          MTRecord $
+          MTRecord mempty $
             M.fromList
-              [ (mkName "two", MTPrim MTBool)
+              [ (mkName "two", MTPrim mempty MTBool)
               ]
         )
         `shouldBe` Right
           ( Substitutions $
               M.fromList
-                [ (NumberedVar 1, MTPrim MTInt),
-                  (NumberedVar 2, MTPrim MTBool)
+                [ (NumberedVar 1, MTPrim mempty MTInt),
+                  (NumberedVar 2, MTPrim mempty MTBool)
                 ]
           )

--- a/test/Test/Usages.hs
+++ b/test/Test/Usages.hs
@@ -17,4 +17,4 @@ spec =
     it "Returns empty when passed nothing" $
       findUsages mempty (ExprHash 6) `shouldBe` Right mempty
     it "Finds all uses of Compose in Stdlib" $
-      findUsages (stdLib :: Project ()) (ExprHash 6) `shouldBe` Right mempty
+      findUsages stdLib (ExprHash 6) `shouldBe` Right mempty


### PR DESCRIPTION
This saves `start` and `end` of each piece of source in the Expr for better error messages.