### PR TITLE
Normalise types and print as letters

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,19 +102,19 @@ lambdas and function application:
 
 ```haskell
 :> :bind id = \x -> x
-Bound id to \x -> x :: U1 -> U1
+Bound id to \x -> x :: A -> A
 
 :> id(1)
 1 :: Int
 
 :> :bind const = \x -> \y -> x
-Bound const to \x -> (\y -> x) :: U1 -> (U2 -> U1)
+Bound const to \x -> (\y -> x) :: A -> (B -> A)
 
 :> const(2)("horse")
 2 :: Int
 
 :> :bind compose = \f -> \g -> \a -> f(g(a))
-Bound compose to \f -> (\g -> (\a -> (f(g(a))))) :: (U5 -> U4) -> ((U3 -> U5) -> (U3 -> U4))
+Bound compose to \f -> (\g -> (\a -> (f(g(a))))) :: (A -> B) -> ((C -> A) -> (C -> B))
 ```
 
 pairs:
@@ -124,7 +124,7 @@ pairs:
 (1, "horse") :: (Int, String)
 
 :> :bind fst = \x -> let (a, b) = x in a
-Bound fst to \x -> let (a, b) = x in a :: (U2, U3) -> U2
+Bound fst to \x -> let (a, b) = x in a :: (A, B) -> A
 
 :> fst((1,"horse"))
 1 :: Int
@@ -155,20 +155,20 @@ type declarations:
 :bindType type Either e a = Left e | Right a
 
 :> \a -> if a then Right a else Left "Oh no"
-\a -> (if a then (Right a) else (Left "Oh no")) :: (7 -> Either String 7)
+\a -> (if a then (Right a) else (Left "Oh no")) :: (A -> Either String A)
 ```
 
 case matching:
 
 ```haskell
 :> :bind eitherMap = \f -> \either -> case either of Left \e -> Left e | Right \a -> Right f(a)
-Bound eitherMap to \f -> (\either -> case either of Left (\e -> (Left e)) | Right (\a -> (Right f(a)))) :: ((11 -> 15) -> (2 -> Either 13 15))
+Bound eitherMap to \f -> (\either -> case either of Left (\e -> (Left e)) | Right (\a -> (Right f(a)))) :: ((A -> B) -> (Either C A -> Either C B))
 
 :> eitherMap(\a -> "dog")(Left "what")
 Left "poo" :: Either String String
 
 :> eitherMap(\a -> "dog")(Right "poo")
-Right "dog" :: Either 14 String
+Right "dog" :: Either A String
 ```
 
 typed holes:
@@ -181,5 +181,5 @@ repl:1:35:
 1 | let map = \f -> \a -> f(a) in map(?dunno)(1)
   |                                   ^^^^^^
 Typed holes found:
-?dunno : (Int -> 5)
+?dunno : (Int -> A)
 ```

--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 79077c236de10c44a63ce41d6508e8187df69e212c704bfdc71a00760537a32e
+-- hash: c34088d8394a0476a06459d3ed045215f34d66d2d5e5bf5b4a8669d712797671
 
 name:           mimsa
 version:        0.1.0.0
@@ -85,6 +85,7 @@ library
       Language.Mimsa.Typechecker.Environment
       Language.Mimsa.Typechecker.Generalise
       Language.Mimsa.Typechecker.Infer
+      Language.Mimsa.Typechecker.NormaliseTypes
       Language.Mimsa.Typechecker.Patterns
       Language.Mimsa.Typechecker.RecordUsages
       Language.Mimsa.Typechecker.TcMonad
@@ -246,6 +247,7 @@ test-suite mimsa-test
       Test.Data.Project
       Test.Helpers
       Test.Interpreter
+      Test.NormaliseType
       Test.Prettier
       Test.RecordUsage
       Test.Repl

--- a/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/src/Language/Mimsa/Typechecker/Infer.hs
@@ -23,6 +23,7 @@ import Language.Mimsa.Typechecker.DataTypes
   )
 import Language.Mimsa.Typechecker.Environment
 import Language.Mimsa.Typechecker.Generalise
