### PR TITLE
Fix Env applicative

### DIFF
--- a/test/Test/Actions.hs
+++ b/test/Test/Actions.hs
@@ -274,3 +274,7 @@ spec = do
       it "Should bind ConsoleF without breaking" $ do
         let action = Actions.bindType (prettyPrint dtConsoleF) dtConsoleF
         Actions.run stdLib action `shouldSatisfy` isRight
+
+      it "Should bind Env without breaking" $ do
+        let action = Actions.bindType (prettyPrint dtEnv) dtEnv
+        Actions.run stdLib action `shouldSatisfy` isRight

--- a/test/Test/Typechecker/Codegen.hs
+++ b/test/Test/Typechecker/Codegen.hs
@@ -39,3 +39,5 @@ spec = do
       typeclassMatches dtMaybe `shouldSatisfy` elem Functor
     it "No newtype instance for Maybe" $ do
       typeclassMatches dtMaybe `shouldNotSatisfy` elem Newtype
+    it "Instances for Env" $ do
+      typeclassMatches dtEnv `shouldBe` [Functor, Foldable]

--- a/test/Test/Typechecker/Codegen/Applicative.hs
+++ b/test/Test/Typechecker/Codegen/Applicative.hs
@@ -63,6 +63,9 @@ spec = do
             ( unsafeParse
                 "\\a -> Reader \\r -> a"
             )
+      it "Does not generate pure for dtEnv" $ do
+        applicativePure dtEnv `shouldSatisfy` isLeft
+
     describe "apply instances" $ do
       it "Generates apply for dtIdentity" $ do
         typecheckInstance applicativeApply dtIdentity `shouldSatisfy` isRight
@@ -116,6 +119,16 @@ spec = do
                   <> "This \\a1 -> This a1) | "
                   <> "This \\a1 -> This a1"
             )
+      it "Generates apply for dtEnv" $ do
+        typecheckInstance applicativeApply dtEnv `shouldSatisfy` isRight
+        applicativeApply dtEnv
+          `shouldBe` Right
+            ( unsafeParse $
+                "\\envF -> \\envA -> "
+                  <> "case envF of Env \\w -> \\f -> "
+                  <> "case envA of Env \\w -> \\a -> Env w f(a)"
+            )
+
       it "Does not make apply for dtConsoleF" $ do
         applicativeApply dtConsoleF `shouldSatisfy` isLeft
       it "Does not make apply for dtReader" $ do

--- a/test/Test/Typechecker/Codegen/Foldable.hs
+++ b/test/Test/Typechecker/Codegen/Foldable.hs
@@ -48,3 +48,12 @@ spec = do
                 <> "Nil total; "
                 <> "fold"
           )
+    it "Generates fold for dtEnv" $ do
+      typecheckInstance fold dtEnv `shouldSatisfy` isRight
+      fold dtEnv
+        `shouldBe` Right
+          ( unsafeParse $
+              "let fold = \\f -> \\total -> \\env -> "
+                <> " case env of Env \\w -> \\a -> f(total)(a); "
+                <> "fold"
+          )

--- a/test/Test/Typechecker/Codegen/Functor.hs
+++ b/test/Test/Typechecker/Codegen/Functor.hs
@@ -80,3 +80,12 @@ spec = do
                 <> "Reader \\rtoa -> Reader \\r -> f(rtoa(r)); "
                 <> "fmap"
           )
+    it "Generates functorMap for dtEnv" $ do
+      typecheckInstance functorMap dtEnv `shouldSatisfy` isRight
+      functorMap dtEnv
+        `shouldBe` Right
+          ( unsafeParse $
+              "let fmap = \\f -> \\env -> case env of "
+                <> "Env \\w -> \\a -> Env w f(a); "
+                <> "fmap"
+          )

--- a/test/Test/Typechecker/Codegen/Shared.hs
+++ b/test/Test/Typechecker/Codegen/Shared.hs
@@ -17,6 +17,7 @@ module Test.Typechecker.Codegen.Shared
     dtReader,
     dtMatchedPair,
     dtConsoleF,
+    dtEnv,
   )
 where
 
@@ -179,6 +180,13 @@ dtConsoleF =
 
 dtPair :: DataType
 dtPair = DataType "Pair" ["a", "b"] (M.singleton "Pair" [VarName "a", VarName "b"])
+
+dtEnv :: DataType
+dtEnv =
+  DataType
+    "Env"
+    ["w", "a"]
+    (M.singleton "Env" [VarName "w", VarName "a"])
 
 typecheckInstance ::
   (DataType -> Either Text (Expr Name ())) ->

--- a/test/golden/PrettyPrint/ff23d4a62c2b22ef78a4f7c4fbff03ce163885f3317d3c39a2a6ac5dfa90228f.mimsa
+++ b/test/golden/PrettyPrint/ff23d4a62c2b22ef78a4f7c4fbff03ce163885f3317d3c39a2a6ac5dfa90228f.mimsa
@@ -1,0 +1,4 @@
+type Env w a 
+  = Env w
+        a;
+True

--- a/test/golden/StoreExpr/ff23d4a62c2b22ef78a4f7c4fbff03ce163885f3317d3c39a2a6ac5dfa90228f.json
+++ b/test/golden/StoreExpr/ff23d4a62c2b22ef78a4f7c4fbff03ce163885f3317d3c39a2a6ac5dfa90228f.json
@@ -1,0 +1,1 @@
+{"storeExpression":{"tag":"MyData","contents":[[],{"dtConstructors":{"Env":[{"tag":"VarName","contents":"w"},{"tag":"VarName","contents":"a"}]},"dtName":"Env","dtVars":["w","a"]},{"tag":"MyLiteral","contents":[[],{"tag":"MyBool","contents":true}]}]},"storeBindings":{},"storeTypeBindings":{}}


### PR DESCRIPTION
`type Env w a = Env w a` was returning 

```
ResolverError:
A binding for w could not be found in [  ]
```

due to it creating a broken Applicative `pure` instance.