### PR TITLE
Codegen pt 1

### DIFF
--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: fd19e92b7acd4898f93650603c3d1de2eb371ad0358131b9447618d469d12f15
+-- hash: bba18516c05dc453ea19e4a2988c7f55509b8b020bb4077e239a2db0de356b5a
 
 name:           mimsa
 version:        0.1.0.0
@@ -31,6 +31,7 @@ library
       Language.Mimsa.Actions
       Language.Mimsa.Actions.AddUnitTest
       Language.Mimsa.Actions.BindExpression
+      Language.Mimsa.Actions.BindType
       Language.Mimsa.Actions.Compile
       Language.Mimsa.Actions.Evaluate
       Language.Mimsa.Actions.Monad

--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f7284538a5062e0578c480469dec051591b079f6939544da44d7a1302b5e4b2d
+-- hash: 4cc248e0df4ccf6d392297886b6fcacf8091b072a018b45ab7605d0bc5f6e361
 
 name:           mimsa
 version:        0.1.0.0
@@ -109,6 +109,7 @@ library
       Language.Mimsa.Store.Substitutor
       Language.Mimsa.Store.UpdateDeps
       Language.Mimsa.Typechecker
+      Language.Mimsa.Typechecker.Codegen
       Language.Mimsa.Typechecker.DataTypes
       Language.Mimsa.Typechecker.DisplayError
       Language.Mimsa.Typechecker.Environment
@@ -281,24 +282,25 @@ test-suite mimsa-test
       Test.Actions
       Test.BackendJS
       Test.Data.Project
-      Test.InstantiateVar
-      Test.Interpreter
-      Test.MonoTypeParser
-      Test.NormaliseType
+      Test.Interpreter.InstantiateVar
+      Test.Interpreter.Interpreter
+      Test.Interpreter.Repl
+      Test.Parser.MonoTypeParser
+      Test.Parser.Syntax
       Test.Prettier
-      Test.RecordUsage
-      Test.Repl
-      Test.Resolver
+      Test.Project.NormaliseType
+      Test.Project.TypeSearch
+      Test.Project.UnitTest
+      Test.Project.Usages
       Test.Serialisation
-      Test.Substitutor
-      Test.Syntax
-      Test.Typechecker
-      Test.TypeError
-      Test.TypeSearch
-      Test.Unify
-      Test.UnitTest
-      Test.UpdateDeps
-      Test.Usages
+      Test.Store.Resolver
+      Test.Store.Substitutor
+      Test.Store.UpdateDeps
+      Test.Typechecker.Codegen
+      Test.Typechecker.RecordUsage
+      Test.Typechecker.Typechecker
+      Test.Typechecker.TypeError
+      Test.Typechecker.Unify
       Test.Utils.Helpers
       Test.Utils.Serialisation
       Paths_mimsa
@@ -306,8 +308,7 @@ test-suite mimsa-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      QuickCheck
-    , aeson
+      aeson
     , base >=4.7 && <5
     , bytestring
     , containers
@@ -315,7 +316,6 @@ test-suite mimsa-test
     , directory
     , envy
     , file-embed
-    , generic-arbitrary
     , haskeline
     , hspec
     , http-types
@@ -326,7 +326,6 @@ test-suite mimsa-test
     , optparse-applicative
     , parser-combinators
     , prettyprinter
-    , quickcheck-instances
     , servant
     , servant-server
     , servant-swagger

--- a/mimsa.cabal
+++ b/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4cc248e0df4ccf6d392297886b6fcacf8091b072a018b45ab7605d0bc5f6e361
+-- hash: fd19e92b7acd4898f93650603c3d1de2eb371ad0358131b9447618d469d12f15
 
 name:           mimsa
 version:        0.1.0.0
@@ -110,6 +110,9 @@ library
       Language.Mimsa.Store.UpdateDeps
       Language.Mimsa.Typechecker
       Language.Mimsa.Typechecker.Codegen
+      Language.Mimsa.Typechecker.Codegen.Enum
+      Language.Mimsa.Typechecker.Codegen.Functor
+      Language.Mimsa.Typechecker.Codegen.Newtype
       Language.Mimsa.Typechecker.DataTypes
       Language.Mimsa.Typechecker.DisplayError
       Language.Mimsa.Typechecker.Environment

--- a/package.yaml
+++ b/package.yaml
@@ -82,6 +82,3 @@ tests:
     dependencies:
     - mimsa
     - hspec
-    - QuickCheck
-    - generic-arbitrary
-    - quickcheck-instances

--- a/src/Language/Mimsa/Actions/BindType.hs
+++ b/src/Language/Mimsa/Actions/BindType.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Actions.BindType
+  ( bindType,
+  )
+where
+
+import Control.Monad.Except (liftEither)
+import Data.Text (Text)
+import Language.Mimsa.Actions
+import qualified Language.Mimsa.Actions.Monad as Actions
+import Language.Mimsa.Printer
+import Language.Mimsa.Project.Helpers
+import Language.Mimsa.Typechecker.Codegen
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.ResolvedExpression
+
+-- add a new type to the project, creating any functions for it as we go
+bindType ::
+  Text ->
+  DataType ->
+  Name ->
+  Actions.ActionM [Typeclass]
+bindType input dt name = do
+  project <- Actions.getProject
+  let expr = MyData mempty dt (MyRecord mempty mempty)
+  (ResolvedExpression _type' storeExpr _ _ _) <-
+    liftEither $ getTypecheckedStoreExpression input project expr
+  Actions.bindStoreExpression storeExpr name
+  case lookupBindingName project name of
+    Nothing -> do
+      Actions.appendMessage
+        ( "Bound type " <> prettyPrint name <> "."
+        )
+      pure mempty
+    Just _oldExprHash ->
+      do
+        Actions.appendMessage
+          ( "Updated type binding of " <> prettyPrint name <> "."
+          )
+        pure mempty

--- a/src/Language/Mimsa/Actions/BindType.hs
+++ b/src/Language/Mimsa/Actions/BindType.hs
@@ -6,15 +6,18 @@ module Language.Mimsa.Actions.BindType
 where
 
 import Control.Monad.Except (liftEither)
+import qualified Data.Map as M
 import Data.Text (Text)
 import Language.Mimsa.Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Project.Helpers
+import Language.Mimsa.Store
 import Language.Mimsa.Typechecker.Codegen
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.ResolvedExpression
+import Language.Mimsa.Types.Store
 
 -- add a new type to the project, creating any functions for it as we go
 bindType ::
@@ -24,19 +27,73 @@ bindType ::
   Actions.ActionM [Typeclass]
 bindType input dt name = do
   project <- Actions.getProject
-  let expr = MyData mempty dt (MyRecord mempty mempty)
-  (ResolvedExpression _type' storeExpr _ _ _) <-
-    liftEither $ getTypecheckedStoreExpression input project expr
+  storeExpr <- createStoreExpressions input dt
+  let typeclasses = typeclassMatches dt
   Actions.bindStoreExpression storeExpr name
   case lookupBindingName project name of
     Nothing -> do
       Actions.appendMessage
         ( "Bound type " <> prettyPrint name <> "."
         )
-      pure mempty
+      pure typeclasses
     Just _oldExprHash ->
       do
         Actions.appendMessage
           ( "Updated type binding of " <> prettyPrint name <> "."
           )
-        pure mempty
+        pure typeclasses
+
+createStoreExpressions :: Text -> DataType -> Actions.ActionM (StoreExpression Annotation)
+createStoreExpressions input dt = do
+  project <- Actions.getProject
+  let funcMap = doCodegen dt
+  resolvedTypeExpr <-
+    liftEither $
+      getTypecheckedStoreExpression input project (MyData mempty dt (MyLiteral mempty (MyUnit mempty)))
+  let projectWithType =
+        project
+          <> fromType
+            (reStoreExpression resolvedTypeExpr)
+            (getStoreExpressionHash (reStoreExpression resolvedTypeExpr))
+  storeExprs <-
+    traverse
+      ( \(name, expr) -> do
+          resolvedExpr <-
+            liftEither $
+              getTypecheckedStoreExpression
+                (prettyPrint expr)
+                projectWithType
+                expr
+          Actions.appendStoreExpression (reStoreExpression resolvedExpr)
+          pure
+            (name, reStoreExpression resolvedExpr)
+      )
+      (M.toList funcMap)
+  -- create project items for use in our record type
+  let newProjectItems =
+        mconcat
+          ( ( \(name, expr) ->
+                fromItem
+                  name
+                  expr
+                  (getStoreExpressionHash expr)
+            )
+              <$> storeExprs
+          )
+  -- add these new expressions (but not their bindings) to the project Store
+  Actions.appendProject
+    ( mconcat
+        ( ( \se ->
+              fromStoreExpression
+                se
+                (getStoreExpressionHash se)
+          )
+            . snd
+            <$> storeExprs
+        )
+    )
+  let realFunctionMap = M.mapWithKey (\k _ -> MyVar mempty k) funcMap
+  let recordExpr = MyData mempty dt (MyRecord mempty realFunctionMap)
+  (ResolvedExpression _ storeExpr _ _ _) <-
+    liftEither $ getTypecheckedStoreExpression input (projectWithType <> newProjectItems) recordExpr
+  pure storeExpr

--- a/src/Language/Mimsa/Actions/Monad.hs
+++ b/src/Language/Mimsa/Actions/Monad.hs
@@ -11,6 +11,7 @@ module Language.Mimsa.Actions.Monad
     setProject,
     appendStoreExpression,
     bindStoreExpression,
+    bindTypeExpression,
     messagesFromOutcomes,
     storeExpressionsFromOutcomes,
     writeFilesFromOutcomes,
@@ -133,3 +134,14 @@ bindStoreExpression storeExpr name = do
         fromItem name storeExpr (getStoreExpressionHash storeExpr)
   appendStoreExpression storeExpr
   appendProject newProject
+
+bindTypeExpression ::
+  StoreExpression Annotation -> ActionM ()
+bindTypeExpression storeExpr = do
+  -- add the expression to the store
+  appendStoreExpression storeExpr
+  -- add the type to the project
+  appendProject $
+    fromType
+      storeExpr
+      (getStoreExpressionHash storeExpr)

--- a/src/Language/Mimsa/Backend/Shared.hs
+++ b/src/Language/Mimsa/Backend/Shared.hs
@@ -70,7 +70,7 @@ outputExport CommonJS name = "module.exports = { " <> coerce name <> ": " <> coe
 
 outputStoreExpression :: (Monoid a) => Backend -> Renderer ann a -> StoreExpression ann -> a
 outputStoreExpression be renderer se =
-  let funcName = mkName "main"
+  let funcName = "main"
       deps = mconcat $ renderImport renderer be <$> M.toList (getBindings $ storeBindings se)
       stdLib = renderStdLib renderer be
       func = renderFunc renderer funcName (storeExpression se)

--- a/src/Language/Mimsa/Project/Helpers.hs
+++ b/src/Language/Mimsa/Project/Helpers.hs
@@ -16,6 +16,7 @@ module Language.Mimsa.Project.Helpers
     getItemsForAllVersions,
     getDependencyHashes,
     lookupBindingName,
+    lookupTypeBindingName,
     getBindingNames,
   )
 where
@@ -100,6 +101,11 @@ lookupBindingName :: Project ann -> Name -> Maybe ExprHash
 lookupBindingName project name =
   let b = getBindings . getCurrentBindings . prjBindings $ project
    in M.lookup name b
+
+lookupTypeBindingName :: Project ann -> TyCon -> Maybe ExprHash
+lookupTypeBindingName project tyCon =
+  let b = getTypeBindings . getCurrentTypeBindings . prjTypeBindings $ project
+   in M.lookup tyCon b
 
 findBindingNameForExprHash ::
   ExprHash ->

--- a/src/Language/Mimsa/Repl/Actions/ExpressionBind.hs
+++ b/src/Language/Mimsa/Repl/Actions/ExpressionBind.hs
@@ -6,23 +6,17 @@ module Language.Mimsa.Repl.Actions.ExpressionBind
   )
 where
 
-import Control.Monad.Except
-import Control.Monad.Reader
 import Data.Foldable
 import Data.Text (Text)
-import Language.Mimsa.Actions
-import Language.Mimsa.Actions.BindExpression
+import qualified Language.Mimsa.Actions.BindExpression as Actions
+import qualified Language.Mimsa.Actions.BindType as Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Project.UnitTest
 import Language.Mimsa.Repl.Helpers
 import Language.Mimsa.Repl.Types
-import Language.Mimsa.Store.Storage
 import Language.Mimsa.Types.AST
-import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
-import Language.Mimsa.Types.ResolvedExpression
-import Language.Mimsa.Types.Store
 
 doBind ::
   Project Annotation ->
@@ -32,7 +26,7 @@ doBind ::
   ReplM Annotation (Project Annotation)
 doBind project input name expr = do
   (newProject, (newExprHash, _, _)) <-
-    toReplM project (bindExpression expr name input)
+    toReplM project (Actions.bindExpression expr name input)
   traverse_
     (replPrint . prettyPrint)
     (getTestsForExprHash newProject newExprHash)
@@ -44,19 +38,6 @@ doBindType ::
   DataType ->
   ReplM Annotation (Project Annotation)
 doBindType project input dt = do
-  let expr = MyData mempty dt (MyRecord mempty mempty)
-  (ResolvedExpression _ storeExpr _ _ _) <-
-    liftRepl $ getTypecheckedStoreExpression input project expr
-  replPrint $
-    "Bound type " <> prettyPrint dt
-  bindTypeExpression project storeExpr
-
-bindTypeExpression ::
-  Project ann ->
-  StoreExpression ann ->
-  ReplM ann (Project ann)
-bindTypeExpression project storeExpr = do
-  mimsaConfig <- ask
-  hash <- lift $ withExceptT StoreErr $ saveExpr mimsaConfig storeExpr
-  let newProject = fromType storeExpr hash
-  pure (project <> newProject)
+  (newProject, _) <-
+    toReplM project (Actions.bindType input dt)
+  pure newProject

--- a/src/Language/Mimsa/Repl/Actions/Tree.hs
+++ b/src/Language/Mimsa/Repl/Actions/Tree.hs
@@ -21,5 +21,5 @@ doTree ::
   ReplM Annotation ()
 doTree env input expr = do
   (ResolvedExpression _ storeExpr _ _ _) <- liftRepl $ getTypecheckedStoreExpression input env expr
-  let graph = createDepGraph (mkName "expression") (prjStore env) storeExpr
+  let graph = createDepGraph "expression" (prjStore env) storeExpr
   replPrint graph