+import Language.Mimsa.Typechecker.NormaliseTypes
 import Language.Mimsa.Typechecker.Patterns (checkCompleteness)
 import Language.Mimsa.Typechecker.RecordUsages
 import Language.Mimsa.Typechecker.TcMonad
@@ -51,8 +52,8 @@ doInference swaps env expr = runTcMonad swaps $ do
   (subs, mt) <- inferAndSubst (defaultEnv recSubst <> env) expr
   holes <- getTypedHoles subs
   if M.null holes
-    then pure (subs, mt)
-    else throwError (TypedHoles holes)
+    then pure (subs, normaliseType mt)
+    else throwError (TypedHoles (normaliseType <$> holes))
 
 doDataTypeInference ::
   Environment ->

--- a/src/Language/Mimsa/Typechecker/NormaliseTypes.hs
+++ b/src/Language/Mimsa/Typechecker/NormaliseTypes.hs
@@ -1,0 +1,46 @@
+module Language.Mimsa.Typechecker.NormaliseTypes (normaliseType) where
+
+import Control.Monad.State
+import Data.Map (Map)
+import qualified Data.Map as M
+import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Typechecker
+
+data NormaliseState
+  = NormaliseState
+      { _nsNext :: Int,
+        _nsAllocated :: Map Int Int
+      }
+
+normaliseType :: MonoType -> MonoType
+normaliseType mt =
+  evalState
+    (normaliseType' mt)
+    (NormaliseState 1 mempty)
+
+findVar :: Int -> State NormaliseState Int
+findVar i = do
+  (NormaliseState next alloc) <- get
+  case M.lookup i alloc of
+    Just a -> pure a
+    Nothing -> do
+      put (NormaliseState (next + 1) (alloc <> M.singleton i next))
+      pure next
+
+normaliseType' :: MonoType -> State NormaliseState MonoType
+normaliseType' mt = case mt of
+  MTVar ann (NumberedVar i) -> do
+    index <- findVar i
+    pure $ MTVar ann (NumberedVar index)
+  MTVar ann (NamedVar n) -> pure (MTVar ann (NamedVar n))
+  MTPrim ann a -> pure (MTPrim ann a)
+  MTFunction ann arg fun ->
+    MTFunction ann
+      <$> normaliseType' arg
+      <*> normaliseType' fun
+  MTPair ann a b ->
+    MTPair ann
+      <$> normaliseType' a <*> normaliseType' b
+  MTRecord ann as -> MTRecord ann <$> traverse normaliseType' as
+  MTData ann name mts ->
+    MTData ann name <$> traverse normaliseType' mts

--- a/src/Language/Mimsa/Types/Typechecker/MonoType.hs
+++ b/src/Language/Mimsa/Types/Typechecker/MonoType.hs
@@ -55,6 +55,15 @@ getAnnotationForType (MTData ann _ _) = ann
 instance Printer (Type ann) where
   prettyDoc = renderMonoType
 
+printTypeNum :: Int -> String
+printTypeNum i = [toEnum (index + start)] <> suffix
+  where
+    index = (i - 1) `mod` 26
+    start = fromEnum 'A'
+    suffix =
+      let diff = (i - 1) `div` 26
+       in if diff < 1 then "" else show diff
+
 renderMonoType :: Type ann -> Doc a
 renderMonoType (MTPrim _ a) = prettyDoc a
 renderMonoType (MTFunction _ a b) =
@@ -76,5 +85,5 @@ renderMonoType (MTRecord _ as) =
     renderItem (Name k, v) = pretty k <+> ":" <+> renderMonoType v
 renderMonoType (MTVar _ a) = case a of
   (NamedVar (Name n)) -> pretty n
-  (NumberedVar i) -> pretty i
+  (NumberedVar i) -> pretty (printTypeNum i)
 renderMonoType (MTData _ (TyCon n) vars) = align $ sep ([pretty n] <> (renderMonoType <$> vars))

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -10,6 +10,7 @@ where
 import qualified Test.BackendJS as JS
 import Test.Hspec
 import qualified Test.Interpreter as Interpreter
+import qualified Test.NormaliseType as NormaliseType
 import qualified Test.Prettier as Prettier
 import Test.QuickCheck.Instances ()
 import qualified Test.RecordUsage as RecordUsage
@@ -38,3 +39,4 @@ main = hspec $ do
   TypeError.spec
   Serialisation.spec
   RecordUsage.spec
+  NormaliseType.spec

--- a/test/Test/NormaliseType.hs
+++ b/test/Test/NormaliseType.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.NormaliseType
+  ( spec,
+  )
+where
+
+import Language.Mimsa.Typechecker.NormaliseTypes
+import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Typechecker
+import Test.Hspec
+
+mkVar :: Int -> MonoType
+mkVar i = MTVar mempty (NumberedVar i)
+
+spec :: Spec
+spec =
+  describe "Normalise type" $ do
+    it "Literals are the same" $
+      normaliseType (MTPrim mempty MTInt)
+        `shouldBe` MTPrim mempty MTInt
+    it "Unification var starts at 1" $
+      normaliseType (mkVar 10)
+        `shouldBe` mkVar 1
+    it "The same vars should get the same numbers " $
+      normaliseType (MTPair mempty (mkVar 10) (mkVar 10))
+        `shouldBe` MTPair mempty (mkVar 1) (mkVar 1)
+    it "We increase the value we return as we go" $
+      normaliseType (MTPair mempty (mkVar 10) (mkVar 8))
+        `shouldBe` MTPair mempty (mkVar 1) (mkVar 2)
+    it "Repeating an earlier value does not break it" $
+      normaliseType
+        ( MTPair
+            mempty
+            (mkVar 10)
+            (MTPair mempty (mkVar 8) (mkVar 10))
+        )
+        `shouldBe` MTPair
+          mempty
+          (mkVar 1)
+          ( MTPair
+              mempty
+              (mkVar 2)
+              (mkVar 1)
+          )

--- a/test/Test/Prettier.hs
+++ b/test/Test/Prettier.hs
@@ -68,3 +68,12 @@ spec =
          in T.putStrLn
               ( prettyPrint mt
               )
+      it "Names type vars" $ do
+        let mt = MTVar () (NumberedVar 1)
+        prettyPrint mt `shouldBe` "A"
+      it "Names type vars 2" $ do
+        let mt = MTVar () (NumberedVar 26)
+        prettyPrint mt `shouldBe` "Z"
+      it "Names type vars 3" $ do
+        let mt = MTVar () (NumberedVar 27)
+        prettyPrint mt `shouldBe` "A1"

--- a/test/Test/Repl.hs
+++ b/test/Test/Repl.hs
@@ -82,7 +82,7 @@ spec =
         result <- eval stdLib "let prelude = ({ id: (\\i -> i) }) in prelude.id"
         result
           `shouldBe` Right
-            ( MTFunction mempty (unknown 5) (unknown 5),
+            ( MTFunction mempty (unknown 1) (unknown 1),
               MyLambda mempty (tvFree 1) (MyVar mempty (tvFree 1))
             )
       it "let prelude = ({ id: (\\i -> i) }) in prelude.id(1)" $ do

--- a/test/Test/Typechecker.hs
+++ b/test/Test/Typechecker.hs
@@ -106,7 +106,7 @@ exprs =
             (MyVar mempty (named "x"))
             (MyVar mempty (named "a"))
         ),
-      Right (MTFunction mempty (MTPair mempty (unknown 2) (unknown 3)) (unknown 2))
+      Right (MTFunction mempty (MTPair mempty (unknown 1) (unknown 2)) (unknown 1))
     ),
     ( MyLet
         mempty


### PR DESCRIPTION
Resolves #119 - now type signatures are simplified and printed as letters, such as:

```haskell
compose :: ((A -> B) -> ((C -> A) -> (C -> B)))
eitherMap :: ((A -> B) -> (Either C A -> Either C B))
fmapMaybe :: ((A -> B) -> (Maybe A -> Maybe B))
id :: (A -> A)
```

This will also enable #120 and make type directed search easier.
