### PR TITLE
Functor for Reader

### DIFF
--- a/test/Test/Typechecker/Codegen.hs
+++ b/test/Test/Typechecker/Codegen.hs
@@ -549,7 +549,7 @@ spec = do
                 (MyVar mempty "fmap")
             )
       it "Generates functorMap for dtReader" $ do
-        -- typecheckInstance functorMap dtReader `shouldSatisfy` isRight
+        typecheckInstance functorMap dtReader `shouldSatisfy` isRight
         functorMap dtReader
           `shouldBe` Right
             ( MyLet

--- a/test/Test/Typechecker/Codegen.hs
+++ b/test/Test/Typechecker/Codegen.hs
@@ -126,6 +126,19 @@ dtTree =
         ]
     )
 
+dtReader :: DataType
+dtReader =
+  DataType
+    "Reader"
+    ["r", "a"]
+    ( M.singleton
+        "Reader"
+        [ TNFunc
+            (VarName "r")
+            (VarName "a")
+        ]
+    )
+
 typecheckInstance ::
   (DataType -> Either Text (Expr Name ())) ->
   DataType ->
@@ -535,6 +548,53 @@ spec = do
                 )
                 (MyVar mempty "fmap")
             )
+      it "Generates functorMap for dtReader" $ do
+        -- typecheckInstance functorMap dtReader `shouldSatisfy` isRight
+        functorMap dtReader
+          `shouldBe` Right
+            ( MyLet
+                mempty
+                "fmap"
+                ( MyLambda
+                    mempty
+                    "f"
+                    ( MyLambda
+                        mempty
+                        "reader"
+                        ( MyCaseMatch
+                            mempty
+                            (MyVar mempty "reader")
+                            ( pure
+                                ( "Reader",
+                                  MyLambda
+                                    mempty
+                                    "rtoa"
+                                    ( MyConsApp
+                                        mempty
+                                        (MyConstructor mempty "Reader")
+                                        ( MyLambda
+                                            mempty
+                                            "r"
+                                            ( MyApp
+                                                mempty
+                                                (MyVar mempty "f")
+                                                ( MyApp
+                                                    mempty
+                                                    (MyVar mempty "rtoa")
+                                                    (MyVar mempty "r")
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                            Nothing
+                        )
+                    )
+                )
+                (MyVar mempty "fmap")
+            )
+
     describe "typeclassMatches" $ do
       it "No instances for Void" $ do
         typeclassMatches dtVoid `shouldBe` mempty


### PR DESCRIPTION
Allows `functor` to be generated for types like `type Reader r a = Reader (r -> a)`