### PR TITLE
Create files in store and then symlink them into output folder

### DIFF
--- a/src/Language/Mimsa/Repl/Actions.hs
+++ b/src/Language/Mimsa/Repl/Actions.hs
@@ -187,5 +187,5 @@ doOutputJS ::
 doOutputJS env input expr = do
   (ResolvedExpression _ storeExpr' _ _ _) <-
     liftRepl $ getTypecheckedStoreExpression input env expr
-  liftIO $ goCompile CommonJS (store env) storeExpr'
-  replPrint ("Output to output/index.js" :: Text)
+  outputPath <- liftIO $ goCompile CommonJS (store env) storeExpr'
+  replPrint ("Output to " <> outputPath)

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-16.18
+resolver: lts-16.22
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 532172
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/18.yaml
-    sha256: 4f2a092c6f4869854e8d7435ab98ce5157c641022c3cbfc4c4614ff3db752e62
-  original: lts-16.18
+    size: 532414
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/22.yaml
+    sha256: e483fb88549fc0f454c190979bf35ac91c7aceff2c0e71e7d8edd11842d772d8
+  original: lts-16.22


### PR DESCRIPTION
Fixes #86 by creating all JS files in the store, and then symlinking them in place. This means we will avoid lots of easy work compiling often used functions. Should use a similar structure to save typecheck info for an expr to save time there too, in future.