### PR TITLE
Typed holes

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,15 @@ Left "poo" :: Either 14 String -- you may notice this is wrong, see issues
 Right "dog" :: Either 14 String -- this is OK though
 ```
 
+typed holes:
+
+```haskell
+:> let map = \f -> \a -> f(a) in map(?dunno)(1)
+
+repl:1:35:
+  |
+1 | let map = \f -> \a -> f(a) in map(?dunno)(1)
+  |                                   ^^^^^^
+Typed holes found:
+?dunno : (Int -> 5)
+```

--- a/src/Language/Mimsa/Backend/Javascript.hs
+++ b/src/Language/Mimsa/Backend/Javascript.hs
@@ -177,3 +177,4 @@ outputJS expr =
     MyConstructor _ a -> outputConstructor @ann a []
     MyConsApp _ c a -> outputConsApp c a
     MyCaseMatch _ a matches catch -> outputCaseMatch a matches catch
+    MyTypedHole _ a -> coerce a -- TODO: this should fail, but dont want to introduce failure into this whole area yet

--- a/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -164,4 +164,5 @@ interpretWithScope interpretExpr =
     (MyCaseMatch _ expr' matches catchAll) -> do
       expr'' <- interpretWithScope expr'
       patternMatch expr'' matches catchAll >>= interpretWithScope
+    typedHole@MyTypedHole {} -> throwError (TypedHoleFound typedHole)
     expr -> bindExpr interpretWithScope expr

--- a/src/Language/Mimsa/Parser/Identifiers.hs
+++ b/src/Language/Mimsa/Parser/Identifiers.hs
@@ -4,6 +4,7 @@ module Language.Mimsa.Parser.Identifiers
   ( varParser,
     nameParser,
     tyConParser,
+    typedHoleParser,
     constructorParser,
   )
 where
@@ -16,6 +17,7 @@ import Language.Mimsa.Parser.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 import Text.Megaparsec
+import Text.Megaparsec.Char
 
 ----
 
@@ -43,4 +45,14 @@ tyConParser =
   maybePred
     identifier
     (inProtected >=> safeMkTyCon)
+
 -----
+
+typedHoleParser :: Parser ParserExpr
+typedHoleParser =
+  withLocation
+    MyTypedHole
+    ( do
+        _ <- string "?"
+        nameParser
+    )

--- a/src/Language/Mimsa/Parser/Language.hs
+++ b/src/Language/Mimsa/Parser/Language.hs
@@ -61,6 +61,7 @@ complexParser =
     <|> try typeParser
     <|> try constructorAppParser
     <|> try caseMatchParser
+    <|> try typedHoleParser
 
 ----
 

--- a/src/Language/Mimsa/Store/ExtractTypes.hs
+++ b/src/Language/Mimsa/Store/ExtractTypes.hs
@@ -45,6 +45,7 @@ extractTypes_ (MyCaseMatch _ sum' matches catchAll) =
     <> mconcat (extractTypes_ . snd <$> NE.toList matches)
     <> mconcat (S.singleton . fst <$> NE.toList matches)
     <> maybe mempty extractTypes catchAll
+extractTypes_ (MyTypedHole _ _) = mempty
 
 filterBuiltIns :: Set TyCon -> Set TyCon
 filterBuiltIns = S.filter (\c -> not $ M.member c builtInTypes)
@@ -93,3 +94,4 @@ withDataTypes f (MyCaseMatch _ sum' matches catchAll) =
   withDataTypes f sum'
     <> mconcat (withDataTypes f . snd <$> NE.toList matches)
     <> maybe mempty (withDataTypes f) catchAll
+withDataTypes _ (MyTypedHole _ _) = mempty

--- a/src/Language/Mimsa/Store/ExtractVars.hs
+++ b/src/Language/Mimsa/Store/ExtractVars.hs
@@ -37,3 +37,4 @@ extractVars_ (MyCaseMatch _ sum' matches catchAll) =
   extractVars sum'
     <> mconcat (extractVars . snd <$> NE.toList matches)
     <> maybe mempty extractVars catchAll
+extractVars_ (MyTypedHole _ _) = mempty

--- a/src/Language/Mimsa/Store/Substitutor.hs
+++ b/src/Language/Mimsa/Store/Substitutor.hs
@@ -223,3 +223,4 @@ mapVar chg (MyCaseMatch ann expr' matches catchAll) = do
   matches' <- traverse mapVarPair matches
   catchAll' <- traverse (mapVar chg) catchAll
   MyCaseMatch ann <$> mapVar chg expr' <*> pure matches' <*> pure catchAll'
+mapVar _ (MyTypedHole ann a) = pure $ MyTypedHole ann a

--- a/src/Language/Mimsa/Typechecker/TcMonad.hs
+++ b/src/Language/Mimsa/Typechecker/TcMonad.hs
@@ -2,14 +2,22 @@ module Language.Mimsa.Typechecker.TcMonad where
 
 import Control.Monad.Except
 import Control.Monad.Reader
-import Control.Monad.State (State, get, put, runState)
+import Control.Monad.State (State, gets, modify, runState)
+import qualified Data.Map as M
+import Data.Map (Map)
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Swaps
 import Language.Mimsa.Types.Typechecker
 
-type TcMonad = ExceptT TypeError (ReaderT Swaps (State Int))
+type TcMonad = ExceptT TypeError (ReaderT Swaps (State TypecheckState))
+
+data TypecheckState
+  = TypecheckState
+      { tcsNum :: Int,
+        tcsTypedHoles :: Map Name (Annotation, Int)
+      }
 
 runTcMonad ::
   Swaps ->
@@ -18,13 +26,34 @@ runTcMonad ::
 runTcMonad swaps value =
   fst either'
   where
-    either' = runState (runReaderT (runExceptT value) swaps) 1
+    defaultState =
+      TypecheckState 1 mempty
+    either' =
+      runState
+        (runReaderT (runExceptT value) swaps)
+        defaultState
 
 getNextUniVar :: TcMonad Int
 getNextUniVar = do
-  nextUniVar <- get
-  put (nextUniVar + 1)
+  nextUniVar <- gets tcsNum
+  modify (\s -> s {tcsNum = nextUniVar + 1})
   pure nextUniVar
+
+-- | Get a new unknown for a typed hole and return it's monotype
+addTypedHole :: Annotation -> Name -> TcMonad MonoType
+addTypedHole ann name = do
+  i <- getNextUniVar
+  modify (\s -> s {tcsTypedHoles = tcsTypedHoles s <> M.singleton name (ann, i)})
+  pure $ MTVar ann (NumberedVar i)
+
+-- todo - look up index in substitutions to get type
+getTypedHoles :: Substitutions -> TcMonad (Map Name MonoType)
+getTypedHoles (Substitutions subs) = do
+  holes <- gets tcsTypedHoles
+  let getMonoType = \(ann, i) -> case M.lookup (NumberedVar i) subs of
+        Just a -> a
+        Nothing -> MTVar ann (NumberedVar i)
+  pure $ fmap getMonoType holes
 
 getUnknown :: Annotation -> TcMonad MonoType
 getUnknown ann = MTVar ann . NumberedVar <$> getNextUniVar

--- a/src/Language/Mimsa/Types/Error/InterpreterError.hs
+++ b/src/Language/Mimsa/Types/Error/InterpreterError.hs
@@ -26,6 +26,7 @@ data InterpreterError ann
   | AdditionWithNonNumber (Expr Variable ann)
   | SubtractionWithNonNumber (Expr Variable ann)
   | ConcatentationWithNonString (Expr Variable ann)
+  | TypedHoleFound (Expr Variable ann)
   deriving (Eq, Ord, Show)
 
 instance Semigroup (InterpreterError a) where
@@ -51,4 +52,5 @@ instance (Show ann, Printer ann) => Printer (InterpreterError ann) where
   prettyPrint (AdditionWithNonNumber a) = "Addition expected number but got this: " <> prettyPrint a
   prettyPrint (SubtractionWithNonNumber a) = "Subtraction expected number but got this: " <> prettyPrint a
   prettyPrint (ConcatentationWithNonString a) = "Concatenation expected string but got this: " <> prettyPrint a
+  prettyPrint (TypedHoleFound a) = "Typed hole found " <> prettyPrint a
   prettyPrint UnknownInterpreterError = "Unknown interpreter error"

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -514,10 +514,16 @@ spec =
             )
       it "if ?missingFn then 1 else 2" $ do
         result <- eval stdLib "if ?missingFn then 1 else 2"
-        print result
         result `shouldSatisfy` \case
           (Left msg) ->
             T.isInfixOf "Typed holes found" msg
               && T.isInfixOf "?missingFn" msg
               && T.isInfixOf "Boolean" msg
+          (Right _) -> False
+      it "let map = \\f -> \\a -> f(a) in map(?flappy)(1)" $ do
+        result <- eval stdLib "let map = \\f -> \\a -> f(a) in map(?flappy)(1)"
+        result `shouldSatisfy` \case
+          (Left msg) ->
+            T.isInfixOf "Typed holes found" msg
+              && T.isInfixOf "^^^^^^^" msg
           (Right _) -> False

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -512,3 +512,12 @@ spec =
                     (MTVar mempty (tvFree 2))
                 )
             )
+      it "if ?missingFn then 1 else 2" $ do
+        result <- eval stdLib "if ?missingFn then 1 else 2"
+        print result
+        result `shouldSatisfy` \case
+          (Left msg) ->
+            T.isInfixOf "Typed holes found" msg
+              && T.isInfixOf "?missingFn" msg
+              && T.isInfixOf "Boolean" msg
+          (Right _) -> False

--- a/test/Test/Syntax.hs
+++ b/test/Test/Syntax.hs
@@ -163,6 +163,8 @@ spec = do
               )
               (MyVar mempty (mkName "const2"))
           )
+    it "Parses typed hole" $ do
+      testParse "?dog" `shouldBe` Right (MyTypedHole mempty (mkName "dog"))
     it "Parses a complex let expression" $
       testParse "let const2 = (\\a -> (\\b -> a)) in (let reuse = ({first: const2(True), second: const2(2)}) in reuse.second(100))"
         `shouldSatisfy` isRight

--- a/test/Test/Unify.hs
+++ b/test/Test/Unify.hs
@@ -10,6 +10,7 @@ import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State (runState)
 import qualified Data.Map as M
+import Language.Mimsa.Typechecker.TcMonad
 import Language.Mimsa.Typechecker.Unify
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
@@ -21,7 +22,12 @@ runUnifier :: (MonoType, MonoType) -> Either TypeError Substitutions
 runUnifier (a, b) =
   fst either'
   where
-    either' = runState (runReaderT (runExceptT (unify a b)) mempty) 1
+    defaultState =
+      TypecheckState 1 mempty
+    either' =
+      runState
+        (runReaderT (runExceptT (unify a b)) mempty)
+        defaultState
 
 spec :: Spec
 spec =

--- a/test/golden/PrettyPrint/240e1dcbb1d06acc50aeeca0741c92499929aa062b91170ba2f67ecdecb25a6d.mimsa
+++ b/test/golden/PrettyPrint/240e1dcbb1d06acc50aeeca0741c92499929aa062b91170ba2f67ecdecb25a6d.mimsa
@@ -1,0 +1,3 @@
+if ?missingFn
+  then 1
+  else 2

--- a/test/golden/StoreExpr/240e1dcbb1d06acc50aeeca0741c92499929aa062b91170ba2f67ecdecb25a6d.json
+++ b/test/golden/StoreExpr/240e1dcbb1d06acc50aeeca0741c92499929aa062b91170ba2f67ecdecb25a6d.json
@@ -1,0 +1,1 @@
+{"storeExpression":{"tag":"MyIf","contents":[[],{"tag":"MyTypedHole","contents":[[],"missingFn"]},{"tag":"MyLiteral","contents":[[],{"tag":"MyInt","contents":1}]},{"tag":"MyLiteral","contents":[[],{"tag":"MyInt","contents":2}]}]},"storeBindings":{},"storeTypeBindings":{}}


### PR DESCRIPTION
Allows multiple missing functions to be left in the code like `?this`, which results in an error showing the inferred types.

```haskell
:> let map = \f -> \a -> f(a) in map(?dunno)(1)

repl:1:35:
  |
1 | let map = \f -> \a -> f(a) in map(?dunno)(1)
  |                                   ^^^^^^
Typed holes found:
?dunno : (Int -> 5)
```

Pretty nice! The next step is to be able to infer potential fits for these holes from a) the project and b) maybe all the functions in the store?