### PR TITLE
WIP compile

### DIFF
--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6dc68fa11a96cb834a0dfe4a3cc939a7eda979e0b06887a8ced3a99a01338571
+-- hash: bd42416d2910ad2be4214287b8bc51252eda44761c3f4e5ea22896d6ce867ba6
 
 name:           mimsa
 version:        0.1.0.0
@@ -31,11 +31,14 @@ library
       Language.Mimsa.Actions
       Language.Mimsa.Actions.AddUnitTest
       Language.Mimsa.Actions.BindExpression
+      Language.Mimsa.Actions.Compile
       Language.Mimsa.Actions.Evaluate
       Language.Mimsa.Actions.Monad
       Language.Mimsa.Backend.Backend
       Language.Mimsa.Backend.Javascript
       Language.Mimsa.Backend.NormaliseConstructors
+      Language.Mimsa.Backend.Shared
+      Language.Mimsa.Backend.Types
       Language.Mimsa.CLI
       Language.Mimsa.Interpreter
       Language.Mimsa.Interpreter.HighestVar

--- a/src/Language/Mimsa/Actions/Compile.hs
+++ b/src/Language/Mimsa/Actions/Compile.hs
@@ -14,6 +14,7 @@ import Control.Monad.Except
 import Data.Bifunctor (first)
 import Data.Coerce
 import Data.Foldable (traverse_)
+import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -34,7 +35,7 @@ compile ::
   Backend ->
   Text ->
   Expr Name Annotation ->
-  Actions.ActionM ()
+  Actions.ActionM (ExprHash, Set ExprHash)
 compile be input expr = do
   project <- Actions.getProject
   (ResolvedExpression _ se _ _ _) <-
@@ -48,6 +49,11 @@ compile be input expr = do
   createIndex be (getStoreExpressionHash se)
   -- create the stdlib
   createStdlib be
+  -- return useful info
+  let rootExprHash = getStoreExpressionHash se
+  -- return all ExprHashes created
+  let allHashes = S.map getStoreExpressionHash list <> S.singleton rootExprHash
+  pure (rootExprHash, allHashes)
 
 -- | Each module comes from a StoreExpression
 -- | and is transpiled into a folder in the store

--- a/src/Language/Mimsa/Actions/Compile.hs
+++ b/src/Language/Mimsa/Actions/Compile.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Actions.Compile where
+
+-- get expression
+-- work out what to compile for it
+-- compile it to Text
+-- compile stdLib to Text
+-- create folders
+-- save files
+-- symlinking (?)
+
+import Control.Monad.Except
+import Data.Bifunctor (first)
+import Data.Coerce
+import Data.Foldable (traverse_)
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import Language.Mimsa.Actions
+import qualified Language.Mimsa.Actions.Monad as Actions
+import Language.Mimsa.Backend.Backend
+import Language.Mimsa.Backend.Javascript
+import Language.Mimsa.Backend.Shared
+import Language.Mimsa.Store
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Error
+import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Project
+import Language.Mimsa.Types.ResolvedExpression
+import Language.Mimsa.Types.Store
+
+compile ::
+  Backend ->
+  Text ->
+  Expr Name Annotation ->
+  Actions.ActionM ()
+compile be input expr = do
+  project <- Actions.getProject
+  (ResolvedExpression _ se _ _ _) <-
+    liftEither $ getTypecheckedStoreExpression input project expr
+  -- this will eventually check for things we have already transpiled to save
+  -- on work
+  let list = getTranspileList (prjStore project) se
+  -- transpile each required file and add to outputs
+  traverse_ (transpileModule be) (list <> S.singleton se)
+  -- create the index
+  createIndex be (getStoreExpressionHash se)
+  -- create the stdlib
+  createStdlib be
+
+-- | Each module comes from a StoreExpression
+-- | and is transpiled into a folder in the store
+transpileModule ::
+  Backend ->
+  StoreExpression Annotation ->
+  Actions.ActionM ()
+transpileModule be se = do
+  project <- Actions.getProject
+  dataTypes <- liftEither $ first StoreErr (resolveTypeDeps (prjStore project) (storeTypeBindings se))
+  let path = Actions.SavePath (T.pack $ transpiledModuleOutputPath be)
+  let filename = Actions.SaveFilename (moduleFilename be (getStoreExpressionHash se))
+  let jsOutput = Actions.SaveContents (coerce $ outputCommonJS dataTypes se)
+  Actions.appendMessage ("Writing " <> coerce path <> "...")
+  Actions.appendWriteFile path filename jsOutput
+
+-- | The index file for a given exprHash is the 'entrypoint' file
+-- | that exposes the expression as a function called 'main' and imports
+-- | the other files
+createIndex ::
+  Backend -> ExprHash -> Actions.ActionM ()
+createIndex be exprHash = do
+  let path = Actions.SavePath (T.pack $ transpiledIndexOutputPath be)
+      outputContent = Actions.SaveContents (outputIndexFile be exprHash)
+      filename = Actions.SaveFilename (indexFilename be)
+  Actions.appendWriteFile path filename outputContent
+
+-- | The stdlib is a set of functions needed to stuff like pattern matching
+createStdlib :: Backend -> Actions.ActionM ()
+createStdlib be = do
+  let path = Actions.SavePath (T.pack $ transpiledStdlibOutputPath be)
+      filename = Actions.SaveFilename (stdLibFilename be)
+      outputContent = Actions.SaveContents (outputStdlib be)
+  Actions.appendWriteFile path filename outputContent

