### PR TITLE
Fix List Bindings endpoint to receive a project

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -36,14 +36,16 @@ jobs:
         restore-keys: |
              ${{ runner.os }}-stack-work-${{ matrix.plan.ghc }}
 
-    - name: Install hlint
-      run: stack install hlint
+    - name: 'Set up HLint'
+      uses: rwe/actions-hlint-setup@v1
+      with:
+        version: '3.1.6'
 
-    - name: Add Hlint to PATH
-      run: echo "::add-path::/home/runner/.local/bin"
-
-    - name: Hlint files
-      run: hlint .
+    - name: 'Run HLint'
+      uses: rwe/actions-hlint-run@v2
+      with:
+        path: src/
+        fail-on: warning
 
     - name: Run stack build
       run: stack build

--- a/src/Language/Mimsa/Server/Project.hs
+++ b/src/Language/Mimsa/Server/Project.hs
@@ -61,8 +61,8 @@ projectEndpoints ::
   Server ProjectAPI
 projectEndpoints prj =
   evaluateExpression
-    :<|> listBindings prj
-    :<|> getExpression prj
+    :<|> listBindings
+    :<|> getExpression
     :<|> createProject prj
     :<|> bindExpression
 
@@ -108,21 +108,27 @@ evaluateExpression body = do
 
 type ListBindings =
   "bindings"
-    :> Get '[JSON] BindingsResponse
+    :> ReqBody '[JSON] ListBindingsRequest
+    :> Get '[JSON] ListBindingsResponse
 
-data BindingsResponse
-  = BindingsResponse
+newtype ListBindingsRequest
+  = ListBindingsRequest
+      {lbProject :: Project Annotation}
+  deriving (Eq, Ord, Show, Generic, JSON.FromJSON, ToSchema)
+
+data ListBindingsResponse
+  = ListBindingsResponse
       { projectBindings :: Map Name Text,
         projectTypeBindings :: Map TyCon Text
       }
   deriving (Eq, Ord, Show, Generic, JSON.ToJSON, ToSchema)
 
 listBindings ::
-  Project Annotation ->
-  Handler BindingsResponse
-listBindings project =
+  ListBindingsRequest ->
+  Handler ListBindingsResponse
+listBindings (ListBindingsRequest project) =
   pure $
-    BindingsResponse
+    ListBindingsResponse
       (outputBindings project)
       (outputTypeBindings project)
 
@@ -131,11 +137,18 @@ listBindings project =
 -- TODO: should this be in Store and have nothing to do with projects?
 -- it could findExpr to get everything we need and then typecheck from there
 type GetExpression =
-  "expression" :> Capture "exprHash" ExprHash
-    :> Get '[JSON] ExpressionResponse
+  "expression" :> ReqBody '[JSON] GetExpressionRequest
+    :> Get '[JSON] GetExpressionResponse
 
-data ExpressionResponse
-  = ExpressionResponse
+data GetExpressionRequest
+  = GetExpressionRequest
+      { geProject :: Project Annotation,
+        geExprHash :: ExprHash
+      }
+  deriving (Eq, Ord, Show, Generic, JSON.FromJSON, ToSchema)
+
+data GetExpressionResponse
+  = GetExpressionResponse
       { exprValue :: Text,
         exprType :: Text,
         exprBindings :: Map Name Text,
@@ -144,17 +157,16 @@ data ExpressionResponse
   deriving (Eq, Ord, Show, Generic, JSON.ToJSON, ToSchema)
 
 getExpression ::
-  Project Annotation ->
-  ExprHash ->
-  Handler ExpressionResponse
-getExpression project exprHash' = do
+  GetExpressionRequest ->
+  Handler GetExpressionResponse
+getExpression (GetExpressionRequest project exprHash') = do
   se <- handleEither InternalError $
     case lookupExprHash project exprHash' of
       Nothing -> Left ("Could not find exprhash!" :: Text)
       Just a -> Right a
   (ResolvedExpression mt _ _ _ _) <- handleEither UserError $ resolveStoreExpression (store project) "" se
   pure
-    ( ExpressionResponse
+    ( GetExpressionResponse
         (prettyPrint (storeExpression se))
         (prettyPrint mt)
         (prettyPrint <$> getBindings (storeBindings se))

--- a/src/Language/Mimsa/Server/Project.hs
+++ b/src/Language/Mimsa/Server/Project.hs
@@ -109,7 +109,7 @@ evaluateExpression body = do
 type ListBindings =
   "bindings"
     :> ReqBody '[JSON] ListBindingsRequest
-    :> Get '[JSON] ListBindingsResponse
+    :> Post '[JSON] ListBindingsResponse
 
 newtype ListBindingsRequest
   = ListBindingsRequest
@@ -138,7 +138,7 @@ listBindings (ListBindingsRequest project) =
 -- it could findExpr to get everything we need and then typecheck from there
 type GetExpression =
   "expression" :> ReqBody '[JSON] GetExpressionRequest
-    :> Get '[JSON] GetExpressionResponse
+    :> Post '[JSON] GetExpressionResponse
 
 data GetExpressionRequest
   = GetExpressionRequest
@@ -215,12 +215,14 @@ data BindExpressionRequest
 
 data BindExpressionResponse
   = BindExpressionResponse
-      { beData :: Project Annotation,
-        beBindings :: Map Name Text,
-        beTypeBindings :: Map TyCon Text,
-        bePrettyExpr :: Text,
-        bePrettyType :: Text,
-        bePrettyHash :: Text
+      { beProjectData :: Project Annotation,
+        beProjectBindings :: Map Name Text,
+        beProjectTypeBindings :: Map TyCon Text,
+        beExprValue :: Text,
+        beExprType :: Text,
+        beExprHash :: Text,
+        beExprBindings :: Map Name Text,
+        beExprTypeBindings :: Map TyCon Text
       }
   deriving (Eq, Ord, Show, Generic, JSON.ToJSON, ToSchema)
 
@@ -240,3 +242,5 @@ bindExpression (BindExpressionRequest project name' input) = do
       (prettyPrint (storeExpression se))
       (prettyPrint mt)
       (prettyPrint hash)
+      (prettyPrint <$> getBindings (storeBindings se))
+      (prettyPrint <$> getTypeBindings (storeTypeBindings se))

--- a/src/Language/Mimsa/Store/Storage.hs
+++ b/src/Language/Mimsa/Store/Storage.hs
@@ -38,10 +38,10 @@ getStoreFolder = do
   pure (path <> "/")
 
 filePath :: FilePath -> ExprHash -> String
-filePath storePath (ExprHash hash) = storePath <> show hash <> ".json"
+filePath storePath hash = storePath <> show hash <> ".json"
 
 downloadPath :: ServerUrl -> ExprHash -> Text
-downloadPath (ServerUrl url) (ExprHash hash) = url <> T.pack (show hash) <> ".json"
+downloadPath (ServerUrl url) (ExprHash hash) = url <> hash <> ".json"
 
 getHash :: BS.ByteString -> ExprHash
 getHash = ExprHash . T.pack . show . Hash.hash


### PR DESCRIPTION
Our API is designed to receive the entire `Project` each time, change it, and return it. (should this change? #93 )

List Bindings did not. This fixes that, and an error in filenames, and a few other things.

This just makes things Better, OK?