--- a/src/Language/Mimsa/Typechecker/Codegen.hs
+++ b/src/Language/Mimsa/Typechecker/Codegen.hs
@@ -1,6 +1,9 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Language.Mimsa.Typechecker.Codegen
   ( Typeclass (..),
     typeclassMatches,
+    doCodegen,
     module Language.Mimsa.Typechecker.Codegen.Newtype,
     module Language.Mimsa.Typechecker.Codegen.Enum,
     module Language.Mimsa.Typechecker.Codegen.Functor,
@@ -8,10 +11,14 @@ module Language.Mimsa.Typechecker.Codegen
 where
 
 import Data.Either (isRight)
+import Data.Functor
+import Data.Map (Map)
+import qualified Data.Map as M
 import Language.Mimsa.Typechecker.Codegen.Enum
 import Language.Mimsa.Typechecker.Codegen.Functor
 import Language.Mimsa.Typechecker.Codegen.Newtype
 import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Identifiers
 
 data Typeclass
   = Enum
@@ -20,10 +27,36 @@ data Typeclass
   deriving (Eq, Ord, Show)
 
 tcPred :: (DataType -> Bool) -> [a] -> DataType -> [a]
-tcPred predicate as dt = if predicate dt then as else mempty
+tcPred predicate as dt =
+  if predicate dt
+    then as
+    else mempty
 
 typeclassMatches :: DataType -> [Typeclass]
 typeclassMatches dt =
   tcPred (isRight . toString) [Enum] dt
-    <> tcPred (\a -> isRight (wrap a) && isRight (unwrap a)) [Newtype] dt
+    <> tcPred
+      ( \a ->
+          isRight (wrap a)
+            && isRight (unwrap a)
+      )
+      [Newtype]
+      dt
     <> tcPred (isRight . functorMap) [Functor] dt
+
+codegenToRow ::
+  (DataType -> Either e (Expr Name ())) ->
+  Name ->
+  DataType ->
+  Map Name (Expr Name Annotation)
+codegenToRow toDt name dt =
+  case toDt dt of
+    Right a -> M.singleton name (a $> mempty)
+    _ -> mempty
+
+doCodegen :: DataType -> Map Name (Expr Name Annotation)
+doCodegen dt =
+  codegenToRow toString "toString" dt
+    <> codegenToRow wrap "wrap" dt
+    <> codegenToRow unwrap "unwrap" dt
+    <> codegenToRow functorMap "fmap" dt

--- a/src/Language/Mimsa/Typechecker/Codegen.hs
+++ b/src/Language/Mimsa/Typechecker/Codegen.hs
@@ -1,9 +1,23 @@
 module Language.Mimsa.Typechecker.Codegen (Typeclass (..), typeclassMatches) where
 
+import qualified Data.Map as M
+import Data.Monoid
 import Language.Mimsa.Types.AST
 
-data Typeclass = Show
+data Typeclass = Enum
   deriving (Eq, Ord, Show)
 
+-- if we can constructors with no args, it's an enum which we can show
+isEnum :: DataType -> Bool
+isEnum (DataType _ _ items) = M.size items > 0 && noConsArgs
+  where
+    noConsArgs :: Bool
+    noConsArgs = getAll (foldMap (All . null) (M.elems items))
+
+{-
+isNewtype :: DataType -> Bool
+isNewtype (DataType _ _ items) = M.size items == 1 &&
+-}
+
 typeclassMatches :: DataType -> [Typeclass]
-typeclassMatches _ = mempty
+typeclassMatches dt = if isEnum dt then [Enum] else mempty

--- a/src/Language/Mimsa/Typechecker/Codegen.hs
+++ b/src/Language/Mimsa/Typechecker/Codegen.hs
@@ -14,6 +14,8 @@ import Data.Either (isRight)
 import Data.Functor
 import Data.Map (Map)
 import qualified Data.Map as M
+import Data.Text.Prettyprint.Doc
+import Language.Mimsa.Printer
 import Language.Mimsa.Typechecker.Codegen.Enum
 import Language.Mimsa.Typechecker.Codegen.Functor
 import Language.Mimsa.Typechecker.Codegen.Newtype
@@ -25,6 +27,9 @@ data Typeclass
   | Newtype
   | Functor
   deriving (Eq, Ord, Show)
+
+instance Printer Typeclass where
+  prettyDoc tc = pretty (show tc)
 
 tcPred :: (DataType -> Bool) -> [a] -> DataType -> [a]
 tcPred predicate as dt =

--- a/src/Language/Mimsa/Typechecker/Codegen.hs
+++ b/src/Language/Mimsa/Typechecker/Codegen.hs
@@ -1,0 +1,9 @@
+module Language.Mimsa.Typechecker.Codegen (Typeclass (..), typeclassMatches) where
+
+import Language.Mimsa.Types.AST
+
+data Typeclass = Show
+  deriving (Eq, Ord, Show)
+
+typeclassMatches :: DataType -> [Typeclass]
+typeclassMatches _ = mempty

--- a/src/Language/Mimsa/Typechecker/Codegen/Enum.hs
+++ b/src/Language/Mimsa/Typechecker/Codegen/Enum.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Typechecker.Codegen.Enum
+  ( toString,
+  )
+where
+
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map as M
+import Data.Text (Text)
+import Language.Mimsa.Printer
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Identifiers
+
+-- | An enum is a datatype with at least one constructor
+-- | each have no arguments
+-- | TODO: create fromString once we have decided how to include
+-- | datatypes in the stdLib
+toString :: DataType -> Either Text (Expr Name ())
+toString (DataType tyCon [] items) = do
+  let tyName = tyConToName tyCon
+  let createMatch (consName, vars) =
+        case vars of
+          [] -> Right (consName, str (showTyCon consName))
+          _ -> Left $ "Constructor " <> prettyPrint consName <> " is expected to have no arguments"
+  matches <- traverse createMatch (M.toList items)
+  case NE.nonEmpty matches of
+    Nothing -> Left "Type has no constructors"
+    Just neMatches ->
+      Right
+        ( MyLambda
+            mempty
+            tyName
+            ( MyCaseMatch
+                mempty
+                (MyVar mempty tyName)
+                neMatches
+                Nothing
+            )
+        )
+toString _ = Left "Datatype is expected to have no parameters"
+
+str :: (Monoid ann) => StringType -> Expr a ann
+str a = MyLiteral mempty (MyString a)
+
+showTyCon :: TyCon -> StringType
+showTyCon (TyCon t) = StringType t

--- a/src/Language/Mimsa/Typechecker/Codegen/Enum.hs
+++ b/src/Language/Mimsa/Typechecker/Codegen/Enum.hs
@@ -16,13 +16,19 @@ import Language.Mimsa.Types.Identifiers
 -- | each have no arguments
 -- | TODO: create fromString once we have decided how to include
 -- | datatypes in the stdLib
-toString :: DataType -> Either Text (Expr Name ())
+toString ::
+  DataType ->
+  Either Text (Expr Name ())
 toString (DataType tyCon [] items) = do
   let tyName = tyConToName tyCon
   let createMatch (consName, vars) =
         case vars of
           [] -> Right (consName, str (showTyCon consName))
-          _ -> Left $ "Constructor " <> prettyPrint consName <> " is expected to have no arguments"
+          _ ->
+            Left $
+              "Constructor "
+                <> prettyPrint consName
+                <> " is expected to have no arguments"
   matches <- traverse createMatch (M.toList items)
   case NE.nonEmpty matches of
     Nothing -> Left "Type has no constructors"

--- a/src/Language/Mimsa/Typechecker/Codegen/Functor.hs
+++ b/src/Language/Mimsa/Typechecker/Codegen/Functor.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Typechecker.Codegen.Functor
+  ( functorMap,
+  )
+where
+
+import Data.Foldable (foldl')
+import qualified Data.List.NonEmpty as NE
+import Data.Map (Map)
+import qualified Data.Map as M
+import Data.Text (Text)
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Identifiers
+import Prelude hiding (fmap)
+
+-- | A newtype is a datatype with one constructor
+-- | with one argument
+functorMap :: DataType -> Either Text (Expr Name ())
+functorMap (DataType tyCon vars items) = do
+  let tyName = tyConToName tyCon
+  fVar <- getFunctorVar vars
+  case getMapItems items of
+    Nothing -> Left "Type should have at least one constructor"
+    Just constructors -> do
+      matches <-
+        traverse
+          ( \(consName, fields) ->
+              (,) consName <$> createMatch fVar consName fields
+          )
+          constructors
+      pure
+        ( MyLambda
+            mempty
+            "f"
+            ( MyLambda
+                mempty
+                tyName
+                ( MyCaseMatch
+                    mempty
+                    (MyVar mempty tyName)
+                    matches
+                    Nothing
+                )
+            )
+        )
+
+getFunctorVar :: [Name] -> Either Text Name
+getFunctorVar names = case NE.nonEmpty names of
+  Just neNames -> Right $ NE.last neNames
+  _ -> Left "Type should have at least one type variable"
+
+createMatch :: Name -> TyCon -> [Field] -> Either Text (Expr Name ())
+createMatch matchVar tyCon fields = do
+  regFields <-
+    traverse
+      ( \case
+          VarName a -> Right a
+          _ -> Left "Expected VarName"
+      )
+      fields
+  let withConsApp =
+        foldl'
+          ( \expr' varName ->
+              let var =
+                    if varName == matchVar
+                      then MyApp mempty (MyVar mempty "f") (MyVar mempty varName)
+                      else MyVar mempty varName
+               in MyConsApp mempty expr' var
+          )
+          (MyConstructor mempty tyCon)
+          regFields
+      expression =
+        foldr
+          ( MyLambda mempty
+          )
+          withConsApp
+          regFields
+  pure expression
+
+getMapItems :: Map k a -> Maybe (NE.NonEmpty (k, a))
+getMapItems = NE.nonEmpty . M.toList

--- a/src/Language/Mimsa/Typechecker/Codegen/Functor.hs
+++ b/src/Language/Mimsa/Typechecker/Codegen/Functor.hs
@@ -17,7 +17,9 @@ import Prelude hiding (fmap)
 
 -- | A newtype is a datatype with one constructor
 -- | with one argument
-functorMap :: DataType -> Either Text (Expr Name ())
+functorMap ::
+  DataType ->
+  Either Text (Expr Name ())
 functorMap (DataType tyCon vars items) = do
   let tyName = tyConToName tyCon
   fVar <- getFunctorVar vars
@@ -51,7 +53,11 @@ getFunctorVar names = case NE.nonEmpty names of
   Just neNames -> Right $ NE.last neNames
   _ -> Left "Type should have at least one type variable"
 
-createMatch :: Name -> TyCon -> [Field] -> Either Text (Expr Name ())
+createMatch ::
+  Name ->
+  TyCon ->
+  [Field] ->
+  Either Text (Expr Name ())
 createMatch matchVar tyCon fields = do
   regFields <-
     traverse

--- a/src/Language/Mimsa/Typechecker/Codegen/Newtype.hs
+++ b/src/Language/Mimsa/Typechecker/Codegen/Newtype.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Typechecker.Codegen.Newtype
+  ( wrap,
+    unwrap,
+  )
+where
+
+--import qualified Data.List.NonEmpty as NE
+import Data.Map (Map)
+import qualified Data.Map as M
+import Data.Text (Text)
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Identifiers
+
+-- | A newtype is a datatype with one constructor
+-- | with one argument
+wrap :: DataType -> Either Text (Expr Name ())
+wrap (DataType _tyCon _vars items) =
+  case getOnlyMapItem items of
+    Nothing -> Left "Type should have one constructor"
+    Just (consName, [VarName _a]) ->
+      Right
+        ( MyLambda
+            mempty
+            "a"
+            ( MyConsApp
+                mempty
+                (MyConstructor mempty consName)
+                (MyVar mempty "a")
+            )
+        )
+    Just (_, _) -> Left "Constructor should only have one argument"
+
+-- | A newtype is a datatype with one constructor
+-- | with one argument
+unwrap :: DataType -> Either Text (Expr Name ())
+unwrap (DataType tyCon _vars items) = do
+  let tyName = tyConToName tyCon
+  case getOnlyMapItem items of
+    Nothing -> Left "Type should have one constructor"
+    Just (consName, [VarName _a]) ->
+      Right
+        ( MyLambda
+            mempty
+            tyName
+            ( MyCaseMatch
+                mempty
+                (MyVar mempty tyName)
+                ( pure (consName, MyLambda mempty "a" (MyVar mempty "a"))
+                )
+                Nothing
+            )
+        )
+    Just (_, _) -> Left "Constructor should only have one argument"
+
+getOnlyMapItem :: Map k a -> Maybe (k, a)
+getOnlyMapItem items = case M.toList items of
+  [(k, a)] -> pure (k, a)
+  _ -> Nothing

--- a/src/Language/Mimsa/Typechecker/Codegen/Newtype.hs
+++ b/src/Language/Mimsa/Typechecker/Codegen/Newtype.hs
@@ -19,7 +19,7 @@ wrap :: DataType -> Either Text (Expr Name ())
 wrap (DataType _tyCon _vars items) =
   case getOnlyMapItem items of
     Nothing -> Left "Type should have one constructor"
-    Just (consName, [VarName _a]) ->
+    Just (consName, [_a]) ->
       Right
         ( MyLambda
             mempty
@@ -39,7 +39,7 @@ unwrap (DataType tyCon _vars items) = do
   let tyName = tyConToName tyCon
   case getOnlyMapItem items of
     Nothing -> Left "Type should have one constructor"
-    Just (consName, [VarName _a]) ->
+    Just (consName, [_a]) ->
       Right
         ( MyLambda
             mempty

--- a/src/Language/Mimsa/Typechecker/DataTypes.hs
+++ b/src/Language/Mimsa/Typechecker/DataTypes.hs
@@ -9,7 +9,7 @@ where
 import Data.Map (Map)
 import qualified Data.Map as M
 import Language.Mimsa.Types.AST (DataType (DataType))
-import Language.Mimsa.Types.Identifiers (TyCon, mkTyCon)
+import Language.Mimsa.Types.Identifiers (TyCon)
 import Language.Mimsa.Types.Typechecker
 
 defaultEnv :: Substitutions -> Environment
@@ -22,8 +22,8 @@ defaultEnv (Substitutions subst) = Environment schemes dts mempty
 builtInTypes :: Map TyCon MonoType
 builtInTypes =
   M.fromList
-    [ (mkTyCon "String", MTPrim mempty MTString),
-      (mkTyCon "Int", MTPrim mempty MTInt),
-      (mkTyCon "Boolean", MTPrim mempty MTBool),
-      (mkTyCon "Unit", MTPrim mempty MTUnit)
+    [ ("String", MTPrim mempty MTString),
+      ("Int", MTPrim mempty MTInt),
+      ("Boolean", MTPrim mempty MTBool),
+      ("Unit", MTPrim mempty MTUnit)
     ]

--- a/src/Language/Mimsa/Types/AST/StringType.hs
+++ b/src/Language/Mimsa/Types/AST/StringType.hs
@@ -8,8 +8,10 @@ module Language.Mimsa.Types.AST.StringType
 where
 
 import qualified Data.Aeson as JSON
+import Data.String
 import Data.Swagger
 import Data.Text (Text)
+import qualified Data.Text as T
 import Data.Text.Prettyprint.Doc
 import GHC.Generics
 import Language.Mimsa.Printer
@@ -21,6 +23,9 @@ import Language.Mimsa.Printer
 newtype StringType = StringType Text
   deriving newtype (Eq, Ord, Show, JSON.FromJSON, JSON.ToJSON)
   deriving (Generic, ToSchema)
+
+instance IsString StringType where
+  fromString = StringType . T.pack
 
 instance Printer StringType where
   prettyDoc = renderStringType

--- a/src/Language/Mimsa/Types/Error/TypeError.hs
+++ b/src/Language/Mimsa/Types/Error/TypeError.hs
@@ -108,7 +108,7 @@ withSwap :: Swaps -> Variable -> Name
 withSwap _ (NamedVar n) = n
 withSwap swaps (NumberedVar i) =
   fromMaybe
-    (mkName "unknownvar")
+    "unknownvar"
     (M.lookup (NumberedVar i) swaps)
 
 -----

--- a/src/Language/Mimsa/Types/Identifiers/Name.hs
+++ b/src/Language/Mimsa/Types/Identifiers/Name.hs
@@ -8,6 +8,7 @@ module Language.Mimsa.Types.Identifiers.Name where
 
 import qualified Data.Aeson as JSON
 import qualified Data.Char as Ch
+import Data.String
 import Data.Swagger
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -30,6 +31,9 @@ newtype Name = Name {getName' :: Text}
       JSON.ToJSONKey,
       FromHttpApiData
     )
+
+instance IsString Name where
+  fromString = mkName . T.pack
 
 getName :: Name -> Text
 getName (Name t) = t

--- a/src/Language/Mimsa/Types/Identifiers/TyCon.hs
+++ b/src/Language/Mimsa/Types/Identifiers/TyCon.hs
@@ -14,6 +14,7 @@ import qualified Data.Text as T
 import Data.Text.Prettyprint.Doc
 import GHC.Generics
 import Language.Mimsa.Printer
+import Language.Mimsa.Types.Identifiers.Name
 
 newtype TyCon = TyCon Text
   deriving (ToSchema)
@@ -53,3 +54,8 @@ safeMkTyCon a =
 
 instance Printer TyCon where
   prettyDoc = pretty . getTyCon
+
+tyConToName :: TyCon -> Name
+tyConToName (TyCon tc) = Name (tHead <> T.tail tc)
+  where
+    tHead = T.pack . pure . Ch.toLower . T.head $ tc

--- a/src/Language/Mimsa/Types/Identifiers/TyCon.hs
+++ b/src/Language/Mimsa/Types/Identifiers/TyCon.hs
@@ -56,6 +56,6 @@ instance Printer TyCon where
   prettyDoc = pretty . getTyCon
 
 tyConToName :: TyCon -> Name
-tyConToName (TyCon tc) = Name (tHead <> T.tail tc)
+tyConToName (TyCon tc) = mkName (tHead <> T.tail tc)
   where
     tHead = T.pack . pure . Ch.toLower . T.head $ tc

--- a/src/Language/Mimsa/Types/Identifiers/TyCon.hs
+++ b/src/Language/Mimsa/Types/Identifiers/TyCon.hs
@@ -7,6 +7,7 @@ module Language.Mimsa.Types.Identifiers.TyCon where
 
 import qualified Data.Aeson as JSON
 import qualified Data.Char as Ch
+import Data.String
 import Data.Swagger
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -24,6 +25,9 @@ newtype TyCon = TyCon Text
       JSON.ToJSON,
       JSON.ToJSONKey
     )
+
+instance IsString TyCon where
+  fromString = mkTyCon . T.pack
 
 getTyCon :: TyCon -> Text
 getTyCon (TyCon t) = t

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -9,25 +9,25 @@ where
 import qualified Test.Actions as Actions
 import qualified Test.BackendJS as JS
 import Test.Hspec
-import qualified Test.InstantiateVar as InstantiateVar
-import qualified Test.Interpreter as Interpreter
-import qualified Test.MonoTypeParser as MonoTypeParser
-import qualified Test.NormaliseType as NormaliseType
+import qualified Test.Interpreter.InstantiateVar as InstantiateVar
+import qualified Test.Interpreter.Interpreter as Interpreter
+import qualified Test.Interpreter.Repl as Repl
+import qualified Test.Parser.MonoTypeParser as MonoTypeParser
+import qualified Test.Parser.Syntax as Syntax
 import qualified Test.Prettier as Prettier
-import Test.QuickCheck.Instances ()
-import qualified Test.RecordUsage as RecordUsage
-import qualified Test.Repl as Repl
-import qualified Test.Resolver as Resolver
+import qualified Test.Project.NormaliseType as NormaliseType
+import qualified Test.Project.TypeSearch as TypeSearch
+import qualified Test.Project.UnitTest as UnitTest
+import qualified Test.Project.Usages as Usages
 import qualified Test.Serialisation as Serialisation
-import qualified Test.Substitutor as Substitutor
-import qualified Test.Syntax as Syntax
-import qualified Test.TypeError as TypeError
-import qualified Test.TypeSearch as TypeSearch
-import qualified Test.Typechecker as Typechecker
-import qualified Test.Unify as Unify
-import qualified Test.UnitTest as UnitTest
-import qualified Test.UpdateDeps as UpdateDeps
-import qualified Test.Usages as Usages
+import qualified Test.Store.Resolver as Resolver
+import qualified Test.Store.Substitutor as Substitutor
+import qualified Test.Store.UpdateDeps as UpdateDeps
+import qualified Test.Typechecker.Codegen as Codegen
+import qualified Test.Typechecker.RecordUsage as RecordUsage
+import qualified Test.Typechecker.TypeError as TypeError
+import qualified Test.Typechecker.Typechecker as Typechecker
+import qualified Test.Typechecker.Unify as Unify
 
 main :: IO ()
 main =
@@ -52,3 +52,4 @@ main =
     UnitTest.spec
     UpdateDeps.spec
     Actions.spec
+    Codegen.spec

--- a/test/Test/Actions.hs
+++ b/test/Test/Actions.hs
@@ -44,7 +44,7 @@ testWithIdInExpr =
   MyInfix
     mempty
     Equals
-    (MyApp mempty (MyVar mempty (mkName "id")) (int 1))
+    (MyApp mempty (MyVar mempty "id") (int 1))
     (int 1)
 
 onePlusOneExpr :: Expr Name Annotation
@@ -84,13 +84,13 @@ spec = do
           stdLib
           ( Actions.bindExpression
               brokenExpr
-              (mkName "broken")
+              "broken"
               "1 == True"
           )
           `shouldSatisfy` isLeft
       it "Adds a fresh new function to Bindings and to Store" $ do
         let expr = int 1
-        case Actions.run stdLib (Actions.bindExpression expr (mkName "one") "1") of
+        case Actions.run stdLib (Actions.bindExpression expr "one" "1") of
           Left _ -> error "Should not have failed"
           Right (newProject, outcomes, _) -> do
             -- one more item in store
@@ -99,15 +99,15 @@ spec = do
             -- one more binding
             lookupBindingName
               newProject
-              (mkName "one")
+              "one"
               `shouldSatisfy` isJust
             -- one new store expression
             S.size (Actions.storeExpressionsFromOutcomes outcomes)
               `shouldBe` 1
       it "Updating an existing binding updates binding" $ do
-        let newIdExpr = MyLambda mempty (mkName "b") (MyVar mempty (mkName "b"))
+        let newIdExpr = MyLambda mempty "b" (MyVar mempty "b")
         let action =
-              Actions.bindExpression newIdExpr (mkName "id") "\\b -> b"
+              Actions.bindExpression newIdExpr "id" "\\b -> b"
         case Actions.run stdLib action of
           Left _ -> error "Should not have failed"
           Right (newProject, outcomes, _) -> do
@@ -120,13 +120,13 @@ spec = do
             -- binding hash has changed
             lookupBindingName
               newProject
-              (mkName "id")
-              `shouldNotBe` lookupBindingName stdLib (mkName "id")
+              "id"
+              `shouldNotBe` lookupBindingName stdLib "id"
       it "Updating an existing binding updates tests" $ do
-        let newIdExpr = MyLambda mempty (mkName "blob") (MyVar mempty (mkName "blob"))
+        let newIdExpr = MyLambda mempty "blob" (MyVar mempty "blob")
         let action = do
               _ <- Actions.addUnitTest testWithIdInExpr (TestName "Check id is OK") "id(1) == 1"
-              Actions.bindExpression newIdExpr (mkName "id") "\\blob -> blob"
+              Actions.bindExpression newIdExpr "id" "\\blob -> blob"
         case Actions.run stdLib action of
           Left _ -> error "Should not have failed"
           Right (newProject, outcomes, _) -> do
@@ -142,11 +142,11 @@ spec = do
             -- binding hash has changed
             lookupBindingName
               newProject
-              (mkName "id")
-              `shouldNotBe` lookupBindingName stdLib (mkName "id")
+              "id"
+              `shouldNotBe` lookupBindingName stdLib "id"
     describe "Compile" $ do
       it "Simplest compilation creates four files" $ do
-        let expr = MyVar mempty (mkName "id")
+        let expr = MyVar mempty "id"
         let action = Actions.compile CommonJS "id" expr
         let (newProject, outcomes, (_, hashes)) = fromRight (Actions.run stdLib action)
         -- creates three files
@@ -164,7 +164,7 @@ spec = do
         -- for the `id` dependency
         S.size hashes `shouldBe` 2
       it "Complex compilation creates many files in 3 folders" $ do
-        let expr = MyVar mempty (mkName "evalState")
+        let expr = MyVar mempty "evalState"
         let action = Actions.compile CommonJS "evalState" expr
         let (newProject, outcomes, _) = fromRight (Actions.run stdLib action)
         -- creates six files

--- a/test/Test/BackendJS.hs
+++ b/test/Test/BackendJS.hs
@@ -20,7 +20,7 @@ import Language.Mimsa.Project.Persistence
 import Language.Mimsa.Repl
 import Language.Mimsa.Store.ResolvedDeps
 import Language.Mimsa.Types.AST
-import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Identifiers ()
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.ResolvedExpression
 import Language.Mimsa.Types.Store
@@ -97,18 +97,18 @@ spec = do
         result `shouldSatisfy` isRight
   describe "Normalise constructors" $ do
     it "is a no-op for nullary constructors" $ do
-      let a = MyConstructor () (mkTyCon "Nowt")
+      let a = MyConstructor () "Nowt"
       normaliseConstructors dataTypes a `shouldBe` a
     it "turns unary constructor into lambda function" $ do
-      let a = MyConstructor () (mkTyCon "Some")
+      let a = MyConstructor () "Some"
       let expected =
             MyLambda
               mempty
               "a"
-              (MyConsApp mempty (MyConstructor mempty (mkTyCon "Some")) (MyVar mempty "a"))
+              (MyConsApp mempty (MyConstructor mempty "Some") (MyVar mempty "a"))
       normaliseConstructors dataTypes a `shouldBe` expected
     it "turns binary constructor into two lambda functions" $ do
-      let a = MyConstructor () (mkTyCon "These")
+      let a = MyConstructor () "These"
       let expected =
             MyLambda
               mempty
@@ -120,7 +120,7 @@ spec = do
                       mempty
                       ( MyConsApp
                           mempty
-                          (MyConstructor mempty (mkTyCon "These"))
+                          (MyConstructor mempty "These")
                           (MyVar mempty "a")
                       )
                       (MyVar mempty "b")
@@ -128,7 +128,7 @@ spec = do
               )
       normaliseConstructors dataTypes a `shouldBe` expected
     it "partially applies when wrapped in ConsApp" $ do
-      let a = MyConsApp () (MyConstructor mempty (mkTyCon "These")) (int 1)
+      let a = MyConsApp () (MyConstructor mempty "These") (int 1)
       let expected =
             MyLambda
               mempty
@@ -137,7 +137,7 @@ spec = do
                   mempty
                   ( MyConsApp
                       mempty
-                      (MyConstructor mempty (mkTyCon "These"))
+                      (MyConstructor mempty "These")
                       (int 1)
                   )
                   (MyVar mempty "b")
@@ -149,7 +149,7 @@ spec = do
               ()
               ( MyConsApp
                   mempty
-                  (MyConstructor mempty (mkTyCon "These"))
+                  (MyConstructor mempty "These")
                   (int 1)
               )
               (int 2)

--- a/test/Test/BackendJS.hs
+++ b/test/Test/BackendJS.hs
@@ -34,7 +34,7 @@ eval env input =
     Left e -> Left $ prettyPrint e
     Right (ResolvedExpression _ storeExpr _ _ _) ->
       pure $
-        renderWithFunction dataTypes (mkName "main") (storeExpression storeExpr)
+        renderWithFunction dataTypes "main" (storeExpression storeExpr)
 
 evalModule :: Project Annotation -> Text -> IO (Either Text Javascript)
 evalModule env input =
@@ -104,26 +104,26 @@ spec = do
       let expected =
             MyLambda
               mempty
-              (mkName "a")
-              (MyConsApp mempty (MyConstructor mempty (mkTyCon "Some")) (MyVar mempty (mkName "a")))
+              "a"
+              (MyConsApp mempty (MyConstructor mempty (mkTyCon "Some")) (MyVar mempty "a"))
       normaliseConstructors dataTypes a `shouldBe` expected
     it "turns binary constructor into two lambda functions" $ do
       let a = MyConstructor () (mkTyCon "These")
       let expected =
             MyLambda
               mempty
-              (mkName "a")
+              "a"
               ( MyLambda
                   mempty
-                  (mkName "b")
+                  "b"
                   ( MyConsApp
                       mempty
                       ( MyConsApp
                           mempty
                           (MyConstructor mempty (mkTyCon "These"))
-                          (MyVar mempty (mkName "a"))
+                          (MyVar mempty "a")
                       )
-                      (MyVar mempty (mkName "b"))
+                      (MyVar mempty "b")
                   )
               )
       normaliseConstructors dataTypes a `shouldBe` expected
@@ -132,7 +132,7 @@ spec = do
       let expected =
             MyLambda
               mempty
-              (mkName "b")
+              "b"
               ( MyConsApp
                   mempty
                   ( MyConsApp
@@ -140,7 +140,7 @@ spec = do
                       (MyConstructor mempty (mkTyCon "These"))
                       (int 1)
                   )
-                  (MyVar mempty (mkName "b"))
+                  (MyVar mempty "b")
               )
       normaliseConstructors dataTypes a `shouldBe` expected
     it "completely applies when wrapped in ConsApp" $ do

--- a/test/Test/Data/Project.hs
+++ b/test/Test/Data/Project.hs
@@ -41,49 +41,49 @@ stdLibE =
   pure mempty
     >>= addBinding
       "\\a -> a"
-      (mkName "id")
+      "id"
     >>= addBinding
       "\\f -> \\g -> \\a -> f(g(a))"
-      (mkName "compose")
+      "compose"
     >>= addBinding
       "\\tuple -> let (tupleFirst,tupleSecond) = tuple in tupleFirst"
-      (mkName "fst")
+      "fst"
     >>= addBinding
       "\\tuple -> let (tupleFirst,tupleSecond) = tuple in tupleSecond"
-      (mkName "snd")
+      "snd"
     >>= addBinding
       "\\a -> \\b -> a == b"
-      (mkName "eq")
+      "eq"
     >>= addBinding
       "\\i -> eq(10)(i)"
-      (mkName "eqTen")
+      "eqTen"
     >>= addBinding
       "\\a -> \\b -> a + b"
-      (mkName "addInt")
+      "addInt"
     >>= addBinding
       "\\a -> \\b -> a - b"
-      (mkName "subtractInt")
+      "subtractInt"
     >>= addBinding
       "\\f -> \\g -> \\aValue -> f(g(aValue))"
-      (mkName "compose")
+      "compose"
     >>= addBinding
       "\\a -> addInt(1)(a)"
-      (mkName "incrementInt")
+      "incrementInt"
     >>= addBinding
       "type Option a = Some a | Nowt in {}"
-      (mkName "typeState")
+      "typeState"
     >>= addBinding
       "\\f -> \\opt -> case opt of Some \\a -> Some f(a) | otherwise Nowt"
-      (mkName "fmapOption")
+      "fmapOption"
     >>= addBinding
       "type These a b = This a | That b | These a b in {}"
-      (mkName "typeThese")
+      "typeThese"
     >>= addBinding
       "(1,2)"
-      (mkName "aPair")
+      "aPair"
     >>= addBinding
       "{ a: 1, b: \"dog\" }"
-      (mkName "aRecord")
+      "aRecord"
     >>= addListMonad
     >>= addPair
     >>= addStateMonad
@@ -93,67 +93,67 @@ addListMonad prj =
   pure prj
     >>= addBinding
       "type List a = Cons a (List a) | Nil in {}"
-      (mkName "typeList")
+      "typeList"
     >>= addBinding
       "\\a -> \\list -> Cons a list"
-      (mkName "cons")
-    >>= addBinding "Nil" (mkName "nil")
+      "cons"
+    >>= addBinding "Nil" "nil"
 
 addPair :: Project Annotation -> ProjectPart
 addPair prj =
   pure prj
     >>= addBinding
       "type Pair a b = Pair a b in {}"
-      (mkName "typePair")
+      "typePair"
     >>= addBinding
       "\\pair -> case pair of Pair (\\a -> \\b -> a)"
-      (mkName "fstPair")
+      "fstPair"
     >>= addBinding
       "\\pair -> case pair of Pair (\\a -> \\b -> b)"
-      (mkName "sndPair")
+      "sndPair"
 
 addStateMonad :: Project Annotation -> ProjectPart
 addStateMonad prj =
   pure prj
     >>= addBinding
       "type State s a = State (s -> (Pair a s)) in {}"
-      (mkName "typeState")
+      "typeState"
     >>= addBinding
       "\\a -> State (\\s -> Pair a s)"
-      (mkName "pureState")
+      "pureState"
     >>= addBinding
       "\\f -> \\state -> case state of State (\\sas -> State (\\s -> let as = sas(s); case as of Pair (\\a -> \\s -> Pair f(a) s)))"
-      (mkName "fmapState")
+      "fmapState"
     >>= addBinding
       "\\stateF -> \\stateA -> State (\\s -> case stateF of State (\\sfs -> let fs = sfs(s); case fs of  Pair (\\f -> \\ss -> case stateA of State (\\sas -> let as = sas(ss); case as of Pair (\\a -> \\sss -> Pair f(a) sss)))))"
-      (mkName "apState")
+      "apState"
     >>= addBinding
       "\\f -> \\state -> State (\\s -> case state of State (\\sas -> let as = sas(s); case as of Pair (\\a -> \\ss -> case f(a) of State (\\sbs -> sbs(ss)))))"
-      (mkName "bindState")
+      "bindState"
     >>= addBinding
       "\\state -> \\s -> case state of State (\\sas -> sas(s))"
-      (mkName "runState")
+      "runState"
     >>= addBinding
       "\\state -> compose(sndPair)(runState(state))"
-      (mkName "execState")
+      "execState"
     >>= addBinding
       "\\state -> compose(fstPair)(runState(state))"
-      (mkName "evalState")
+      "evalState"
     >>= addBinding
       "\\s -> State (\\ignore -> Pair Unit s)"
-      (mkName "putState")
+      "putState"
     >>= addBinding
       "State (\\s -> Pair s s)"
-      (mkName "getState")
+      "getState"
     >>= addBinding
       "\\f -> State (\\s -> Pair Unit f(s))"
-      (mkName "modifyState")
+      "modifyState"
     >>= addBinding
       "\\f -> \\stateA -> \\stateB -> apState(fmapState(f)(stateA))(stateB)"
-      (mkName "liftA2State")
+      "liftA2State"
     >>= addBinding
       "\\newName -> let sas = \\s -> let return = newName <> \"!!!\"; let list = cons(newName)(s); Pair return list; State sas"
-      (mkName "storeName")
+      "storeName"
 
 unsafeGetExpr :: Text -> StoreExpression Annotation
 unsafeGetExpr input =

--- a/test/Test/Interpreter/InstantiateVar.hs
+++ b/test/Test/Interpreter/InstantiateVar.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Test.InstantiateVar
+module Test.Interpreter.InstantiateVar
   ( spec,
   )
 where

--- a/test/Test/Interpreter/Interpreter.hs
+++ b/test/Test/Interpreter/Interpreter.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Test.Interpreter
+module Test.Interpreter.Interpreter
   ( spec,
   )
 where
@@ -72,11 +72,11 @@ spec =
           mempty
           (str (StringType "poo"))
           (str (StringType "poo"))
-    describe "Let and Var" $
-      it "let x = 1 in 1" $
-        do
-          let f = MyLet mempty (named "x") (int 1) (MyVar mempty (named "x"))
-          testInterpret mempty f (int 1)
+    describe "Let and Var"
+      $ it "let x = 1 in 1"
+      $ do
+        let f = MyLet mempty (named "x") (int 1) (MyVar mempty (named "x"))
+        testInterpret mempty f (int 1)
     describe "Lambda and App" $ do
       it "let id = \\x -> x in (id 1)" $ do
         let f =
@@ -145,13 +145,13 @@ spec =
                     ( MyRecord
                         mempty
                         ( M.fromList
-                            [ ( mkName "first",
+                            [ ( "first",
                                 MyApp
                                   mempty
                                   (MyVar mempty (named "const2"))
                                   (MyLiteral mempty (MyInt 1))
                               ),
-                              ( mkName "second",
+                              ( "second",
                                 MyApp
                                   mempty
                                   (MyVar mempty (named "const2"))
@@ -162,7 +162,7 @@ spec =
                     )
                     ( MyApp
                         mempty
-                        (MyRecordAccess mempty (MyVar mempty (named "reuse")) (mkName "first"))
+                        (MyRecordAccess mempty (MyVar mempty (named "reuse")) "first")
                         (MyLiteral mempty (MyInt 100))
                     )
                 )

--- a/test/Test/Interpreter/Repl.hs
+++ b/test/Test/Interpreter/Repl.hs
@@ -150,31 +150,31 @@ spec =
           result <- eval stdLib "type LeBool = Vrai | Faux in Vrai"
           result
             `shouldBe` Right
-              ( MTData mempty (mkTyCon "LeBool") [],
-                MyConstructor mempty (mkTyCon "Vrai")
+              ( MTData mempty "LeBool" [],
+                MyConstructor mempty "Vrai"
               )
         it "type Nat = Zero | Suc Nat in Suc Zero" $ do
           result <- eval stdLib "type Nat = Zero | Suc Nat in Suc Zero"
           result
             `shouldBe` Right
-              ( MTData mempty (mkTyCon "Nat") [],
+              ( MTData mempty "Nat" [],
                 MyConsApp
                   mempty
-                  (MyConstructor mempty (mkTyCon "Suc"))
-                  (MyConstructor mempty (mkTyCon "Zero"))
+                  (MyConstructor mempty "Suc")
+                  (MyConstructor mempty "Zero")
               )
         it "type Nat = Zero | Suc Nat in Suc Suc Zero" $ do
           result <- eval stdLib "type Nat = Zero | Suc Nat in Suc Suc Zero"
           result
             `shouldBe` Right
-              ( MTData mempty (mkTyCon "Nat") [],
+              ( MTData mempty "Nat" [],
                 MyConsApp
                   mempty
-                  (MyConstructor mempty (mkTyCon "Suc"))
+                  (MyConstructor mempty "Suc")
                   ( MyConsApp
                       mempty
-                      (MyConstructor mempty (mkTyCon "Suc"))
-                      (MyConstructor mempty (mkTyCon "Zero"))
+                      (MyConstructor mempty "Suc")
+                      (MyConstructor mempty "Zero")
                   )
               )
         it "type Nat = Zero | Suc Nat in Suc 1" $ do
@@ -191,9 +191,9 @@ spec =
             `shouldBe` Right
               ( MTFunction
                   mempty
-                  (MTData mempty (mkTyCon "Nat") [])
-                  (MTData mempty (mkTyCon "Nat") []),
-                MyConstructor mempty (mkTyCon "Suc")
+                  (MTData mempty "Nat" [])
+                  (MTData mempty "Nat" []),
+                MyConstructor mempty "Suc"
               )
         it "type OhNat = Zero | Suc OhNat String in Suc" $ do
           result <- eval stdLib "type OhNat = Zero | Suc OhNat String in Suc"
@@ -201,22 +201,22 @@ spec =
             `shouldBe` Right
               ( MTFunction
                   mempty
-                  (MTData mempty (mkTyCon "OhNat") [])
+                  (MTData mempty "OhNat" [])
                   ( MTFunction
                       mempty
                       (MTPrim mempty MTString)
-                      (MTData mempty (mkTyCon "OhNat") [])
+                      (MTData mempty "OhNat" [])
                   ),
-                MyConstructor mempty (mkTyCon "Suc")
+                MyConstructor mempty "Suc"
               )
         it "type Pet = Cat String | Dog String in Cat \"mimsa\"" $ do
           result <- eval stdLib "type Pet = Cat String | Dog String in Cat \"mimsa\""
           result
             `shouldBe` Right
-              ( MTData mempty (mkTyCon "Pet") [],
+              ( MTData mempty "Pet" [],
                 MyConsApp
                   mempty
-                  (MyConstructor mempty (mkTyCon "Cat"))
+                  (MyConstructor mempty "Cat")
                   (str' "mimsa")
               )
         it "type Void in 1" $ do
@@ -235,26 +235,26 @@ spec =
                   ( MTFunction
                       mempty
                       (MTPrim mempty MTString)
-                      (MTData mempty (mkTyCon "LongBoy") [])
+                      (MTData mempty "LongBoy" [])
                   ),
                 MyConsApp
                   mempty
-                  (MyConstructor mempty (mkTyCon "Stuff"))
+                  (MyConstructor mempty "Stuff")
                   (str' "yes")
               )
         it "type Tree = Leaf Int | Branch Tree Tree in Branch (Leaf 1) (Leaf 2)" $ do
           result <- eval stdLib "type Tree = Leaf Int | Branch Tree Tree in Branch (Leaf 1) (Leaf 2)"
           result
             `shouldBe` Right
-              ( MTData mempty (mkTyCon "Tree") [],
+              ( MTData mempty "Tree" [],
                 MyConsApp
                   mempty
                   ( MyConsApp
                       mempty
-                      (MyConstructor mempty $ mkTyCon "Branch")
-                      (MyConsApp mempty (MyConstructor mempty $ mkTyCon "Leaf") (int 1))
+                      (MyConstructor mempty "Branch")
+                      (MyConsApp mempty (MyConstructor mempty "Leaf") (int 1))
                   )
-                  (MyConsApp mempty (MyConstructor mempty $ mkTyCon "Leaf") (int 2))
+                  (MyConsApp mempty (MyConstructor mempty "Leaf") (int 2))
               )
         it "type Maybe a = Just a | Nothing in Just" $ do
           result <- eval stdLib "type Maybe a = Just a | Nothing in Just"
@@ -263,24 +263,24 @@ spec =
               ( MTFunction
                   mempty
                   (MTVar mempty (tvNumbered 1))
-                  (MTData mempty (mkTyCon "Maybe") [MTVar mempty (tvNumbered 1)]),
-                MyConstructor mempty $ mkTyCon "Just"
+                  (MTData mempty "Maybe" [MTVar mempty (tvNumbered 1)]),
+                MyConstructor mempty "Just"
               )
         it "type Maybe a = Just a | Nothing in Nothing" $ do
           result <- eval stdLib "type Maybe a = Just a | Nothing in Nothing"
           result
             `shouldBe` Right
-              ( MTData mempty (mkTyCon "Maybe") [MTVar mempty (tvNumbered 1)],
-                MyConstructor mempty $ mkTyCon "Nothing"
+              ( MTData mempty "Maybe" [MTVar mempty (tvNumbered 1)],
+                MyConstructor mempty "Nothing"
               )
         it "type Maybe a = Just a | Nothing in Just 1" $ do
           result <- eval stdLib "type Maybe a = Just a | Nothing in Just 1"
           result
             `shouldBe` Right
-              ( MTData mempty (mkTyCon "Maybe") [MTPrim mempty MTInt],
+              ( MTData mempty "Maybe" [MTPrim mempty MTInt],
                 MyConsApp
                   mempty
-                  (MyConstructor mempty $ mkTyCon "Just")
+                  (MyConstructor mempty "Just")
                   (int 1)
               )
         it "type Maybe a = Just a | Nothing in case Just 1 of Just \\a -> eq(100)(a) | Nothing False" $ do
@@ -322,10 +322,10 @@ spec =
           result <- eval stdLib "type Tree a = Leaf a | Branch (Tree a) (Tree a) in Leaf 1"
           result
             `shouldBe` Right
-              ( MTData mempty (mkTyCon "Tree") [MTPrim mempty MTInt],
+              ( MTData mempty "Tree" [MTPrim mempty MTInt],
                 MyConsApp
                   mempty
-                  (MyConstructor mempty $ mkTyCon "Leaf")
+                  (MyConstructor mempty "Leaf")
                   (int 1)
               )
         it "type Tree a = Leaf a | Branch (Tree a) (Tree b) in Leaf 1" $ do
@@ -340,19 +340,19 @@ spec =
           result <- eval stdLib "type Tree a = Empty | Branch (Tree a) a (Tree a) in Branch (Empty) 1 (Empty)"
           result
             `shouldBe` Right
-              ( MTData mempty (mkTyCon "Tree") [MTPrim mempty MTInt],
+              ( MTData mempty "Tree" [MTPrim mempty MTInt],
                 MyConsApp
                   mempty
                   ( MyConsApp
                       mempty
                       ( MyConsApp
                           mempty
-                          (MyConstructor mempty $ mkTyCon "Branch")
-                          (MyConstructor mempty $ mkTyCon "Empty")
+                          (MyConstructor mempty "Branch")
+                          (MyConstructor mempty "Empty")
                       )
                       (int 1)
                   )
-                  (MyConstructor mempty $ mkTyCon "Empty")
+                  (MyConstructor mempty "Empty")
               )
         it "type Maybe a = Just a | Nothing in case Just True of Just \\a -> a | Nothing \"what\"" $ do
           result <- eval stdLib "type Maybe a = Just a | Nothing in case Just True of Just \\a -> a | Nothing \"what\""
@@ -365,7 +365,7 @@ spec =
                 result <- eval stdLib "type Maybe a = Just a | Nothing in \\maybe -> case maybe of Just \\a -> a | Nothing \"poo\""
                 fst <$> result
                   `shouldBe` Right
-                    ( MTFunction (MTData (mkTyCon "Maybe") []) (MTPrim MTString)
+                    ( MTFunction (MTData ( "Maybe") []) (MTPrim MTString)
                     )
         
         -}
@@ -373,18 +373,18 @@ spec =
           result <- eval stdLib "type Arr a = Empty | Item a (Arr a) in case (Item 1 (Item 2 Empty)) of Empty Empty | Item \\a -> \\rest -> rest"
           result
             `shouldBe` Right
-              ( MTData mempty (mkTyCon "Arr") [MTPrim mempty MTInt],
+              ( MTData mempty "Arr" [MTPrim mempty MTInt],
                 MyConsApp
                   mempty
                   ( MyConsApp
                       mempty
                       ( MyConstructor
                           mempty
-                          (mkTyCon "Item")
+                          "Item"
                       )
                       (int 2)
                   )
-                  (MyConstructor mempty $ mkTyCon "Empty")
+                  (MyConstructor mempty "Empty")
               )
         it "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)" $ do
           result <- eval stdLib "let loop = (\\a -> if eq(10)(a) then a else loop(addInt(a)(1))) in loop(1)"
@@ -410,10 +410,10 @@ spec =
           result <- eval stdLib "let some = \\a -> Some a in if True then some(1) else Nowt"
           result
             `shouldBe` Right
-              ( MTData mempty (mkTyCon "Option") [MTPrim mempty MTInt],
+              ( MTData mempty "Option" [MTPrim mempty MTInt],
                 MyConsApp
                   mempty
-                  (MyConstructor mempty (mkTyCon "Some"))
+                  (MyConstructor mempty "Some")
                   (int 1)
               )
         it "\\a -> case a of Some \\as -> True | Nowt 100" $ do
@@ -426,7 +426,7 @@ spec =
             `shouldBe` Right
               ( MTFunction
                   mempty
-                  (MTData mempty (mkTyCon "Option") [MTPrim mempty MTInt])
+                  (MTData mempty "Option" [MTPrim mempty MTInt])
                   (MTPrim mempty MTInt)
               )
         it "let fromMaybe = \\def -> (\\maybe -> case maybe of Some (\\a -> a) | Nowt def) in fromMaybe(\"Horse\")(Some 1)" $ do
@@ -553,7 +553,7 @@ spec =
             `shouldBe` Right
               ( MyConsApp
                   mempty
-                  (MyConstructor mempty (mkTyCon "Some"))
+                  (MyConstructor mempty "Some")
                   (bool True)
               )
         it "\\a -> if (100 == a.int) then 100 else 0" $ do
@@ -568,11 +568,11 @@ spec =
             `shouldBe` Right
               ( MTData
                   mempty
-                  (mkTyCon "Reader")
+                  "Reader"
                   [MTPrim mempty MTInt, MTPrim mempty MTInt],
                 MyConsApp
                   mempty
-                  (MyConstructor mempty (mkTyCon "Reader"))
+                  (MyConstructor mempty "Reader")
                   ( MyLambda
                       mempty
                       (numbered 0)

--- a/test/Test/Interpreter/Repl.hs
+++ b/test/Test/Interpreter/Repl.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Test.Repl
+module Test.Interpreter.Repl
   ( spec,
   )
 where
@@ -514,15 +514,15 @@ spec =
                   mempty
                   ( MTRecord
                       mempty
-                      (M.singleton (mkName "one") (MTVar mempty (tvFree 1)))
+                      (M.singleton "one" (MTVar mempty (tvFree 1)))
                   )
                   ( MTFunction
                       mempty
                       ( MTRecord
                           mempty
                           ( M.fromList
-                              [ (mkName "one", MTVar mempty (tvFree 2)),
-                                (mkName "two", MTVar mempty (tvFree 3))
+                              [ ("one", MTVar mempty (tvFree 2)),
+                                ("two", MTVar mempty (tvFree 3))
                               ]
                           )
                       )

--- a/test/Test/Parser/MonoTypeParser.hs
+++ b/test/Test/Parser/MonoTypeParser.hs
@@ -13,7 +13,7 @@ import Data.Text (Text)
 import Language.Mimsa.Parser.Helpers
 import Language.Mimsa.Parser.MonoType
 import Language.Mimsa.Printer
-import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Identifiers ()
 import Language.Mimsa.Types.Typechecker
 import Test.Hspec
 import Test.Utils.Helpers
@@ -132,7 +132,7 @@ spec =
                       (MTPrim mempty MTInt)
                       ( MTData
                           mempty
-                          (mkTyCon "Maybe")
+                          "Maybe"
                           [MTPrim mempty MTInt]
                       )
                   ),
@@ -145,7 +145,7 @@ spec =
                           (MTVar mempty (tvNamed "b"))
                           ( MTData
                               mempty
-                              (mkTyCon "Either")
+                              "Either"
                               [ MTPrim mempty MTString,
                                 MTPrim mempty MTInt
                               ]
@@ -157,13 +157,13 @@ spec =
     it "Nullary data type" $
       testParser "MyUnit"
         `shouldBe` Right
-          (MTData mempty (mkTyCon "MyUnit") mempty)
+          (MTData mempty "MyUnit" mempty)
     it "Unary data type" $
       testParser "Maybe String"
         `shouldBe` Right
           ( MTData
               mempty
-              (mkTyCon "Maybe")
+              "Maybe"
               [MTPrim mempty MTString]
           )
     it "Binary data type" $
@@ -171,7 +171,7 @@ spec =
         `shouldBe` Right
           ( MTData
               mempty
-              (mkTyCon "Either")
+              "Either"
               [ MTPrim mempty MTString,
                 MTPrim mempty MTInt
               ]
@@ -181,11 +181,11 @@ spec =
         `shouldBe` Right
           ( MTData
               mempty
-              (mkTyCon "Either")
+              "Either"
               [ MTPrim mempty MTString,
                 MTData
                   mempty
-                  (mkTyCon "Maybe")
+                  "Maybe"
                   [MTPrim mempty MTInt]
               ]
           )
@@ -194,7 +194,7 @@ spec =
         `shouldBe` Right
           ( MTFunction
               mempty
-              (MTData mempty (mkTyCon "MyUnit") mempty)
+              (MTData mempty "MyUnit" mempty)
               (MTPrim mempty MTInt)
           )
     it "Functions with datatypes with brackets" $
@@ -202,7 +202,7 @@ spec =
         `shouldBe` Right
           ( MTFunction
               mempty
-              (MTData mempty (mkTyCon "Maybe") [MTPrim mempty MTString])
+              (MTData mempty "Maybe" [MTPrim mempty MTString])
               (MTPrim mempty MTInt)
           )
     it "Functions with datatypes with no brackets" $
@@ -210,7 +210,7 @@ spec =
         `shouldBe` Right
           ( MTFunction
               mempty
-              (MTData mempty (mkTyCon "Maybe") [typeName "a"])
+              (MTData mempty "Maybe" [typeName "a"])
               (typeName "b")
           )
     it "Parses higher order function" $
@@ -231,7 +231,7 @@ spec =
           ( MTFunction
               mempty
               (MTFunction mempty (typeName "a") (typeName "b"))
-              (MTData mempty (mkTyCon "Option") [typeName "a"])
+              (MTData mempty "Option" [typeName "a"])
           )
     it "Parses weird variation on fmap" $
       testParser "(a -> b) -> Option (a -> Option b)"
@@ -241,11 +241,11 @@ spec =
               (MTFunction mempty (typeName "a") (typeName "b"))
               ( MTData
                   mempty
-                  (mkTyCon "Option")
+                  "Option"
                   [ MTFunction
                       mempty
                       (typeName "a")
-                      (MTData mempty (mkTyCon "Option") [typeName "b"])
+                      (MTData mempty "Option" [typeName "b"])
                   ]
               )
           )
@@ -257,7 +257,7 @@ spec =
               (MTFunction mempty (typeName "a") (typeName "b"))
               ( MTFunction
                   mempty
-                  (MTData mempty (mkTyCon "Option") [typeName "a"])
-                  (MTData mempty (mkTyCon "Option") [typeName "b"])
+                  (MTData mempty "Option" [typeName "a"])
+                  (MTData mempty "Option" [typeName "b"])
               )
           )

--- a/test/Test/Parser/MonoTypeParser.hs
+++ b/test/Test/Parser/MonoTypeParser.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Test.MonoTypeParser
+module Test.Parser.MonoTypeParser
   ( spec,
   )
 where
@@ -96,8 +96,8 @@ spec =
         `shouldBe` Right
           ( MTRecord mempty $
               M.fromList
-                [ (mkName "one", MTPrim mempty MTInt),
-                  (mkName "two", MTPrim mempty MTString)
+                [ ("one", MTPrim mempty MTInt),
+                  ("two", MTPrim mempty MTString)
                 ]
           )
     it "Record with functions as items" $
@@ -105,13 +105,13 @@ spec =
         `shouldBe` Right
           ( MTRecord mempty $
               M.fromList
-                [ ( mkName "one",
+                [ ( "one",
                     MTFunction
                       mempty
                       (MTPrim mempty MTInt)
                       (MTPrim mempty MTInt)
                   ),
-                  ( mkName "two",
+                  ( "two",
                     MTFunction
                       mempty
                       (MTPrim mempty MTString)
@@ -126,7 +126,7 @@ spec =
         `shouldBe` Right
           ( MTRecord mempty $
               M.fromList
-                [ ( mkName "one",
+                [ ( "one",
                     MTFunction
                       mempty
                       (MTPrim mempty MTInt)
@@ -136,7 +136,7 @@ spec =
                           [MTPrim mempty MTInt]
                       )
                   ),
-                  ( mkName "two",
+                  ( "two",
                     MTFunction
                       mempty
                       (MTPrim mempty MTString)

--- a/test/Test/Parser/Syntax.hs
+++ b/test/Test/Parser/Syntax.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Test.Syntax
+module Test.Parser.Syntax
   ( spec,
   )
 where
@@ -52,7 +52,7 @@ spec = do
       testParse "\"dog\"" `shouldBe` Right (str (StringType "dog"))
     it "Parses a variable name" $
       testParse "log"
-        `shouldBe` Right (MyVar mempty (mkName "log"))
+        `shouldBe` Right (MyVar mempty "log")
     it "Does not accept 'let' as a variable name" $
       isLeft (testParse "let")
         `shouldBe` True
@@ -65,40 +65,40 @@ spec = do
       testParse "log!dog"
         `shouldSatisfy` isLeft
     it "Does a basic let binding" $ do
-      let expected = MyLet mempty (mkName "xa") (bool True) (MyVar mempty (mkName "xa"))
+      let expected = MyLet mempty "xa" (bool True) (MyVar mempty "xa")
       testParse "let xa = True in xa"
         `shouldBe` Right expected
     it "Does a basic let binding with excessive whitespace" $ do
-      let expected = MyLet mempty (mkName "x") (bool True) (MyVar mempty (mkName "x"))
+      let expected = MyLet mempty "x" (bool True) (MyVar mempty "x")
       testParse "let       x       =       True       in        x"
         `shouldBe` Right expected
     it "Does a let binding inside parens" $ do
-      let expected = MyLet mempty (mkName "x") (bool True) (MyVar mempty (mkName "x"))
+      let expected = MyLet mempty "x" (bool True) (MyVar mempty "x")
       testParse "(let x = True in x)"
         `shouldBe` Right expected
     it "Recognises a basic lambda" $
       testParse "\\x -> x"
-        `shouldBe` Right (MyLambda mempty (mkName "x") (MyVar mempty (mkName "x")))
+        `shouldBe` Right (MyLambda mempty "x" (MyVar mempty "x"))
     it "Recognises a lambda with too much whitespace everywhere" $
       testParse "\\        x          ->             x"
-        `shouldBe` Right (MyLambda mempty (mkName "x") (MyVar mempty (mkName "x")))
+        `shouldBe` Right (MyLambda mempty "x" (MyVar mempty "x"))
     it "Recognises a lambda in parens" $
       testParse "(\\x -> x)"
-        `shouldBe` Right (MyLambda mempty (mkName "x") (MyVar mempty (mkName "x")))
+        `shouldBe` Right (MyLambda mempty "x" (MyVar mempty "x"))
     it "Recognises nested lambdas in parens" $
       testParse "(\\a -> (\\b -> a))"
         `shouldBe` Right
           ( MyLambda
               mempty
-              (mkName "a")
-              (MyLambda mempty (mkName "b") (MyVar mempty (mkName "a")))
+              "a"
+              (MyLambda mempty "b" (MyVar mempty "a"))
           )
     it "Recognises function application in parens" $
       testParse "add (1)"
         `shouldBe` Right
           ( MyApp
               mempty
-              ( MyVar mempty (mkName "add")
+              ( MyVar mempty "add"
               )
               (int 1)
           )
@@ -109,7 +109,7 @@ spec = do
               mempty
               ( MyApp
                   mempty
-                  ( MyVar mempty (mkName "add")
+                  ( MyVar mempty "add"
                   )
                   (int 1)
               )
@@ -137,34 +137,34 @@ spec = do
         `shouldBe` Right
           ( MyLet
               mempty
-              (mkName "x")
+              "x"
               (MyPair mempty (int 1) (int 2))
-              (MyVar mempty (mkName "x"))
+              (MyVar mempty "x")
           )
     it "Allows a let to use a pair and apply to it" $
       testParse "let x = ((1,2)) in fst(x)"
         `shouldBe` Right
           ( MyLet
               mempty
-              (mkName "x")
+              "x"
               (MyPair mempty (int 1) (int 2))
-              (MyApp mempty (MyVar mempty (mkName "fst")) (MyVar mempty (mkName "x")))
+              (MyApp mempty (MyVar mempty "fst") (MyVar mempty "x"))
           )
     it "Allows a let to use a nested lambda" $
       testParse "let const2 = (\\a -> (\\b -> a)) in (const2)"
         `shouldBe` Right
           ( MyLet
               mempty
-              (mkName "const2")
+              "const2"
               ( MyLambda
                   mempty
-                  (mkName "a")
-                  (MyLambda mempty (mkName "b") (MyVar mempty (mkName "a")))
+                  "a"
+                  (MyLambda mempty "b" (MyVar mempty "a"))
               )
-              (MyVar mempty (mkName "const2"))
+              (MyVar mempty "const2")
           )
     it "Parses typed hole" $ do
-      testParse "?dog" `shouldBe` Right (MyTypedHole mempty (mkName "dog"))
+      testParse "?dog" `shouldBe` Right (MyTypedHole mempty "dog")
     it "Parses a complex let expression" $
       testParse "let const2 = (\\a -> (\\b -> a)) in (let reuse = ({first: const2(True), second: const2(2)}) in reuse.second(100))"
         `shouldSatisfy` isRight
@@ -173,7 +173,7 @@ spec = do
     it "Parses two integers with infix operator" $
       testParse "123 == 123" `shouldBe` Right (MyInfix mempty Equals (int 123) (int 123))
     it "Parses var and number equality" $
-      testParse "a == 1" `shouldBe` Right (MyInfix mempty Equals (MyVar mempty (mkName "a")) (int 1))
+      testParse "a == 1" `shouldBe` Right (MyInfix mempty Equals (MyVar mempty "a") (int 1))
     it "Parsers two constructor applications with infix operator" $
       let mkSome = MyConsApp mempty (MyConstructor mempty (mkTyCon "Some"))
        in testParse "(Some 1) == Some 2"
@@ -183,15 +183,15 @@ spec = do
     it "Parses a record literal with a single item inside" $
       testParse "{ dog: 1 }"
         `shouldBe` Right
-          (MyRecord mempty (M.singleton (mkName "dog") (int 1)))
+          (MyRecord mempty (M.singleton "dog" (int 1)))
     it "Parses a record literal with multiple items inside" $
       testParse "{ dog:1, cat:True, horse:\"of course\" }"
         `shouldBe` Right
           ( MyRecord mempty $
               M.fromList
-                [ (mkName "dog", int 1),
-                  (mkName "cat", bool True),
-                  (mkName "horse", str' "of course")
+                [ ("dog", int 1),
+                  ("cat", bool True),
+                  ("horse", str' "of course")
                 ]
           )
     it "Parses a record literal with multiple items inside and less spacing" $
@@ -199,9 +199,9 @@ spec = do
         `shouldBe` Right
           ( MyRecord mempty $
               M.fromList
-                [ (mkName "dog", int 1),
-                  (mkName "cat", bool True),
-                  (mkName "horse", str' "of course")
+                [ ("dog", int 1),
+                  ("cat", bool True),
+                  ("horse", str' "of course")
                 ]
           )
     it "Parses a destructuring of pairs" $
@@ -209,20 +209,20 @@ spec = do
         `shouldBe` Right
           ( MyLetPair
               mempty
-              (mkName "a")
-              (mkName "b")
+              "a"
+              "b"
               (MyPair mempty (bool True) (int 1))
-              (MyVar mempty (mkName "a"))
+              (MyVar mempty "a")
           )
     it "Parses a destructuring of pairs with silly whitespace" $
       testParse "let   (    a ,      b ) =    ((       True, 1) ) in a"
         `shouldBe` Right
           ( MyLetPair
               mempty
-              (mkName "a")
-              (mkName "b")
+              "a"
+              "b"
               (MyPair mempty (bool True) (int 1))
-              (MyVar mempty (mkName "a"))
+              (MyVar mempty "a")
           )
     it "Parses Void" $
       testParse "type Void in 1"
@@ -255,11 +255,11 @@ spec = do
               mempty
               ( DataType
                   (mkTyCon "Arr")
-                  [mkName "a"]
+                  ["a"]
                   ( M.fromList
                       [ (mkTyCon "Empty", mempty),
                         ( mkTyCon "Item",
-                          [VarName $mkName "a"]
+                          [VarName "a"]
                         )
                       ]
                   )
@@ -335,9 +335,9 @@ spec = do
               mempty
               ( DataType
                   (mkTyCon "Maybe")
-                  [mkName "a"]
+                  ["a"]
                   ( M.fromList
-                      [ (mkTyCon "Just", [VarName $ mkName "a"]),
+                      [ (mkTyCon "Just", [VarName "a"]),
                         (mkTyCon "Nothing", [])
                       ]
                   )
@@ -351,12 +351,12 @@ spec = do
               mempty
               ( DataType
                   (mkTyCon "Reader")
-                  [mkName "r", mkName "a"]
+                  ["r", "a"]
                   ( M.fromList
                       [ ( mkTyCon "Reader",
                           [ TNFunc
-                              (VarName $ mkName "r")
-                              (VarName $ mkName "a")
+                              (VarName "r")
+                              (VarName "a")
                           ]
                         )
                       ]
@@ -371,15 +371,15 @@ spec = do
               mempty
               ( DataType
                   (mkTyCon "Reader")
-                  [mkName "r", mkName "a"]
+                  ["r", "a"]
                   ( M.fromList
                       [ ( mkTyCon "Reader",
                           [ TNFunc
-                              (VarName $ mkName "r")
+                              (VarName "r")
                               ( ConsName
                                   (mkTyCon "Pair")
-                                  [ VarName $mkName "a",
-                                    VarName $ mkName "b"
+                                  [ VarName "a",
+                                    VarName "b"
                                   ]
                               )
                           ]
@@ -398,7 +398,7 @@ spec = do
               mempty
               (MyConsApp mempty (MyConstructor mempty $ mkTyCon "Just") (int 1))
               ( NE.fromList
-                  [ (mkTyCon "Just", MyLambda mempty (mkName "a") (MyVar mempty (mkName "a"))),
+                  [ (mkTyCon "Just", MyLambda mempty "a" (MyVar mempty "a")),
                     (mkTyCon "Nothing", int 0)
                   ]
               )
@@ -411,7 +411,7 @@ spec = do
               mempty
               (MyConsApp mempty (MyConstructor mempty $ mkTyCon "Just") (int 1))
               ( NE.fromList
-                  [ (mkTyCon "Just", MyLambda mempty (mkName "a") (MyVar mempty (mkName "a")))
+                  [ (mkTyCon "Just", MyLambda mempty "a" (MyVar mempty "a"))
                   ]
               )
               (Just $ int 0)
@@ -423,12 +423,12 @@ spec = do
               mempty
               ( DataType
                   (mkTyCon "Tree")
-                  [mkName "a"]
+                  ["a"]
                   ( M.fromList
-                      [ (mkTyCon "Leaf", [VarName $ mkName "a"]),
+                      [ (mkTyCon "Leaf", [VarName "a"]),
                         ( mkTyCon "Branch",
-                          [ ConsName (mkTyCon "Tree") [VarName $ mkName "a"],
-                            ConsName (mkTyCon "Tree") [VarName $ mkName "b"]
+                          [ ConsName (mkTyCon "Tree") [VarName "a"],
+                            ConsName (mkTyCon "Tree") [VarName "b"]
                           ]
                         )
                       ]
@@ -443,13 +443,13 @@ spec = do
               mempty
               ( DataType
                   (mkTyCon "Tree")
-                  [mkName "a"]
+                  ["a"]
                   ( M.fromList
                       [ (mkTyCon "Empty", mempty),
                         ( mkTyCon "Branch",
-                          [ ConsName (mkTyCon "Tree") [VarName $ mkName "a"],
-                            VarName $ mkName "a",
-                            ConsName (mkTyCon "Tree") [VarName $ mkName "a"]
+                          [ ConsName (mkTyCon "Tree") [VarName "a"],
+                            VarName "a",
+                            ConsName (mkTyCon "Tree") [VarName "a"]
                           ]
                         )
                       ]
@@ -482,7 +482,7 @@ spec = do
                           mempty
                           ( MyApp
                               mempty
-                              (MyVar mempty (mkName "thing"))
+                              (MyVar mempty "thing")
                               (int 1)
                           )
                           (int 2)
@@ -499,7 +499,7 @@ spec = do
       testParse "if id(True) then id(1) else id(2)" `shouldSatisfy` isRight
   describe "Test annotations" $ do
     it "Parses a var with location information" $
-      testParseWithAnn "dog" `shouldBe` Right (MyVar (Location 0 3) (mkName "dog"))
+      testParseWithAnn "dog" `shouldBe` Right (MyVar (Location 0 3) "dog")
     it "Parses a tyCon with location information" $
       testParseWithAnn "Log" `shouldBe` Right (MyConstructor (Location 0 3) (mkTyCon "Log"))
     it "Parses a true bool with location information" $
@@ -517,47 +517,47 @@ spec = do
         `shouldBe` Right
           ( MyRecordAccess
               (Location 0 8)
-              (MyVar (Location 0 3) (mkName "dog"))
-              (mkName "tail")
+              (MyVar (Location 0 3) "dog")
+              "tail"
           )
     it "Parses let-in with location information" $
       testParseWithAnn "let a = 1 in a"
         `shouldBe` Right
           ( MyLet
               (Location 0 14)
-              (mkName "a")
+              "a"
               (MyLiteral (Location 8 9) (MyInt 1))
-              (MyVar (Location 13 14) (mkName "a"))
+              (MyVar (Location 13 14) "a")
           )
     it "Parses let-newline with location information" $
       testParseWithAnn "let a = 1; a"
         `shouldBe` Right
           ( MyLet
               (Location 0 12)
-              (mkName "a")
+              "a"
               (MyLiteral (Location 8 9) (MyInt 1))
-              (MyVar (Location 11 12) (mkName "a"))
+              (MyVar (Location 11 12) "a")
           )
     it "Parses let pair with location information" $
       testParseWithAnn "let (a,b) = dog in a"
         `shouldBe` Right
           ( MyLetPair
               (Location 0 20)
-              (mkName "a")
-              (mkName "b")
-              (MyVar (Location 12 15) (mkName "dog"))
-              (MyVar (Location 19 20) (mkName "a"))
+              "a"
+              "b"
+              (MyVar (Location 12 15) "dog")
+              (MyVar (Location 19 20) "a")
           )
     it "Parsers lambda with location information" $
       testParseWithAnn "\\a -> a"
         `shouldBe` Right
-          (MyLambda (Location 0 7) (mkName "a") (MyVar (Location 6 7) (mkName "a")))
+          (MyLambda (Location 0 7) "a" (MyVar (Location 6 7) "a"))
     it "Parses application with location information" $
       testParseWithAnn "a(1)"
         `shouldBe` Right
           ( MyApp
               (Location 0 4)
-              (MyVar (Location 0 1) (mkName "a"))
+              (MyVar (Location 0 1) "a")
               (MyLiteral (Location 2 3) (MyInt 1))
           )
     it "Parses record with location information" $
@@ -566,7 +566,7 @@ spec = do
           ( MyRecord
               (Location 0 11)
               ( M.singleton
-                  (mkName "a")
+                  "a"
                   (MyLiteral (Location 5 9) (MyBool True))
               )
           )
@@ -612,12 +612,12 @@ spec = do
         `shouldBe` Right
           ( MyCaseMatch
               (Location 0 35)
-              (MyVar (Location 5 6) (mkName "a"))
+              (MyVar (Location 5 6) "a")
               ( NE.fromList
                   [ ( mkTyCon "Just",
                       MyLambda
                         (Location 15 23)
-                        (mkName "as")
+                        "as"
                         (MyLiteral (Location 22 23) (MyInt 1))
                     ),
                     (mkTyCon "Nothing", MyLiteral (Location 34 35) (MyInt 0))

--- a/test/Test/Parser/Syntax.hs
+++ b/test/Test/Parser/Syntax.hs
@@ -175,7 +175,7 @@ spec = do
     it "Parses var and number equality" $
       testParse "a == 1" `shouldBe` Right (MyInfix mempty Equals (MyVar mempty "a") (int 1))
     it "Parsers two constructor applications with infix operator" $
-      let mkSome = MyConsApp mempty (MyConstructor mempty (mkTyCon "Some"))
+      let mkSome = MyConsApp mempty (MyConstructor mempty "Some")
        in testParse "(Some 1) == Some 2"
             `shouldBe` Right (MyInfix mempty Equals (mkSome (int 1)) (mkSome (int 2)))
     it "Parses an empty record literal" $
@@ -230,7 +230,7 @@ spec = do
           ( MyData
               mempty
               ( DataType
-                  (mkTyCon "Void")
+                  "Void"
                   mempty
                   mempty
               )
@@ -242,9 +242,9 @@ spec = do
           ( MyData
               mempty
               ( DataType
-                  (mkTyCon "AbsoluteUnit")
+                  "AbsoluteUnit"
                   mempty
-                  (M.singleton (mkTyCon "AbsoluteUnit") mempty)
+                  (M.singleton "AbsoluteUnit" mempty)
               )
               (int 1)
           )
@@ -254,11 +254,11 @@ spec = do
           ( MyData
               mempty
               ( DataType
-                  (mkTyCon "Arr")
+                  "Arr"
                   ["a"]
                   ( M.fromList
-                      [ (mkTyCon "Empty", mempty),
-                        ( mkTyCon "Item",
+                      [ ("Empty", mempty),
+                        ( "Item",
                           [VarName "a"]
                         )
                       ]
@@ -275,11 +275,11 @@ spec = do
           ( MyData
               mempty
               ( DataType
-                  (mkTyCon "Dog")
+                  "Dog"
                   mempty
                   ( M.singleton
-                      (mkTyCon "Dog")
-                      [ConsName (mkTyCon "String") mempty]
+                      "Dog"
+                      [ConsName "String" mempty]
                   )
               )
               (int 1)
@@ -290,11 +290,11 @@ spec = do
           ( MyData
               mempty
               ( DataType
-                  (mkTyCon "LeBool")
+                  "LeBool"
                   mempty
                   ( M.fromList
-                      [ (mkTyCon "Vrai", []),
-                        (mkTyCon "Faux", [])
+                      [ ("Vrai", []),
+                        ("Faux", [])
                       ]
                   )
               )
@@ -306,11 +306,11 @@ spec = do
           ( MyData
               mempty
               ( DataType
-                  (mkTyCon "Nat")
+                  "Nat"
                   mempty
                   ( M.fromList
-                      [ (mkTyCon "Zero", []),
-                        (mkTyCon "Succ", [ConsName (mkTyCon "Nat") mempty])
+                      [ ("Zero", []),
+                        ("Succ", [ConsName "Nat" mempty])
                       ]
                   )
               )
@@ -323,7 +323,7 @@ spec = do
               mempty
               ( MyConsApp
                   mempty
-                  (MyConstructor mempty $ mkTyCon "Dog")
+                  (MyConstructor mempty "Dog")
                   (str' "hi")
               )
               (str' "dog")
@@ -334,15 +334,15 @@ spec = do
           ( MyData
               mempty
               ( DataType
-                  (mkTyCon "Maybe")
+                  "Maybe"
                   ["a"]
                   ( M.fromList
-                      [ (mkTyCon "Just", [VarName "a"]),
-                        (mkTyCon "Nothing", [])
+                      [ ("Just", [VarName "a"]),
+                        ("Nothing", [])
                       ]
                   )
               )
-              (MyConstructor mempty $ mkTyCon "Nothing")
+              (MyConstructor mempty "Nothing")
           )
     it "Parses a type declaration with a function as arg" $
       testParse "type Reader r a = Reader (r -> a) in {}"
@@ -350,10 +350,10 @@ spec = do
           ( MyData
               mempty
               ( DataType
-                  (mkTyCon "Reader")
+                  "Reader"
                   ["r", "a"]
                   ( M.fromList
-                      [ ( mkTyCon "Reader",
+                      [ ( "Reader",
                           [ TNFunc
                               (VarName "r")
                               (VarName "a")
@@ -370,14 +370,14 @@ spec = do
           ( MyData
               mempty
               ( DataType
-                  (mkTyCon "Reader")
+                  "Reader"
                   ["r", "a"]
                   ( M.fromList
-                      [ ( mkTyCon "Reader",
+                      [ ( "Reader",
                           [ TNFunc
                               (VarName "r")
                               ( ConsName
-                                  (mkTyCon "Pair")
+                                  "Pair"
                                   [ VarName "a",
                                     VarName "b"
                                   ]
@@ -390,16 +390,16 @@ spec = do
               (MyRecord mempty mempty)
           )
     it "Uses a constructor" $
-      testParse "Vrai" `shouldBe` Right (MyConstructor mempty (mkTyCon "Vrai"))
+      testParse "Vrai" `shouldBe` Right (MyConstructor mempty "Vrai")
     it "Parses a custom case match" $
       testParse "case Just 1 of Just \\a -> a | Nothing 0"
         `shouldBe` Right
           ( MyCaseMatch
               mempty
-              (MyConsApp mempty (MyConstructor mempty $ mkTyCon "Just") (int 1))
+              (MyConsApp mempty (MyConstructor mempty "Just") (int 1))
               ( NE.fromList
-                  [ (mkTyCon "Just", MyLambda mempty "a" (MyVar mempty "a")),
-                    (mkTyCon "Nothing", int 0)
+                  [ ("Just", MyLambda mempty "a" (MyVar mempty "a")),
+                    ("Nothing", int 0)
                   ]
               )
               Nothing
@@ -409,9 +409,9 @@ spec = do
         `shouldBe` Right
           ( MyCaseMatch
               mempty
-              (MyConsApp mempty (MyConstructor mempty $ mkTyCon "Just") (int 1))
+              (MyConsApp mempty (MyConstructor mempty "Just") (int 1))
               ( NE.fromList
-                  [ (mkTyCon "Just", MyLambda mempty "a" (MyVar mempty "a"))
+                  [ ("Just", MyLambda mempty "a" (MyVar mempty "a"))
                   ]
               )
               (Just $ int 0)
@@ -422,19 +422,19 @@ spec = do
           ( MyData
               mempty
               ( DataType
-                  (mkTyCon "Tree")
+                  "Tree"
                   ["a"]
                   ( M.fromList
-                      [ (mkTyCon "Leaf", [VarName "a"]),
-                        ( mkTyCon "Branch",
-                          [ ConsName (mkTyCon "Tree") [VarName "a"],
-                            ConsName (mkTyCon "Tree") [VarName "b"]
+                      [ ("Leaf", [VarName "a"]),
+                        ( "Branch",
+                          [ ConsName "Tree" [VarName "a"],
+                            ConsName "Tree" [VarName "b"]
                           ]
                         )
                       ]
                   )
               )
-              (MyConsApp mempty (MyConstructor mempty $ mkTyCon "Leaf") (int 1))
+              (MyConsApp mempty (MyConstructor mempty "Leaf") (int 1))
           )
     it "Parses even more complex type constructors" $
       testParse "type Tree a = Empty | Branch (Tree a) a (Tree a) in Branch (Empty) 1 (Empty)"
@@ -442,14 +442,14 @@ spec = do
           ( MyData
               mempty
               ( DataType
-                  (mkTyCon "Tree")
+                  "Tree"
                   ["a"]
                   ( M.fromList
-                      [ (mkTyCon "Empty", mempty),
-                        ( mkTyCon "Branch",
-                          [ ConsName (mkTyCon "Tree") [VarName "a"],
+                      [ ("Empty", mempty),
+                        ( "Branch",
+                          [ ConsName "Tree" [VarName "a"],
                             VarName "a",
-                            ConsName (mkTyCon "Tree") [VarName "a"]
+                            ConsName "Tree" [VarName "a"]
                           ]
                         )
                       ]
@@ -461,12 +461,12 @@ spec = do
                       mempty
                       ( MyConsApp
                           mempty
-                          (MyConstructor mempty $ mkTyCon "Branch")
-                          (MyConstructor mempty $ mkTyCon "Empty")
+                          (MyConstructor mempty "Branch")
+                          (MyConstructor mempty "Empty")
                       )
                       (int 1)
                   )
-                  (MyConstructor mempty $ mkTyCon "Empty")
+                  (MyConstructor mempty "Empty")
               )
           )
     it "Parses big function application" $
@@ -501,7 +501,7 @@ spec = do
     it "Parses a var with location information" $
       testParseWithAnn "dog" `shouldBe` Right (MyVar (Location 0 3) "dog")
     it "Parses a tyCon with location information" $
-      testParseWithAnn "Log" `shouldBe` Right (MyConstructor (Location 0 3) (mkTyCon "Log"))
+      testParseWithAnn "Log" `shouldBe` Right (MyConstructor (Location 0 3) "Log")
     it "Parses a true bool with location information" $
       testParseWithAnn "True" `shouldBe` Right (MyLiteral (Location 0 4) (MyBool True))
     it "Parses a false bool with location information" $
@@ -593,9 +593,9 @@ spec = do
           ( MyData
               (Location 0 25)
               ( DataType
-                  (mkTyCon "MyUnit")
+                  "MyUnit"
                   mempty
-                  (M.singleton (mkTyCon "MyUnit") mempty)
+                  (M.singleton "MyUnit" mempty)
               )
               (MyLiteral (Location 24 25) (MyInt 1))
           )
@@ -604,7 +604,7 @@ spec = do
         `shouldBe` Right
           ( MyConsApp
               (Location 0 6)
-              (MyConstructor (Location 0 4) (mkTyCon "Just"))
+              (MyConstructor (Location 0 4) "Just")
               (MyLiteral (Location 5 6) (MyInt 1))
           )
     it "Parses case match with location information" $
@@ -614,13 +614,13 @@ spec = do
               (Location 0 35)
               (MyVar (Location 5 6) "a")
               ( NE.fromList
-                  [ ( mkTyCon "Just",
+                  [ ( "Just",
                       MyLambda
                         (Location 15 23)
                         "as"
                         (MyLiteral (Location 22 23) (MyInt 1))
                     ),
-                    (mkTyCon "Nothing", MyLiteral (Location 34 35) (MyInt 0))
+                    ("Nothing", MyLiteral (Location 34 35) (MyInt 0))
                   ]
               )
               Nothing

--- a/test/Test/Prettier.hs
+++ b/test/Test/Prettier.hs
@@ -24,7 +24,7 @@ spec =
             expr' =
               MyConsApp
                 ()
-                (MyConstructor mempty (mkTyCon "Some"))
+                (MyConstructor mempty "Some")
                 (MyInfix mempty Equals (int 1) (int 1))
         prettyPrint expr'
           `shouldBe` "Some (1 == 1)"
@@ -53,7 +53,7 @@ spec =
                       ( "maybeDog",
                         MTData
                           mempty
-                          (mkTyCon "Maybe")
+                          "Maybe"
                           [MTPrim mempty MTString]
                       )
                     ]

--- a/test/Test/Prettier.hs
+++ b/test/Test/Prettier.hs
@@ -17,17 +17,17 @@ import Test.Utils.Helpers
 spec :: Spec
 spec =
   describe "Prettier" $ do
-    describe "Expr" $
-      it "Cons with infix" $
-        do
-          let expr' :: Expr Name ()
-              expr' =
-                MyConsApp
-                  ()
-                  (MyConstructor mempty (mkTyCon "Some"))
-                  (MyInfix mempty Equals (int 1) (int 1))
-          prettyPrint expr'
-            `shouldBe` "Some (1 == 1)"
+    describe "Expr"
+      $ it "Cons with infix"
+      $ do
+        let expr' :: Expr Name ()
+            expr' =
+              MyConsApp
+                ()
+                (MyConstructor mempty (mkTyCon "Some"))
+                (MyInfix mempty Equals (int 1) (int 1))
+        prettyPrint expr'
+          `shouldBe` "Some (1 == 1)"
     describe
       "MonoType"
       $ do
@@ -48,9 +48,9 @@ spec =
               mt =
                 MTRecord mempty $
                   M.fromList
-                    [ (mkName "dog", MTPrim mempty MTUnit),
-                      (mkName "horse", MTPrim mempty MTString),
-                      ( mkName "maybeDog",
+                    [ ("dog", MTPrim mempty MTUnit),
+                      ("horse", MTPrim mempty MTString),
+                      ( "maybeDog",
                         MTData
                           mempty
                           (mkTyCon "Maybe")
@@ -81,7 +81,6 @@ spec =
            in T.putStrLn
                 ( prettyPrint mt
                 )
-
         it "Names type vars" $ do
           let mt = MTVar () (tvNumbered 1)
           prettyPrint mt `shouldBe` "a"

--- a/test/Test/Project/NormaliseType.hs
+++ b/test/Test/Project/NormaliseType.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Test.NormaliseType
+module Test.Project.NormaliseType
   ( spec,
   )
 where

--- a/test/Test/Project/TypeSearch.hs
+++ b/test/Test/Project/TypeSearch.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Test.TypeSearch
+module Test.Project.TypeSearch
   ( spec,
   )
 where
@@ -44,7 +44,7 @@ spec =
       it "Finds the id function in test project" $ do
         let result = typeSearch typeMap idType
         result
-          `shouldBe` M.singleton (mkName "id") idType
+          `shouldBe` M.singleton "id" idType
       it "Finds the addInt and subtractInt functions in test project" $ do
         let addIntType =
               MTFunction
@@ -58,14 +58,13 @@ spec =
         let result = typeSearch typeMap addIntType
         result
           `shouldBe` M.fromList
-            [ (mkName "addInt", addIntType),
-              (mkName "subtractInt", addIntType)
+            [ ("addInt", addIntType),
+              ("subtractInt", addIntType)
             ]
-
     describe "from text input" $ do
       it "Finds id function" $ do
         typeSearchFromText typeMap "a -> a"
-          `shouldBe` Right (M.singleton (mkName "id") idType)
+          `shouldBe` Right (M.singleton "id" idType)
       it "Finds fmapOption" $ do
         let fmapOption =
               MTFunction
@@ -79,6 +78,6 @@ spec =
         typeSearchFromText typeMap "(a -> b) -> (Option a) -> (Option b)"
           `shouldBe` Right
             ( M.singleton
-                (mkName "fmapOption")
+                "fmapOption"
                 (normaliseType fmapOption)
             )

--- a/test/Test/Project/TypeSearch.hs
+++ b/test/Test/Project/TypeSearch.hs
@@ -72,8 +72,8 @@ spec =
                 (MTFunction mempty (typeName "a") (typeName "b"))
                 ( MTFunction
                     mempty
-                    (MTData mempty (mkTyCon "Option") [typeName "a"])
-                    (MTData mempty (mkTyCon "Option") [typeName "b"])
+                    (MTData mempty "Option" [typeName "a"])
+                    (MTData mempty "Option" [typeName "b"])
                 )
         typeSearchFromText typeMap "(a -> b) -> (Option a) -> (Option b)"
           `shouldBe` Right

--- a/test/Test/Project/UnitTest.hs
+++ b/test/Test/Project/UnitTest.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Test.UnitTest
+module Test.Project.UnitTest
   ( spec,
   )
 where
@@ -25,34 +25,34 @@ testExpr =
     mempty
     Equals
     (int 1)
-    (MyApp mempty (MyVar mempty (mkName "incrementInt")) (int 1))
+    (MyApp mempty (MyVar mempty "incrementInt") (int 1))
 
 incrementIntH :: ExprHash
-incrementIntH = getHashOfName stdLib (mkName "incrementInt")
+incrementIntH = getHashOfName stdLib "incrementInt"
 
 testStoreExpr :: StoreExpression Annotation
 testStoreExpr =
   StoreExpression
     testExpr
-    (Bindings $ M.singleton (mkName "incrementInt") incrementIntH)
+    (Bindings $ M.singleton "incrementInt" incrementIntH)
     mempty
 
 idHash :: ExprHash
-idHash = getHashOfName stdLib (mkName "id")
+idHash = getHashOfName stdLib "id"
 
 testingIdExpr :: Expr Name Annotation
 testingIdExpr =
   MyInfix
     mempty
     Equals
-    (MyApp mempty (MyVar mempty (mkName "id")) (int 100))
+    (MyApp mempty (MyVar mempty "id") (int 100))
     (int 100)
 
 testingStoreExpr :: StoreExpression Annotation
 testingStoreExpr =
   StoreExpression
     testingIdExpr
-    (Bindings $ M.singleton (mkName "id") idHash)
+    (Bindings $ M.singleton "id" idHash)
     mempty
 
 altIdStoreExpr :: StoreExpression Annotation
@@ -60,8 +60,8 @@ altIdStoreExpr =
   StoreExpression
     ( MyLambda
         mempty
-        (mkName "b")
-        (MyVar mempty (mkName "b"))
+        "b"
+        (MyVar mempty "b")
     )
     mempty
     mempty
@@ -99,7 +99,7 @@ spec =
         let stdLibWithTest =
               stdLib
                 <> fromUnitTest firstTest testingStoreExpr
-                <> fromItem (mkName "id") altIdStoreExpr altIdHash
+                <> fromItem "id" altIdStoreExpr altIdHash
         let (prj, exprs) = case createNewUnitTests stdLibWithTest idHash altIdHash of
               Right (a, b) -> (a, b)
               Left _ -> (undefined, undefined)
@@ -148,7 +148,6 @@ spec =
         let storeExpr = StoreExpression (int 100) mempty mempty
         createUnitTest stdLib storeExpr (TestName "100 is not a valid test")
           `shouldSatisfy` isLeft
-
       it "Finds incrementInt and addInt" $ do
         createUnitTest stdLib testStoreExpr (TestName "incrementInt is a no-op")
           `shouldBe` Right

--- a/test/Test/Project/Usages.hs
+++ b/test/Test/Project/Usages.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Test.Usages
+module Test.Project.Usages
   ( spec,
   )
 where

--- a/test/Test/Store/Resolver.hs
+++ b/test/Test/Store/Resolver.hs
@@ -118,7 +118,7 @@ spec =
             )
     describe "createTypeStoreExpression" $ do
       it "Creates the most basic StoreExpression for a type" $ do
-        let dt = DataType (mkTyCon "Void") mempty mempty
+        let dt = DataType "Void" mempty mempty
             expr = MyData mempty dt (MyRecord mempty mempty)
             storeExpr = createStoreExpression' mempty mempty expr
         storeExpr
@@ -130,22 +130,22 @@ spec =
                 }
             )
       it "Throws when trying to use an unavailable type" $ do
-        let cons' = ConsName (mkTyCon "MyUnit") []
+        let cons' = ConsName "MyUnit" []
             dt =
               DataType
-                (mkTyCon "VoidBox")
+                "VoidBox"
                 mempty
-                (M.singleton (mkTyCon "Box") [cons'])
+                (M.singleton "Box" [cons'])
             storeExpr = createTypeStoreExpression' mempty dt
         storeExpr
-          `shouldBe` Left (MissingType (mkTyCon "MyUnit") mempty)
+          `shouldBe` Left (MissingType "MyUnit" mempty)
       it "Creates a StoreExpression that uses a type from the type bindings" $ do
-        let cons' = ConsName (mkTyCon "MyUnit") []
+        let cons' = ConsName "MyUnit" []
             dt =
               DataType
-                (mkTyCon "VoidBox")
+                "VoidBox"
                 mempty
-                (M.singleton (mkTyCon "Box") [cons'])
+                (M.singleton "Box" [cons'])
             hash = exprHash 123
             tBindings' = TypeBindings $ M.singleton (TyCon "MyUnit") hash
             storeExpr = createTypeStoreExpression' tBindings' dt

--- a/test/Test/Store/Resolver.hs
+++ b/test/Test/Store/Resolver.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Test.Resolver
+module Test.Store.Resolver
   ( spec,
   )
 where
@@ -102,7 +102,7 @@ spec =
       it "Looks for vars and can't find them" $
         createStoreExpression' mempty mempty (MyVar mempty (Name "missing"))
           `shouldBe` Left
-            (MissingBinding (mkName "missing") mempty)
+            (MissingBinding "missing" mempty)
       it "Looks for vars and finds them" $ do
         let hash = exprHash 1234
             expr = MyVar mempty (Name "missing")

--- a/test/Test/Store/Substitutor.hs
+++ b/test/Test/Store/Substitutor.hs
@@ -46,12 +46,12 @@ constExpr =
 
 maybeDecl :: DataType
 maybeDecl =
-  DataType (mkTyCon "Maybe") ["a"] cons'
+  DataType "Maybe" ["a"] cons'
   where
     cons' =
       M.fromList
-        [ (mkTyCon "Just", [VarName "a"]),
-          (mkTyCon "Nothing", [])
+        [ ("Just", [VarName "a"]),
+          ("Nothing", [])
         ]
 
 maybeExpr :: Monoid ann => StoreExpression ann
@@ -199,7 +199,7 @@ spec = do
             StoreExpression
               expr
               mempty
-              (TypeBindings $ M.singleton (mkTyCon "Maybe") hash)
+              (TypeBindings $ M.singleton "Maybe" hash)
           store' = storeWithBothIn
           ans = testSubstitute store' storeExpr
       seSwaps ans `shouldBe` mempty

--- a/test/Test/Store/Substitutor.hs
+++ b/test/Test/Store/Substitutor.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Test.Substitutor
+module Test.Store.Substitutor
   ( spec,
   )
 where
@@ -25,8 +25,8 @@ trueStoreExpr =
 falseStoreExpr :: Monoid ann => StoreExpression ann
 falseStoreExpr =
   StoreExpression
-    (MyVar mempty (mkName "true"))
-    (Bindings $ M.singleton (mkName "true") (exprHash 1))
+    (MyVar mempty "true")
+    (Bindings $ M.singleton "true" (exprHash 1))
     mempty
 
 constExpr :: Monoid ann => StoreExpression ann
@@ -34,11 +34,11 @@ constExpr =
   StoreExpression
     ( MyLambda
         mempty
-        (mkName "a")
+        "a"
         ( MyLambda
             mempty
-            (mkName "b")
-            (MyVar mempty (mkName "a"))
+            "b"
+            (MyVar mempty "a")
         )
     )
     mempty
@@ -46,11 +46,11 @@ constExpr =
 
 maybeDecl :: DataType
 maybeDecl =
-  DataType (mkTyCon "Maybe") [mkName "a"] cons'
+  DataType (mkTyCon "Maybe") ["a"] cons'
   where
     cons' =
       M.fromList
-        [ (mkTyCon "Just", [VarName (mkName "a")]),
+        [ (mkTyCon "Just", [VarName "a"]),
           (mkTyCon "Nothing", [])
         ]
 
@@ -97,11 +97,11 @@ spec = do
         let expr =
               MyLambda
                 mempty
-                (mkName "x")
+                "x"
                 ( MyPair
                     mempty
-                    (MyVar mempty (mkName "x"))
-                    (MyLambda mempty (mkName "x") (MyVar mempty (mkName "x")))
+                    (MyVar mempty "x")
+                    (MyLambda mempty "x" (MyVar mempty "x"))
                 )
             expected =
               MyLambda
@@ -114,8 +114,8 @@ spec = do
                 )
             expectSwaps =
               M.fromList
-                [ (numbered 0, mkName "x"),
-                  (numbered 1, mkName "x")
+                [ (numbered 0, "x"),
+                  (numbered 1, "x")
                 ]
             ans = testSubstitute mempty (StoreExpression expr mempty mempty)
         ans `shouldBe` SubstitutedExpression expectSwaps expected mempty
@@ -141,10 +141,10 @@ spec = do
             expr =
               MyRecord mempty $
                 M.fromList
-                  [ (mkName "first", MyApp mempty (MyVar mempty (mkName "id")) (int 1)),
-                    (mkName "second", MyApp mempty (MyVar mempty (mkName "id")) (int 2))
+                  [ ("first", MyApp mempty (MyVar mempty "id") (int 1)),
+                    ("second", MyApp mempty (MyVar mempty "id") (int 2))
                   ]
-            bindings' = Bindings $ M.singleton (mkName "id") hash
+            bindings' = Bindings $ M.singleton "id" hash
             storeExpr = StoreExpression expr bindings' mempty
             store' = Store (M.singleton hash idExpr)
             expectedId = MyLambda mempty (numbered 0) (MyVar mempty (numbered 0))
@@ -158,8 +158,8 @@ spec = do
           `shouldBe` MyRecord
             mempty
             ( M.fromList
-                [ (mkName "first", MyApp mempty (MyVar mempty (numbered 1)) (int 1)),
-                  (mkName "second", MyApp mempty (MyVar mempty (numbered 1)) (int 2))
+                [ ("first", MyApp mempty (MyVar mempty (numbered 1)) (int 1)),
+                  ("second", MyApp mempty (MyVar mempty (numbered 1)) (int 2))
                 ]
             )
         seScope ans
@@ -172,8 +172,8 @@ spec = do
     $ it "'true' is introduced as a numbered variable"
     $ do
       let hash = exprHash 2
-          expr = MyVar mempty (mkName "true")
-          bindings' = Bindings (M.singleton (mkName "true") hash)
+          expr = MyVar mempty "true"
+          bindings' = Bindings (M.singleton "true" hash)
           storeExpr = StoreExpression expr bindings' mempty
           store' = storeWithBothIn
       let ans = testSubstitute store' storeExpr

--- a/test/Test/Store/UpdateDeps.hs
+++ b/test/Test/Store/UpdateDeps.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Test.UpdateDeps
+module Test.Store.UpdateDeps
   ( spec,
   )
 where
@@ -8,7 +8,7 @@ where
 import Data.Either (isLeft, isRight)
 import qualified Data.Map as M
 import Language.Mimsa.Store.UpdateDeps
-import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Identifiers ()
 import Language.Mimsa.Types.Store
 import Test.Data.Project
 import Test.Hspec
@@ -24,13 +24,12 @@ spec = do
       let storeExpr =
             StoreExpression
               (bool True)
-              (Bindings $ M.singleton (mkName "dog") (ExprHash "1"))
+              (Bindings $ M.singleton "dog" (ExprHash "1"))
               mempty
       updateExprHash storeExpr (ExprHash "1") (ExprHash "2")
         `shouldBe` Bindings
-          ( M.singleton (mkName "dog") (ExprHash "2")
+          ( M.singleton "dog" (ExprHash "2")
           )
-
   describe
     "UpdateDeps"
     $ do
@@ -39,14 +38,14 @@ spec = do
         updateStoreExpressionBindings stdLib mempty storeExpr
           `shouldBe` Right storeExpr
       it "Replacing function with one that doesn't typecheck fails" $ do
-        let storeExpr = getStoreExpression stdLib (getHashOfName stdLib (mkName "incrementInt"))
-        let newHash = getHashOfName stdLib (mkName "id")
-        let newBindings = Bindings (M.singleton (mkName "addInt") newHash)
+        let storeExpr = getStoreExpression stdLib (getHashOfName stdLib "incrementInt")
+        let newHash = getHashOfName stdLib "id"
+        let newBindings = Bindings (M.singleton "addInt" newHash)
         updateStoreExpressionBindings stdLib newBindings storeExpr
           `shouldSatisfy` isLeft
       it "Replacing function with an equivalent one succeeds" $ do
-        let storeExpr = getStoreExpression stdLib (getHashOfName stdLib (mkName "incrementInt"))
-        let newHash = getHashOfName stdLib (mkName "subtractInt")
-        let newBindings = Bindings (M.singleton (mkName "addInt") newHash)
+        let storeExpr = getStoreExpression stdLib (getHashOfName stdLib "incrementInt")
+        let newHash = getHashOfName stdLib "subtractInt"
+        let newBindings = Bindings (M.singleton "addInt" newHash)
         updateStoreExpressionBindings stdLib newBindings storeExpr
           `shouldSatisfy` isRight

--- a/test/Test/Typechecker/Codegen.hs
+++ b/test/Test/Typechecker/Codegen.hs
@@ -5,11 +5,22 @@ module Test.Typechecker.Codegen
   )
 where
 
+import Data.Bifunctor (first)
+import Data.Either (isRight)
+import Data.Functor
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map as M
+import Data.Text (Text)
+import Language.Mimsa.Actions
+import Language.Mimsa.Printer
 import Language.Mimsa.Typechecker.Codegen
 import Language.Mimsa.Types.AST
-import Language.Mimsa.Types.Identifiers ()
+import Language.Mimsa.Types.Error
+import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.ResolvedExpression
+import Test.Data.Project
 import Test.Hspec
+import Test.Utils.Helpers
 
 -- | has no constructors, we can do nothing with this
 dtVoid :: DataType
@@ -32,14 +43,252 @@ dtTrafficLights =
 -- | we can wrap and unwrap maybe?
 dtWrappedString :: DataType
 dtWrappedString =
-  DataType "WrappedString" mempty (M.singleton "Wrapped" [VarName "String"])
+  DataType
+    "WrappedString"
+    mempty
+    (M.singleton "Wrapped" [VarName "String"])
+
+-- | Identity monad
+dtIdentity :: DataType
+dtIdentity =
+  DataType
+    "Identity"
+    ["a"]
+    (M.singleton "Identity" [VarName "a"])
+
+-- | Maybe monad
+dtMaybe :: DataType
+dtMaybe =
+  DataType
+    "Maybe"
+    ["a"]
+    (M.fromList [("Just", [VarName "a"]), ("Nothing", [])])
+
+-- | These monad
+dtThese :: DataType
+dtThese =
+  DataType
+    "These"
+    ["a", "b"]
+    ( M.fromList
+        [ ("This", [VarName "a"]),
+          ("That", [VarName "b"]),
+          ("These", [VarName "a", VarName "b"])
+        ]
+    )
+
+typecheckInstance ::
+  (DataType -> Either Text (Expr Name ())) ->
+  DataType ->
+  Either (Error Annotation) (ResolvedExpression Annotation)
+typecheckInstance mkInstance dt =
+  inst'
+    >>= (\expr -> getTypecheckedStoreExpression (prettyPrint expr) stdLib expr)
+  where
+    inst' =
+      first ParseError (fmap ($> mempty) (mkInstance dt))
 
 spec :: Spec
 spec = do
   describe "Codegen" $ do
-    it "No instances for Void" $ do
-      typeclassMatches dtVoid `shouldBe` mempty
-    it "Enum instance for TrafficLights" $ do
-      typeclassMatches dtTrafficLights `shouldSatisfy` elem Enum
-    it "No enum instance for WrappedString" $ do
-      typeclassMatches dtWrappedString `shouldBe` mempty
+    describe "Enum instances" $ do
+      it "Generates toString for dtTrafficLights" $ do
+        typecheckInstance toString dtTrafficLights `shouldSatisfy` isRight
+        toString dtTrafficLights
+          `shouldBe` Right
+            ( MyLambda
+                mempty
+                "trafficLights"
+                ( MyCaseMatch
+                    mempty
+                    (MyVar mempty "trafficLights")
+                    ( NE.fromList
+                        [ ("Green", str "Green"),
+                          ("Red", str "Red"),
+                          ("Yellow", str "Yellow")
+                        ]
+                    )
+                    Nothing
+                )
+            )
+    describe "Newtype instances" $ do
+      it "Generates wrap for dtWrappedString" $ do
+        typecheckInstance wrap dtWrappedString `shouldSatisfy` isRight
+        wrap dtWrappedString
+          `shouldBe` Right
+            ( MyLambda
+                mempty
+                "a"
+                ( MyConsApp
+                    mempty
+                    (MyConstructor mempty "Wrapped")
+                    (MyVar mempty "a")
+                )
+            )
+      it "Generates unwrap for dtWrappedString" $ do
+        typecheckInstance unwrap dtWrappedString `shouldSatisfy` isRight
+        unwrap dtWrappedString
+          `shouldBe` Right
+            ( MyLambda
+                mempty
+                "wrappedString"
+                ( MyCaseMatch
+                    mempty
+                    (MyVar mempty "wrappedString")
+                    ( pure ("Wrapped", MyLambda mempty "a" (MyVar mempty "a"))
+                    )
+                    Nothing
+                )
+            )
+    describe "Functor instances" $ do
+      it "Generates functorMap for dtIdentity" $ do
+        typecheckInstance functorMap dtIdentity `shouldSatisfy` isRight
+        functorMap dtIdentity
+          `shouldBe` Right
+            ( MyLambda
+                mempty
+                "f"
+                ( MyLambda
+                    mempty
+                    "identity"
+                    ( MyCaseMatch
+                        mempty
+                        (MyVar mempty "identity")
+                        ( pure
+                            ( "Identity",
+                              MyLambda
+                                mempty
+                                "a"
+                                ( MyConsApp
+                                    mempty
+                                    (MyConstructor mempty "Identity")
+                                    ( MyApp
+                                        mempty
+                                        (MyVar mempty "f")
+                                        (MyVar mempty "a")
+                                    )
+                                )
+                            )
+                        )
+                        Nothing
+                    )
+                )
+            )
+      it "Generates functorMap for dtMaybe" $ do
+        typecheckInstance functorMap dtMaybe `shouldSatisfy` isRight
+        functorMap dtMaybe
+          `shouldBe` Right
+            ( MyLambda
+                mempty
+                "f"
+                ( MyLambda
+                    mempty
+                    "maybe"
+                    ( MyCaseMatch
+                        mempty
+                        (MyVar mempty "maybe")
+                        ( NE.fromList
+                            [ ( "Just",
+                                MyLambda
+                                  mempty
+                                  "a"
+                                  ( MyConsApp
+                                      mempty
+                                      (MyConstructor mempty "Just")
+                                      ( MyApp
+                                          mempty
+                                          (MyVar mempty "f")
+                                          (MyVar mempty "a")
+                                      )
+                                  )
+                              ),
+                              ("Nothing", MyConstructor mempty "Nothing")
+                            ]
+                        )
+                        Nothing
+                    )
+                )
+            )
+      it "Generates functorMap for dtThese" $ do
+        typecheckInstance functorMap dtThese `shouldSatisfy` isRight
+        functorMap dtThese
+          `shouldBe` Right
+            ( MyLambda
+                mempty
+                "f"
+                ( MyLambda
+                    mempty
+                    "these"
+                    ( MyCaseMatch
+                        mempty
+                        (MyVar mempty "these")
+                        ( NE.fromList
+                            [ ( "That",
+                                MyLambda
+                                  mempty
+                                  "b"
+                                  ( MyConsApp
+                                      mempty
+                                      (MyConstructor mempty "That")
+                                      ( MyApp
+                                          mempty
+                                          (MyVar mempty "f")
+                                          (MyVar mempty "b")
+                                      )
+                                  )
+                              ),
+                              ( "These",
+                                MyLambda
+                                  mempty
+                                  "a"
+                                  ( MyLambda
+                                      mempty
+                                      "b"
+                                      ( MyConsApp
+                                          mempty
+                                          ( MyConsApp
+                                              mempty
+                                              (MyConstructor mempty "These")
+                                              (MyVar mempty "a")
+                                          )
+                                          ( MyApp
+                                              mempty
+                                              (MyVar mempty "f")
+                                              (MyVar mempty "b")
+                                          )
+                                      )
+                                  )
+                              ),
+                              ( "This",
+                                MyLambda
+                                  mempty
+                                  "a"
+                                  ( MyConsApp
+                                      mempty
+                                      (MyConstructor mempty "This")
+                                      (MyVar mempty "a")
+                                  )
+                              )
+                            ]
+                        )
+                        Nothing
+                    )
+                )
+            )
+    describe "typeclassMatches" $ do
+      it "No instances for Void" $ do
+        typeclassMatches dtVoid `shouldBe` mempty
+      it "Enum instance for TrafficLights" $ do
+        typeclassMatches dtTrafficLights `shouldSatisfy` elem Enum
+      it "No enum instance for WrappedString" $ do
+        typeclassMatches dtWrappedString `shouldNotSatisfy` elem Enum
+      it "Newtype instance for WrappedString" $ do
+        typeclassMatches dtWrappedString `shouldSatisfy` elem Newtype
+      it "Functor instance for Identity" $ do
+        typeclassMatches dtIdentity `shouldSatisfy` elem Functor
+      it "Newtype instance for Identity" $ do
+        typeclassMatches dtIdentity `shouldSatisfy` elem Newtype
+      it "Functor instance for Maybe" $ do
+        typeclassMatches dtMaybe `shouldSatisfy` elem Functor
+      it "No newtype instance for Maybe" $ do
+        typeclassMatches dtMaybe `shouldNotSatisfy` elem Newtype

--- a/test/Test/Typechecker/Codegen.hs
+++ b/test/Test/Typechecker/Codegen.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Typechecker.Codegen
+  ( spec,
+  )
+where
+
+import qualified Data.Map as M
+import Language.Mimsa.Typechecker.Codegen
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Identifiers ()
+import Test.Hspec
+
+dtVoid :: DataType
+dtVoid = DataType "Void" mempty mempty
+
+dtTrafficLights :: DataType
+dtTrafficLights =
+  DataType
+    "TrafficLights"
+    mempty
+    ( M.fromList
+        [ ("Red", mempty),
+          ("Yellow", mempty),
+          ("green", mempty)
+        ]
+    )
+
+spec :: Spec
+spec = do
+  describe "Codegen" $ do
+    it "No instances for Void" $ do
+      typeclassMatches dtVoid `shouldBe` mempty
+    it "Show instance for TrafficLights" $ do
+      typeclassMatches dtTrafficLights `shouldSatisfy` elem Show

--- a/test/Test/Typechecker/Codegen.hs
+++ b/test/Test/Typechecker/Codegen.hs
@@ -46,7 +46,7 @@ dtWrappedString =
   DataType
     "WrappedString"
     mempty
-    (M.singleton "Wrapped" [VarName "String"])
+    (M.singleton "Wrapped" [ConsName "String" mempty])
 
 -- | Identity monad
 dtIdentity :: DataType
@@ -82,9 +82,12 @@ typecheckInstance ::
   DataType ->
   Either (Error Annotation) (ResolvedExpression Annotation)
 typecheckInstance mkInstance dt =
-  inst'
-    >>= (\expr -> getTypecheckedStoreExpression (prettyPrint expr) stdLib expr)
+  (,) <$> newStdLib <*> inst'
+    >>= ( \(stdLib', expr) ->
+            getTypecheckedStoreExpression (prettyPrint expr) stdLib' expr
+        )
   where
+    newStdLib = addBinding (prettyPrint dt <> " in {}") "temporaryAddType" stdLib
     inst' =
       first ParseError (fmap ($> mempty) (mkInstance dt))
 

--- a/test/Test/Typechecker/Codegen.hs
+++ b/test/Test/Typechecker/Codegen.hs
@@ -11,9 +11,11 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers ()
 import Test.Hspec
 
+-- | has no constructors, we can do nothing with this
 dtVoid :: DataType
 dtVoid = DataType "Void" mempty mempty
 
+-- | an enum, we can go to and from a string
 dtTrafficLights :: DataType
 dtTrafficLights =
   DataType
@@ -22,14 +24,22 @@ dtTrafficLights =
     ( M.fromList
         [ ("Red", mempty),
           ("Yellow", mempty),
-          ("green", mempty)
+          ("Green", mempty)
         ]
     )
+
+-- | A newtype around a string
+-- | we can wrap and unwrap maybe?
+dtWrappedString :: DataType
+dtWrappedString =
+  DataType "WrappedString" mempty (M.singleton "Wrapped" [VarName "String"])
 
 spec :: Spec
 spec = do
   describe "Codegen" $ do
     it "No instances for Void" $ do
       typeclassMatches dtVoid `shouldBe` mempty
-    it "Show instance for TrafficLights" $ do
-      typeclassMatches dtTrafficLights `shouldSatisfy` elem Show
+    it "Enum instance for TrafficLights" $ do
+      typeclassMatches dtTrafficLights `shouldSatisfy` elem Enum
+    it "No enum instance for WrappedString" $ do
+      typeclassMatches dtWrappedString `shouldBe` mempty

--- a/test/Test/Typechecker/RecordUsage.hs
+++ b/test/Test/Typechecker/RecordUsage.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Test.RecordUsage
+module Test.Typechecker.RecordUsage
   ( spec,
   )
 where
@@ -52,19 +52,19 @@ spec = do
                   ( MyRecordAccess
                       ()
                       (MyVar () (named "a"))
-                      (mkName "one")
+                      "one"
                   )
                   ( MyRecordAccess
                       ()
                       (MyVar () (named "a"))
-                      (mkName "two")
+                      "two"
                   )
               )
       getRecordUsages expr'
         `shouldBe` CombineMap
           ( M.fromList
               [ ( named "a",
-                  S.fromList [mkName "one", mkName "two"]
+                  S.fromList ["one", "two"]
                 )
               ]
           )

--- a/test/Test/Typechecker/TypeError.hs
+++ b/test/Test/Typechecker/TypeError.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Test.TypeError
+module Test.Typechecker.TypeError
   ( spec,
   )
 where

--- a/test/Test/Typechecker/Typechecker.hs
+++ b/test/Test/Typechecker/Typechecker.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Test.Typechecker
+module Test.Typechecker.Typechecker
   ( spec,
   )
 where
@@ -14,7 +14,6 @@ import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Typechecker
 import Test.Hspec
-import Test.QuickCheck.Instances ()
 import Test.Utils.Helpers
 
 exprs :: (Monoid ann) => [(Expr Variable ann, Either TypeError MonoType)]
@@ -139,16 +138,16 @@ exprs =
     ( MyRecord
         mempty
         ( M.fromList
-            [ (mkName "dog", int 1),
-              (mkName "cat", int 2)
+            [ ("dog", int 1),
+              ("cat", int 2)
             ]
         ),
       Right $
         MTRecord
           mempty
           ( M.fromList
-              [ (mkName "dog", MTPrim mempty MTInt),
-                (mkName "cat", MTPrim mempty MTInt)
+              [ ("dog", MTPrim mempty MTInt),
+                ("cat", MTPrim mempty MTInt)
               ]
           )
     ),
@@ -160,7 +159,7 @@ exprs =
             ( MyRecordAccess
                 mempty
                 (MyVar mempty (named "i"))
-                (mkName "dog")
+                "dog"
             )
             (int 1)
             (int 2)
@@ -170,7 +169,7 @@ exprs =
           mempty
           ( MTRecord mempty $
               M.singleton
-                (mkName "dog")
+                "dog"
                 (MTPrim mempty MTBool)
           )
           (MTPrim mempty MTInt)
@@ -223,7 +222,3 @@ spec =
               (MTPrim mempty MTInt)
           )
       startInference mempty mempty expr `shouldBe` Right (MTPrim mempty MTInt)
-{-  describe "Serialisation" $ do
-it "Round trip" $ do
-  property $ \x -> JSON.decode (JSON.encode x) == (Just x :: Maybe Expr)
--}

--- a/test/Test/Typechecker/Unify.hs
+++ b/test/Test/Typechecker/Unify.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Test.Unify
+module Test.Typechecker.Unify
   ( spec,
   )
 where
@@ -13,7 +13,7 @@ import qualified Data.Map as M
 import Language.Mimsa.Typechecker.TcMonad
 import Language.Mimsa.Typechecker.Unify
 import Language.Mimsa.Types.Error
-import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Identifiers ()
 import Language.Mimsa.Types.Typechecker
 import Test.Hspec
 import Test.Utils.Helpers
@@ -53,13 +53,13 @@ spec =
       runUnifier
         ( MTRecord mempty $
             M.fromList
-              [ (mkName "one", MTPrim mempty MTInt),
-                (mkName "two", MTVar mempty (tvFree 1))
+              [ ("one", MTPrim mempty MTInt),
+                ("two", MTVar mempty (tvFree 1))
               ],
           MTRecord mempty $
             M.fromList
-              [ (mkName "one", MTVar mempty (tvFree 2)),
-                (mkName "two", MTPrim mempty MTBool)
+              [ ("one", MTVar mempty (tvFree 2)),
+                ("two", MTPrim mempty MTBool)
               ]
         )
         `shouldBe` Right


### PR DESCRIPTION
This adds auto-generated instances for `enum`, `newtype` and basic `functor`.

It works using the `bindType` command in the repl, and creates a binding matching the typename with a record of functions in it. For example:

```haskell
:> :bindType type TrafficLights = Green | Yellow | Red
```

would create the `TrafficLights` type, and a `trafficLights` binding, which is a record containing one function `toString`, of type `TrafficLights -> String`. This would override any previous binding on this name, which is bad but also YOLO because everything is immutable.

Part 2 will be make a bind type endpoint and change datatypes to be stored as `DataType` JSON files rather than `type MyDataType in {.....}` store expressions which could get a bit messy.