--- a/src/Language/Mimsa/Actions/Monad.hs
+++ b/src/Language/Mimsa/Actions/Monad.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Language.Mimsa.Actions.Monad
@@ -5,12 +7,17 @@ module Language.Mimsa.Actions.Monad
     getProject,
     appendProject,
     appendMessage,
+    appendWriteFile,
     setProject,
     appendStoreExpression,
     bindStoreExpression,
     messagesFromOutcomes,
     storeExpressionsFromOutcomes,
+    writeFilesFromOutcomes,
     ActionM,
+    SavePath (..),
+    SaveContents (..),
+    SaveFilename (..),
   )
 where
 
@@ -28,9 +35,19 @@ import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Store
 
+newtype SavePath = SavePath Text
+  deriving newtype (Eq, Ord, Show)
+
+newtype SaveContents = SaveContents Text
+  deriving newtype (Eq, Ord, Show)
+
+newtype SaveFilename = SaveFilename Text
+  deriving newtype (Eq, Ord, Show)
+
 data ActionOutcome
   = NewMessage Text
   | NewStoreExpression (StoreExpression Annotation)
+  | NewWriteFile SavePath SaveFilename SaveContents
   deriving (Eq, Ord, Show)
 
 type ActionM =
@@ -62,6 +79,14 @@ appendMessage :: Text -> ActionM ()
 appendMessage =
   tell . pure . NewMessage
 
+appendWriteFile ::
+  SavePath ->
+  SaveFilename ->
+  SaveContents ->
+  ActionM ()
+appendWriteFile savePath filename content =
+  tell $ pure $ NewWriteFile savePath filename content
+
 appendStoreExpression :: StoreExpression Annotation -> ActionM ()
 appendStoreExpression =
   tell . pure . NewStoreExpression
@@ -82,6 +107,14 @@ storeExpressionsFromOutcomes =
           NewStoreExpression se -> pure se
           _ -> mempty
       )
+
+writeFilesFromOutcomes :: [ActionOutcome] -> [(SavePath, SaveFilename, SaveContents)]
+writeFilesFromOutcomes =
+  foldMap
+    ( \case
+        NewWriteFile sp sf sc -> pure (sp, sf, sc)
+        _ -> mempty
+    )
 
 -- add binding for expression and add it to store
 bindStoreExpression ::

--- a/src/Language/Mimsa/Actions/Monad.hs
+++ b/src/Language/Mimsa/Actions/Monad.hs
@@ -27,6 +27,7 @@ import Control.Monad.Writer
 import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)
+import qualified Data.Text as T
 import Language.Mimsa.Project
 import Language.Mimsa.Store
 import Language.Mimsa.Types.AST
@@ -36,13 +37,19 @@ import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Store
 
 newtype SavePath = SavePath Text
-  deriving newtype (Eq, Ord, Show)
+  deriving newtype (Eq, Ord)
+
+instance Show SavePath where
+  show (SavePath s) = T.unpack s
 
 newtype SaveContents = SaveContents Text
   deriving newtype (Eq, Ord, Show)
 
 newtype SaveFilename = SaveFilename Text
-  deriving newtype (Eq, Ord, Show)
+  deriving newtype (Eq, Ord)
+
+instance Show SaveFilename where
+  show (SaveFilename s) = T.unpack s
 
 data ActionOutcome
   = NewMessage Text

--- a/src/Language/Mimsa/Backend/Backend.hs
+++ b/src/Language/Mimsa/Backend/Backend.hs
@@ -3,6 +3,7 @@
 module Language.Mimsa.Backend.Backend
   ( outputCommonJS,
     goCompile,
+    getStdlib,
     Backend (..),
   )
 where
@@ -10,31 +11,19 @@ where
 import Control.Monad.Except
 import Data.Coerce
 import Data.Foldable (traverse_)
-import qualified Data.Map as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Language.Mimsa.Backend.Javascript
-import Language.Mimsa.Printer
+import Language.Mimsa.Backend.Shared
+import Language.Mimsa.Backend.Types
 import Language.Mimsa.Server.EnvVars
 import Language.Mimsa.Store.ResolvedDeps
 import Language.Mimsa.Store.Storage (getStoreExpressionHash, getStoreFolder, trySymlink)
-import Language.Mimsa.Types.AST
-import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Store
 import System.Directory
-
-data Backend
-  = CommonJS
-
-data Renderer ann a = Renderer
-  { renderFunc :: Name -> Expr Name ann -> a,
-    renderImport :: Backend -> (Name, ExprHash) -> a,
-    renderStdLib :: Backend -> a,
-    renderExport :: Backend -> Name -> a
-  }
 
 ------
 
@@ -47,9 +36,21 @@ createOutputFolder CommonJS exprHash = do
 
 -- all files are created in the store and then symlinked into output folders
 -- this creates the folder in the store
-createStoreOutputPath :: MimsaConfig -> Backend -> IO FilePath
-createStoreOutputPath mimsaConfig CommonJS =
-  getStoreFolder mimsaConfig "transpiled/common-js"
+createModuleOutputPath :: MimsaConfig -> Backend -> IO FilePath
+createModuleOutputPath mimsaConfig be =
+  getStoreFolder mimsaConfig (transpiledModuleOutputPath be)
+
+-- all files are created in the store and then symlinked into output folders
+-- this creates the folder in the store
+createIndexOutputPath :: MimsaConfig -> Backend -> IO FilePath
+createIndexOutputPath mimsaConfig be =
+  getStoreFolder mimsaConfig (transpiledIndexOutputPath be)
+
+-- all files are created in the store and then symlinked into output folders
+-- this creates the folder in the store
+createStdlibOutputPath :: MimsaConfig -> Backend -> IO FilePath
+createStdlibOutputPath mimsaConfig be =
+  getStoreFolder mimsaConfig (transpiledStdlibOutputPath be)
 
 transpileStoreExpression ::
   (Monoid ann) =>
@@ -59,8 +60,8 @@ transpileStoreExpression ::
   StoreExpression ann ->
   IO FilePath
 transpileStoreExpression mimsaConfig be store' se = do
-  outputFolderPath <- createStoreOutputPath mimsaConfig be
-  let filename = outputFilename be (getStoreExpressionHash se)
+  outputFolderPath <- createModuleOutputPath mimsaConfig be
+  let filename = moduleFilename be (getStoreExpressionHash se)
   let path = T.pack outputFolderPath <> filename
   exists <-
     doesFileExist
@@ -77,39 +78,41 @@ transpileStoreExpression mimsaConfig be store' se = do
   pure
     (T.unpack path)
 
-createIndexFile :: Backend -> ExprHash -> IO Text
-createIndexFile CommonJS rootExprHash = do
+-- we write the index to the store and then symlink it
+createIndexFile :: MimsaConfig -> Backend -> ExprHash -> IO Text
+createIndexFile mimsaConfig CommonJS rootExprHash = do
+  storePath <- createIndexOutputPath mimsaConfig CommonJS
   outputPath <- createOutputFolder CommonJS rootExprHash
-  let file = "const main = require('./" <> outputFilename CommonJS rootExprHash <> "').main;\nconsole.log(main)"
-      path = outputPath <> "index.js"
-  T.writeFile path file
-  pure (T.pack path)
+  let outputContent = outputIndexFile CommonJS rootExprHash
+      filename = "index.js"
+      fromPath = storePath <> filename
+      toPath = outputPath <> filename
+  T.writeFile fromPath outputContent
+  _ <- runExceptT $ trySymlink fromPath toPath
+  pure (T.pack toPath)
+
+getStdlib :: Backend -> Text
+getStdlib CommonJS = coerce commonJSStandardLibrary
 
 -- we write the stdlib to the store and then symlink it
-writeStdLib :: MimsaConfig -> Backend -> ExprHash -> IO ()
-writeStdLib mimsaConfig CommonJS rootExprHash = do
-  storePath <- createStoreOutputPath mimsaConfig CommonJS
+writeStdlib :: MimsaConfig -> Backend -> ExprHash -> IO ()
+writeStdlib mimsaConfig CommonJS rootExprHash = do
+  storePath <- createStdlibOutputPath mimsaConfig CommonJS
   outputPath <- createOutputFolder CommonJS rootExprHash
   let fromPath = T.pack storePath <> stdLibFilename CommonJS
-  T.writeFile (T.unpack fromPath) (coerce commonJSStandardLibrary)
+  T.writeFile (T.unpack fromPath) (getStdlib CommonJS)
   let toPath = T.pack outputPath <> stdLibFilename CommonJS
   _ <- runExceptT $ trySymlink (T.unpack fromPath) (T.unpack toPath)
   pure ()
-
--- recursively get all the StoreExpressions we need to output
-getOutputList :: (Ord ann) => Store ann -> StoreExpression ann -> Set (StoreExpression ann)
-getOutputList store' se = case recursiveResolve store' se of
-  Right as -> S.fromList as
-  Left _ -> mempty
 
 -- this recreates the folders which i dislike, however, yolo
 symlinkOutput :: MimsaConfig -> Set (StoreExpression ann) -> Backend -> ExprHash -> IO ()
 symlinkOutput mimsaConfig list CommonJS rootExprHash =
   do
-    storePath <- createStoreOutputPath mimsaConfig CommonJS
+    storePath <- createModuleOutputPath mimsaConfig CommonJS
     outputPath <- createOutputFolder CommonJS rootExprHash
     let doLink se = do
-          let filename = outputFilename CommonJS (getStoreExpressionHash se)
+          let filename = moduleFilename CommonJS (getStoreExpressionHash se)
               fromPath = storePath <> T.unpack filename
               toPath = outputPath <> T.unpack filename
           runExceptT $ trySymlink fromPath toPath
@@ -123,58 +126,16 @@ goCompile ::
   StoreExpression ann ->
   IO Text
 goCompile mimsaConfig be store' se = do
-  let list = getOutputList store' se
+  let list = getTranspileList store' se
   let rootExprHash = getStoreExpressionHash se
   -- create output files in store if they don't exist
   traverse_ (transpileStoreExpression mimsaConfig be store') list
   _ <- transpileStoreExpression mimsaConfig be store' se
   -- create index file in output folder
-  outputPath <- createIndexFile be rootExprHash
+  outputPath <- createIndexFile mimsaConfig be rootExprHash
   -- write stdlib file in output folder
-  writeStdLib mimsaConfig be rootExprHash
+  writeStdlib mimsaConfig be rootExprHash
   -- symlink all the files
   symlinkOutput mimsaConfig (list <> S.singleton se) be rootExprHash
   -- return path of main filename
   pure outputPath
-
-----
-
-stdLibFilename :: Backend -> Text
-stdLibFilename CommonJS = "cjs-stdlib.js"
-
-outputFilename :: Backend -> ExprHash -> Text
-outputFilename CommonJS hash' = "cjs-" <> prettyPrint hash' <> ".js"
-
-outputExport :: Backend -> Name -> Text
-outputExport CommonJS name = "module.exports = { " <> coerce name <> ": " <> coerce name <> " }"
-
-outputStoreExpression :: (Monoid a) => Backend -> Renderer ann a -> StoreExpression ann -> a
-outputStoreExpression be renderer se =
-  let funcName = mkName "main"
-      deps = mconcat $ renderImport renderer be <$> M.toList (getBindings $ storeBindings se)
-      stdLib = renderStdLib renderer be
-      func = renderFunc renderer funcName (storeExpression se)
-      export = renderExport renderer be funcName
-   in deps <> stdLib <> func <> export
-
-outputCommonJS :: (Monoid ann) => ResolvedTypeDeps -> StoreExpression ann -> Javascript
-outputCommonJS dataTypes =
-  outputStoreExpression
-    CommonJS
-    Renderer
-      { renderFunc = \name expr ->
-          "const " <> coerce name <> " = "
-            <> output dataTypes expr
-            <> ";\n",
-        renderImport = \be (name, hash') ->
-          Javascript $
-            "const "
-              <> coerce name
-              <> " = require(\"./"
-              <> outputFilename be hash'
-              <> "\").main;\n",
-        renderExport = \be name -> Javascript $ outputExport be name,
-        renderStdLib = \be ->
-          let filename = stdLibFilename be
-           in Javascript $ "const { __match, __eq } = require(\"./" <> filename <> "\");\n"
-      }

--- a/src/Language/Mimsa/Backend/Backend.hs
+++ b/src/Language/Mimsa/Backend/Backend.hs
@@ -21,7 +21,11 @@ import Language.Mimsa.Backend.Shared
 import Language.Mimsa.Backend.Types
 import Language.Mimsa.Server.EnvVars
 import Language.Mimsa.Store.ResolvedDeps
-import Language.Mimsa.Store.Storage (getStoreExpressionHash, getStoreFolder, trySymlink)
+import Language.Mimsa.Store.Storage
+  ( getStoreExpressionHash,
+    getStoreFolder,
+    trySymlink,
+  )
 import Language.Mimsa.Types.Store
 import System.Directory
 
@@ -30,7 +34,8 @@ import System.Directory
 -- each expression is symlinked from the store to ./output/<exprhash>/<filename.ext>
 createOutputFolder :: Backend -> ExprHash -> IO FilePath
 createOutputFolder CommonJS exprHash = do
-  let path = "./output/cjs" <> show exprHash
+  let outputPath = symlinkedOutputPath CommonJS
+  let path = outputPath <> show exprHash
   createDirectoryIfMissing True path
   pure (path <> "/")
 

--- a/src/Language/Mimsa/Backend/Javascript.hs
+++ b/src/Language/Mimsa/Backend/Javascript.hs
@@ -1,18 +1,16 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Language.Mimsa.Backend.Javascript
   ( output,
-    commonJSStandardLibrary,
+    outputCommonJS,
     Javascript (..),
   )
 where
 
 import Data.Coerce
-import Data.FileEmbed
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
 import Data.Map (Map)
@@ -21,12 +19,13 @@ import Data.Monoid
 import Data.String
 import Data.Text (Text)
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 import Language.Mimsa.Backend.NormaliseConstructors
+import Language.Mimsa.Backend.Shared
+import Language.Mimsa.Backend.Types
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
-import Language.Mimsa.Types.Store.ResolvedTypeDeps
+import Language.Mimsa.Types.Store
 
 ----
 newtype Javascript = Javascript Text
@@ -36,13 +35,6 @@ instance IsString Javascript where
   fromString = Javascript . T.pack
 
 ----
-
--- these are saved in a file that is included in compilation
-commonJSStandardLibrary :: Javascript
-commonJSStandardLibrary =
-  Javascript $ T.decodeUtf8 $(embedFile "static/backend/commonjs/stdlib.js")
-
----
 
 outputLiteral :: Literal -> Javascript
 outputLiteral (MyUnit _) = "{}"
@@ -178,3 +170,25 @@ outputJS expr =
     MyConsApp _ c a -> outputConsApp c a
     MyCaseMatch _ a matches catch -> outputCaseMatch a matches catch
     MyTypedHole _ a -> coerce a -- TODO: this should fail, but dont want to introduce failure into this whole area yet
+
+outputCommonJS :: (Monoid ann) => ResolvedTypeDeps -> StoreExpression ann -> Javascript
+outputCommonJS dataTypes =
+  outputStoreExpression
+    CommonJS
+    Renderer
+      { renderFunc = \name expr ->
+          "const " <> coerce name <> " = "
+            <> output dataTypes expr
+            <> ";\n",
+        renderImport = \be (name, hash') ->
+          Javascript $
+            "const "
+              <> coerce name
+              <> " = require(\"./"
+              <> moduleFilename be hash'
+              <> "\").main;\n",
+        renderExport = \be name -> Javascript $ outputExport be name,
+        renderStdLib = \be ->
+          let filename = stdLibFilename be
+           in Javascript $ "const { __match, __eq } = require(\"./" <> filename <> "\");\n"
+      }

--- a/src/Language/Mimsa/Backend/Shared.hs
+++ b/src/Language/Mimsa/Backend/Shared.hs
@@ -5,6 +5,7 @@ module Language.Mimsa.Backend.Shared
   ( transpiledModuleOutputPath,
     transpiledIndexOutputPath,
     transpiledStdlibOutputPath,
+    symlinkedOutputPath,
     outputStoreExpression,
     outputExport,
     outputIndexFile,
@@ -40,6 +41,10 @@ stdLibFilename CommonJS = "cjs-stdlib.js"
 
 indexFilename :: Backend -> Text
 indexFilename CommonJS = "index.js"
+
+symlinkedOutputPath :: Backend -> FilePath
+symlinkedOutputPath CommonJS =
+  "./output/cjs"
 
 transpiledModuleOutputPath :: Backend -> FilePath
 transpiledModuleOutputPath CommonJS = "transpiled/module/common-js"

--- a/src/Language/Mimsa/Backend/Shared.hs
+++ b/src/Language/Mimsa/Backend/Shared.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Language.Mimsa.Backend.Shared
+  ( transpiledModuleOutputPath,
+    transpiledIndexOutputPath,
+    transpiledStdlibOutputPath,
+    outputStoreExpression,
+    outputExport,
+    outputIndexFile,
+    outputStdlib,
+    indexFilename,
+    moduleFilename,
+    stdLibFilename,
+    getTranspileList,
+    commonJSStandardLibrary,
+  )
+where
+
+import Data.Coerce
+import Data.FileEmbed
+import qualified Data.Map as M
+import Data.Set (Set)
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text.Encoding as T
+import Language.Mimsa.Backend.Types
+import Language.Mimsa.Printer
+import Language.Mimsa.Store.ResolvedDeps
+import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Store
+
+-- these are saved in a file that is included in compilation
+commonJSStandardLibrary :: Text
+commonJSStandardLibrary =
+  T.decodeUtf8 $(embedFile "static/backend/commonjs/stdlib.js")
+
+stdLibFilename :: Backend -> Text
+stdLibFilename CommonJS = "cjs-stdlib.js"
+
+indexFilename :: Backend -> Text
+indexFilename CommonJS = "index.js"
+
+transpiledModuleOutputPath :: Backend -> FilePath
+transpiledModuleOutputPath CommonJS = "transpiled/module/common-js"
+
+transpiledIndexOutputPath :: Backend -> FilePath
+transpiledIndexOutputPath CommonJS = "transpiled/index/common-js"
+
+transpiledStdlibOutputPath :: Backend -> FilePath
+transpiledStdlibOutputPath CommonJS = "transpiled/stdlib/common-js"
+
+outputIndexFile :: Backend -> ExprHash -> Text
+outputIndexFile CommonJS exprHash =
+  "const main = require('./" <> moduleFilename CommonJS exprHash <> "').main;\nconsole.log(main)"
+
+moduleFilename :: Backend -> ExprHash -> Text
+moduleFilename CommonJS hash' = "cjs-" <> prettyPrint hash' <> ".js"
+
+outputStdlib :: Backend -> Text
+outputStdlib CommonJS = coerce commonJSStandardLibrary
+
+outputExport :: Backend -> Name -> Text
+outputExport CommonJS name = "module.exports = { " <> coerce name <> ": " <> coerce name <> " }"
+
+outputStoreExpression :: (Monoid a) => Backend -> Renderer ann a -> StoreExpression ann -> a
+outputStoreExpression be renderer se =
+  let funcName = mkName "main"
+      deps = mconcat $ renderImport renderer be <$> M.toList (getBindings $ storeBindings se)
+      stdLib = renderStdLib renderer be
+      func = renderFunc renderer funcName (storeExpression se)
+      export = renderExport renderer be funcName
+   in deps <> stdLib <> func <> export
+
+-- recursively get all the StoreExpressions we need to output
+getTranspileList :: (Ord ann) => Store ann -> StoreExpression ann -> Set (StoreExpression ann)
+getTranspileList store' se = case recursiveResolve store' se of
+  Right as -> S.fromList as
+  Left _ -> mempty

--- a/src/Language/Mimsa/Backend/Types.hs
+++ b/src/Language/Mimsa/Backend/Types.hs
@@ -1,0 +1,15 @@
+module Language.Mimsa.Backend.Types (Backend (..), Renderer (..)) where
+
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Store
+
+data Backend
+  = CommonJS
+
+data Renderer ann a = Renderer
+  { renderFunc :: Name -> Expr Name ann -> a,
+    renderImport :: Backend -> (Name, ExprHash) -> a,
+    renderStdLib :: Backend -> a,
+    renderExport :: Backend -> Name -> a
+  }

--- a/src/Language/Mimsa/Repl/Actions/Compile.hs
+++ b/src/Language/Mimsa/Repl/Actions/Compile.hs
@@ -8,7 +8,9 @@ where
 import Control.Monad.Reader
 import Data.Text (Text)
 import Language.Mimsa.Actions
+import qualified Language.Mimsa.Actions.Compile as Actions
 import Language.Mimsa.Backend.Backend (Backend (..), goCompile)
+import Language.Mimsa.Repl.Helpers
 import Language.Mimsa.Repl.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
@@ -20,11 +22,11 @@ doOutputJS ::
   Text ->
   Expr Name Annotation ->
   ReplM Annotation ()
-doOutputJS env input expr = do
+doOutputJS project input expr = do
+  (newProject, (newExprHash, _, _)) <-
+    toReplM project (Actions.compile CommonJS input expr)
   mimsaConfig <- ask
-  (ResolvedExpression _ storeExpr' _ _ _) <-
-    liftRepl $ getTypecheckedStoreExpression input env expr
   outputPath <-
     liftIO $
-      goCompile mimsaConfig CommonJS (prjStore env) storeExpr'
+      goCompile mimsaConfig CommonJS (prjStore project) storeExpr'
   replPrint ("Output to " <> outputPath)

--- a/src/Language/Mimsa/Repl/Actions/Compile.hs
+++ b/src/Language/Mimsa/Repl/Actions/Compile.hs
@@ -7,7 +7,6 @@ where
 
 import Control.Monad.Reader
 import Data.Text (Text)
-import Language.Mimsa.Actions
 import qualified Language.Mimsa.Actions.Compile as Actions
 import Language.Mimsa.Backend.Backend (Backend (..), goCompile)
 import Language.Mimsa.Repl.Helpers
@@ -15,7 +14,6 @@ import Language.Mimsa.Repl.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
-import Language.Mimsa.Types.ResolvedExpression
 
 doOutputJS ::
   Project Annotation ->
@@ -23,10 +21,10 @@ doOutputJS ::
   Expr Name Annotation ->
   ReplM Annotation ()
 doOutputJS project input expr = do
-  (newProject, (newExprHash, _, _)) <-
+  (newProject, _) <-
     toReplM project (Actions.compile CommonJS input expr)
   mimsaConfig <- ask
   outputPath <-
     liftIO $
-      goCompile mimsaConfig CommonJS (prjStore project) storeExpr'
+      goCompile mimsaConfig CommonJS (prjStore newProject) undefined
   replPrint ("Output to " <> outputPath)

--- a/src/Language/Mimsa/Repl/Actions/Compile.hs
+++ b/src/Language/Mimsa/Repl/Actions/Compile.hs
@@ -6,14 +6,20 @@ module Language.Mimsa.Repl.Actions.Compile
 where
 
 import Control.Monad.Reader
+import Data.Set (Set)
 import Data.Text (Text)
 import qualified Language.Mimsa.Actions.Compile as Actions
-import Language.Mimsa.Backend.Backend (Backend (..), goCompile)
+import Language.Mimsa.Backend.Backend
+  ( Backend (..),
+    copyLocalOutput,
+  )
 import Language.Mimsa.Repl.Helpers
 import Language.Mimsa.Repl.Types
 import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
+import Language.Mimsa.Types.Store
 
 doOutputJS ::
   Project Annotation ->
@@ -21,10 +27,12 @@ doOutputJS ::
   Expr Name Annotation ->
   ReplM Annotation ()
 doOutputJS project input expr = do
-  (newProject, _) <-
+  (_, (rootExprHash, exprHashes)) <-
     toReplM project (Actions.compile CommonJS input expr)
-  mimsaConfig <- ask
-  outputPath <-
-    liftIO $
-      goCompile mimsaConfig CommonJS (prjStore newProject) undefined
+  outputPath <- doCopying CommonJS exprHashes rootExprHash
   replPrint ("Output to " <> outputPath)
+
+doCopying :: Backend -> Set ExprHash -> ExprHash -> ReplM Annotation Text
+doCopying be exprHashes rootExprHash = do
+  mimsaConfig <- ask
+  liftExceptTToRepl StoreErr (copyLocalOutput mimsaConfig be exprHashes rootExprHash)

--- a/src/Language/Mimsa/Repl/Helpers.hs
+++ b/src/Language/Mimsa/Repl/Helpers.hs
@@ -21,6 +21,10 @@ saveExpression storeExpr = do
   mimsaConfig <- ask
   lift $ withExceptT StoreErr $ saveExpr mimsaConfig storeExpr
 
+-- | given an expression to save, save it
+saveFile :: (Actions.SavePath, Actions.SaveFilename, Actions.SaveContents) -> ReplM Annotation ()
+saveFile (_path, _filename, _content) = undefined
+
 -- | Run an Action, printing any messages to the console and saving any
 -- expressions to disk
 toReplM ::
@@ -32,4 +36,5 @@ toReplM project action = case Actions.run project action of
   Right (newProject, outcomes, a) -> do
     traverse_ replPrint (Actions.messagesFromOutcomes outcomes)
     traverse_ saveExpression (Actions.storeExpressionsFromOutcomes outcomes)
+    traverse_ saveFile (Actions.writeFilesFromOutcomes outcomes)
     pure (newProject, a)

--- a/src/Language/Mimsa/Repl/Helpers.hs
+++ b/src/Language/Mimsa/Repl/Helpers.hs
@@ -35,9 +35,8 @@ saveFile (path, filename, content) = do
   mimsaConfig <- ask
   fullPath <- liftIO $ getStoreFolder mimsaConfig (show path)
   let savePath = fullPath <> show filename
-  liftIO $ print savePath
+  liftIO $ putStrLn $ "Saving to " <> savePath
   liftIO $ T.writeFile savePath (coerce content)
-  pure ()
 
 -- | Run an Action, printing any messages to the console and saving any
 -- expressions to disk

--- a/src/Language/Mimsa/Repl/Types.hs
+++ b/src/Language/Mimsa/Repl/Types.hs
@@ -35,6 +35,13 @@ liftRepl :: Either (Error ann) a -> ReplM ann a
 liftRepl (Right a) = pure a
 liftRepl (Left e) = throwError e
 
+liftExceptTToRepl :: (e -> Error ann) -> ExceptT e IO a -> ReplM ann a
+liftExceptTToRepl errorF comp = do
+  value <- liftIO $ runExceptT comp
+  case value of
+    Right a -> pure a
+    Left e -> throwError (errorF e)
+
 data ReplAction ann
   = Help
   | Info (Expr Name ann)

--- a/src/Language/Mimsa/Store/Storage.hs
+++ b/src/Language/Mimsa/Store/Storage.hs
@@ -6,7 +6,7 @@ module Language.Mimsa.Store.Storage
     findExpr,
     getStoreExpressionHash,
     getStoreFolder,
-    trySymlink,
+    tryCopy,
     storeSize,
   )
 where
@@ -38,14 +38,14 @@ getStoreFolder cfg subFolder = do
   createDirectoryIfMissing True path
   pure (path <> "/")
 
--- when transpiling we write to the store then symlink it in place
--- this tries that, and failing that, copies the file (for Windows etc)
-trySymlink :: String -> String -> StoreM ()
-trySymlink from to = do
-  symLinkCreated <- liftIO $ try (createFileLink from to)
-  case (symLinkCreated :: Either IOError ()) of
-    Right _ -> pure ()
-    Left _ -> liftIO $ copyFile from to
+-- try copying a file from a to b
+tryCopy :: String -> String -> StoreM ()
+tryCopy from to = do
+  fileCopied <- liftIO $ try (copyFile from to)
+  case (fileCopied :: Either IOError ()) of
+    Right _ -> do
+      liftIO $ putStrLn $ "File copied from " <> from <> " to " <> to
+    Left _ -> pure ()
 
 getExpressionFolder :: MimsaConfig -> IO FilePath
 getExpressionFolder cfg = getStoreFolder cfg "expressions"

--- a/test/Test/Actions.hs
+++ b/test/Test/Actions.hs
@@ -12,6 +12,7 @@ import Data.List (nub)
 import qualified Data.Map as M
 import Data.Maybe (isJust)
 import qualified Data.Set as S
+import qualified Data.Text as T
 import qualified Language.Mimsa.Actions.AddUnitTest as Actions
 import qualified Language.Mimsa.Actions.BindExpression as Actions
 import qualified Language.Mimsa.Actions.Compile as Actions
@@ -48,6 +49,11 @@ testWithIdInExpr =
 
 onePlusOneExpr :: Expr Name Annotation
 onePlusOneExpr = MyInfix mempty Add (int 1) (int 1)
+
+fromRight :: (Printer e) => Either e a -> a
+fromRight either' = case either' of
+  Left e -> error (T.unpack $ prettyPrint e)
+  Right a -> a
 
 spec :: Spec
 spec = do
@@ -139,41 +145,39 @@ spec = do
               (mkName "id")
               `shouldNotBe` lookupBindingName stdLib (mkName "id")
     describe "Compile" $ do
-      it "Simplest compilation creates one file" $ do
+      it "Simplest compilation creates four files" $ do
         let expr = MyVar mempty (mkName "id")
         let action = Actions.compile CommonJS "id" expr
-        case Actions.run stdLib action of
-          Left _ -> error "Should not have failed"
-          Right (newProject, outcomes, _) -> do
-            -- creates three filew
-            length (Actions.writeFilesFromOutcomes outcomes) `shouldBe` 3
-            -- doesn't change project (for now)
-            newProject `shouldBe` stdLib
-            -- uses three different folders
-            let uniqueFolders =
-                  nub
-                    ( (\(path, _, _) -> path)
-                        <$> Actions.writeFilesFromOutcomes outcomes
-                    )
-            length uniqueFolders `shouldBe` 3
+        let (newProject, outcomes, (_, hashes)) = fromRight (Actions.run stdLib action)
+        -- creates three files
+        length (Actions.writeFilesFromOutcomes outcomes) `shouldBe` 4
+        -- doesn't change project (for now)
+        newProject `shouldBe` stdLib
+        -- uses three different folders
+        let uniqueFolders =
+              nub
+                ( (\(path, _, _) -> path)
+                    <$> Actions.writeFilesFromOutcomes outcomes
+                )
+        length uniqueFolders `shouldBe` 3
+        -- should have returned two exprHashs (one for the main expr, one
+        -- for the `id` dependency
+        S.size hashes `shouldBe` 2
       it "Complex compilation creates many files in 3 folders" $ do
-        let expr = MyVar mempty (mkName "evalStore")
-        let action = Actions.compile CommonJS "evalStore" expr
-        case Actions.run stdLib action of
-          Left _ -> error "Should not have failed"
-          Right (newProject, outcomes, _) -> do
-            -- creates six files
-            length (Actions.writeFilesFromOutcomes outcomes) `shouldBe` 6
-            -- doesn't change project (for now)
-            newProject `shouldBe` stdLib
-            -- uses three different folders
-            let uniqueFolders =
-                  nub
-                    ( (\(path, _, _) -> path)
-                        <$> Actions.writeFilesFromOutcomes outcomes
-                    )
-            length uniqueFolders `shouldBe` 3
-
+        let expr = MyVar mempty (mkName "evalState")
+        let action = Actions.compile CommonJS "evalState" expr
+        let (newProject, outcomes, _) = fromRight (Actions.run stdLib action)
+        -- creates six files
+        length (Actions.writeFilesFromOutcomes outcomes) `shouldBe` 7
+        -- doesn't change project (for now)
+        newProject `shouldBe` stdLib
+        -- uses three different folders
+        let uniqueFolders =
+              nub
+                ( (\(path, _, _) -> path)
+                    <$> Actions.writeFilesFromOutcomes outcomes
+                )
+        length uniqueFolders `shouldBe` 3
     describe "Evaluate" $ do
       it "Should return an error for a broken expr" $ do
         Actions.run stdLib (Actions.evaluate (prettyPrint brokenExpr) brokenExpr) `shouldSatisfy` isLeft

--- a/test/Test/BackendJS.hs
+++ b/test/Test/BackendJS.hs
@@ -34,7 +34,7 @@ eval env input =
     Left e -> Left $ prettyPrint e
     Right (ResolvedExpression _ storeExpr _ _ _) ->
       pure $
-        output dataTypes (storeExpression storeExpr)
+        renderWithFunction dataTypes (mkName "main") (storeExpression storeExpr)
 
 evalModule :: Project Annotation -> Text -> IO (Either Text Javascript)
 evalModule env input =
@@ -48,31 +48,31 @@ evalModule env input =
 
 successes :: [(Text, Javascript)]
 successes =
-  [ ("True", "true"),
-    ("False", "false"),
-    ("123", "123"),
-    ("\"Poo\"", "\"Poo\""),
-    ("id", "id"),
-    ("\\a -> a", "a => a"),
-    ("id(1)", "id(1)"),
-    ("if True then 1 else 2", "true ? 1 : 2"),
-    ("let a = \"dog\" in 123", "const a = \"dog\";\nreturn 123"),
-    ("let a = \"dog\" in let b = \"horse\" in 123", "const a = \"dog\";\nconst b = \"horse\";\nreturn 123"),
-    ("{ a: 123, b: \"horse\" }", "{ a: 123, b: \"horse\" }"),
-    ("let (a,b) = aPair in a", "const [a,b] = aPair;\nreturn a"),
-    ("\\a -> let b = 123 in a", "a => { const b = 123;\nreturn a }"),
-    ("(1,2)", "[1,2]"),
-    ("aRecord.a", "aRecord.a"),
-    ("Some", "a => ({ type: \"Some\", vars: [a] })"),
-    ("Some 1", "{ type: \"Some\", vars: [1] }"),
-    ("Nowt", "{ type: \"Nowt\", vars: [] }"),
-    ("These", "a => b => ({ type: \"These\", vars: [a,b] })"),
-    ("case Some 1 of Some \\a -> a | Nowt 0", "__match({ type: \"Some\", vars: [1] }, { Some: a => a, Nowt: 0 }, null)"),
-    ("case Some 1 of Some \\a -> a | otherwise 0", "__match({ type: \"Some\", vars: [1] }, { Some: a => a }, 0)"),
-    ("True == False", "__eq(true, false)"),
-    ("2 + 2", "2 + 2"),
-    ("10 - 2", "10 - 2"),
-    ("\"dog\" <> \"log\"", "\"dog\" + \"log\"")
+  [ ("True", "const main = true;\n"),
+    ("False", "const main = false;\n"),
+    ("123", "const main = 123;\n"),
+    ("\"Poo\"", "const main = \"Poo\";\n"),
+    ("id", "const main = id;\n"),
+    ("\\a -> a", "const main = a => a;\n"),
+    ("id(1)", "const main = id(1);\n"),
+    ("if True then 1 else 2", "const main = true ? 1 : 2;\n"),
+    ("let a = \"dog\" in 123", "const main = function() { const a = \"dog\";\nreturn 123 }();\n"),
+    ("let a = \"dog\" in let b = \"horse\" in 123", "const main = function() { const a = \"dog\";\nconst b = \"horse\";\nreturn 123 }();\n"),
+    ("{ a: 123, b: \"horse\" }", "const main = { a: 123, b: \"horse\" };\n"),
+    ("let (a,b) = aPair in a", "const main = function() { const [a,b] = aPair;\nreturn a }();\n"),
+    ("\\a -> let b = 123 in a", "const main = a => { const b = 123;\nreturn a };\n"),
+    ("(1,2)", "const main = [1,2];\n"),
+    ("aRecord.a", "const main = aRecord.a;\n"),
+    ("Some", "const main = a => ({ type: \"Some\", vars: [a] });\n"),
+    ("Some 1", "const main = { type: \"Some\", vars: [1] };\n"),
+    ("Nowt", "const main = { type: \"Nowt\", vars: [] };\n"),
+    ("These", "const main = a => b => ({ type: \"These\", vars: [a,b] });\n"),
+    ("case Some 1 of Some \\a -> a | Nowt 0", "const main = __match({ type: \"Some\", vars: [1] }, { Some: a => a, Nowt: 0 }, null);\n"),
+    ("case Some 1 of Some \\a -> a | otherwise 0", "const main = __match({ type: \"Some\", vars: [1] }, { Some: a => a }, 0);\n"),
+    ("True == False", "const main = __eq(true, false);\n"),
+    ("2 + 2", "const main = 2 + 2;\n"),
+    ("10 - 2", "const main = 10 - 2;\n"),
+    ("\"dog\" <> \"log\"", "const main = \"dog\" + \"log\";\n")
   ]
 
 testIt :: (Text, Javascript) -> Spec


### PR DESCRIPTION
Convert compilation to be an Action. This means splitting "working out the code" and "saving the files" and "copying them to the project". This a) makes everything less of a pile of poo and b) will make downloading JS from the server easier.