### PR TITLE
Pretty printer improvements

### DIFF
--- a/src/Language/Mimsa/Parser/Language.hs
+++ b/src/Language/Mimsa/Parser/Language.hs
@@ -104,24 +104,13 @@ letPairParser =
           name <- withOptionalSpace nameParser
           _ <- thenSpace (string ")")
           pure name
-     in MyLetPair
-          mempty
-          <$> binder1
-          <*> binder2
-          <*> equalsParser
-          <*> inParser
-
------
-
-equalsParser :: Parser ParserExpr
-equalsParser = do
-  _ <- thenSpace (string "=")
-  thenSpace expressionParser
-
-inParser :: Parser ParserExpr
-inParser = do
-  _ <- thenSpace (string "in")
-  expressionParser
+     in do
+          bindA <- binder1
+          bindB <- binder2
+          _ <- thenSpace (string "=")
+          expr <- expressionParser
+          _ <- withOptionalSpace (string ";" <|> string "in ")
+          MyLetPair mempty bindA bindB expr <$> expressionParser
 
 -----
 
@@ -358,5 +347,5 @@ defineInfixParser = addLocation $ do
   infixOp <- thenSpace infixOpParser
   _ <- thenSpace (string "=")
   boundName <- nameParser
-  _ <- withOptionalSpace (string ";")
+  _ <- withOptionalSpace (string ";" <|> string "in ")
   MyDefineInfix mempty infixOp boundName <$> expressionParser

--- a/src/Language/Mimsa/Types/AST/DataType.hs
+++ b/src/Language/Mimsa/Types/AST/DataType.hs
@@ -45,16 +45,17 @@ renderDataType (DataType tyCon vars' constructors') =
     <+> if M.null constructors'
       then mempty
       else
-        line
-          <> indent
-            2
-            ( align $
-                vsep $
-                  zipWith
-                    (<+>)
-                    ("=" : repeat "|")
-                    (printCons <$> M.toList constructors')
-            )
+        group $
+          line
+            <> indent
+              2
+              ( align $
+                  vsep $
+                    zipWith
+                      (<+>)
+                      ("=" : repeat "|")
+                      (printCons <$> M.toList constructors')
+              )
   where
     printVars [] = mempty
     printVars as = space <> sep (renderName <$> as)

--- a/src/Language/Mimsa/Types/AST/Expr.hs
+++ b/src/Language/Mimsa/Types/AST/Expr.hs
@@ -281,7 +281,8 @@ prettyLet var expr1 expr2 =
   group
     ( "let" <+> prettyDoc var
         <+> "="
-        <+> prettyDoc expr1
+        <> line
+        <> indentMulti 2 (prettyDoc expr1)
         <> newlineOrIn
         <> prettyDoc expr2
     )
@@ -298,7 +299,8 @@ prettyLetPair var1 var2 expr1 body =
     ( "let" <+> "(" <> prettyDoc var1 <> "," <+> prettyDoc var2
         <> ")"
         <+> "="
-        <+> printSubExpr expr1
+        <> line
+        <> indentMulti 2 (printSubExpr expr1)
         <> newlineOrIn
         <> printSubExpr body
     )
@@ -320,6 +322,18 @@ prettyDefineInfix infixOp bindName expr =
         <+> prettyDoc bindName
         <> newlineOrIn
         <> prettyDoc expr
+    )
+
+prettyPair :: (Printer var, Show var) => Expr var ann -> Expr var ann -> Doc style
+prettyPair a b =
+  group
+    ( "("
+        <> align
+          ( vsep
+              [ printSubExpr a <> ",",
+                printSubExpr b <> ")"
+              ]
+          )
     )
 
 instance (Show var, Printer var) => Printer (Expr var ann) where
@@ -363,11 +377,7 @@ instance (Show var, Printer var) => Printer (Expr var ann) where
           )
       ]
   prettyDoc (MyPair _ a b) =
-    "("
-      <> printSubExpr a
-      <> ","
-      <+> printSubExpr b
-      <> ")"
+    prettyPair a b
   prettyDoc (MyRecord _ map') = encloseSep lbrace rbrace comma exprs'
     where
       exprs' =

--- a/test/Test/Prettier.hs
+++ b/test/Test/Prettier.hs
@@ -5,8 +5,11 @@ module Test.Prettier
   )
 where
 
+import Data.Functor (($>))
 import qualified Data.Map as M
+import Data.Text (Text)
 import qualified Data.Text.IO as T
+import Language.Mimsa.Parser
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
@@ -14,10 +17,15 @@ import Language.Mimsa.Types.Typechecker
 import Test.Hspec
 import Test.Utils.Helpers
 
+unsafeParseExpr :: Text -> Expr Name ()
+unsafeParseExpr t = case parseExpr t of
+  Right a -> a $> ()
+  Left _ -> error "Error parsing expr for Prettier tests"
+
 spec :: Spec
 spec =
   describe "Prettier" $ do
-    describe "Expr" $
+    describe "Expr" $ do
       it "Cons with infix" $
         do
           let expr' :: Expr Name ()
@@ -28,6 +36,12 @@ spec =
                   (MyInfix mempty Equals (int 1) (int 1))
           prettyPrint expr'
             `shouldBe` "Some (1 == 1)"
+      it "Many + operators" $ do
+        let expr' :: Expr Name ()
+            expr' = unsafeParseExpr "1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10"
+        let doc = prettyDoc expr'
+        renderWithWidth 50 doc `shouldBe` "1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10"
+        renderWithWidth 5 doc `shouldBe` "1 + 2\n  + 3\n  + 4\n  + 5\n  + 6\n  + 7\n  + 8\n  + 9\n  + 10"
     describe
       "MonoType"
       $ do

--- a/test/Test/Prettier.hs
+++ b/test/Test/Prettier.hs
@@ -71,6 +71,24 @@ spec =
         renderWithWidth 50 doc `shouldBe` "(\"horseshorseshorses1\", \"horseshorseshorses2\")"
         renderWithWidth 5 doc `shouldBe` "(\"horseshorseshorses1\",\n \"horseshorseshorses2\")"
 
+      it "Renders empty record nicely" $ do
+        let expr' = unsafeParseExpr "{}"
+            doc = prettyDoc expr'
+        renderWithWidth 50 doc `shouldBe` "{}"
+        renderWithWidth 5 doc `shouldBe` "{}"
+
+      it "Renders records nicely" $ do
+        let expr' = unsafeParseExpr "{a:1,b:2,c:3,d:4,e:5}"
+            doc = prettyDoc expr'
+        renderWithWidth 50 doc `shouldBe` "{ a: 1, b: 2, c: 3, d: 4, e: 5 }"
+        renderWithWidth 5 doc `shouldBe` "{ a: 1,\n  b: 2,\n  c: 3,\n  d: 4,\n  e: 5 }"
+
+      it "Renders if nicely" $ do
+        let expr' = unsafeParseExpr "if True then 1 else 2"
+            doc = prettyDoc expr'
+        renderWithWidth 50 doc `shouldBe` "if True then 1 else 2"
+        renderWithWidth 4 doc `shouldBe` "if True\nthen\n  1\nelse\n  2"
+
     describe
       "MonoType"
       $ do

--- a/test/Test/Prettier.hs
+++ b/test/Test/Prettier.hs
@@ -51,13 +51,13 @@ spec =
         let expr' = unsafeParseExpr "let a = 1; a"
             doc = prettyDoc expr'
         renderWithWidth 50 doc `shouldBe` "let a = 1 in a"
-        renderWithWidth 5 doc `shouldBe` "let a = 1;\n\na"
+        renderWithWidth 5 doc `shouldBe` "let a =\n  1;\n\na"
 
       it "Line between let pair bindings" $ do
         let expr' = unsafeParseExpr "let (a,b) = ((1,2)); a"
             doc = prettyDoc expr'
         renderWithWidth 50 doc `shouldBe` "let (a, b) = ((1, 2)) in a"
-        renderWithWidth 5 doc `shouldBe` "let (a, b) = ((1, 2));\n\na"
+        renderWithWidth 5 doc `shouldBe` "let (a, b) =\n  ((1,\n    2));\n\na"
 
       it "Line between infix bindings" $ do
         let expr' = unsafeParseExpr "infix >> = compose in a"

--- a/test/Test/Prettier.hs
+++ b/test/Test/Prettier.hs
@@ -89,6 +89,12 @@ spec =
         renderWithWidth 50 doc `shouldBe` "if True then 1 else 2"
         renderWithWidth 4 doc `shouldBe` "if True\nthen\n  1\nelse\n  2"
 
+      it "Renders datatype nicely with two line break" $ do
+        let expr' = unsafeParseExpr "type These a = That a in 1"
+            doc = prettyDoc expr'
+        renderWithWidth 50 doc `shouldBe` "type These a    = That a in 1"
+        renderWithWidth 5 doc `shouldBe` "type These a \n  = That\n  a;\n\n1"
+
     describe
       "MonoType"
       $ do


### PR DESCRIPTION
Resolves #169 

Before:

```haskell
type These a b 
  = That b
  | These a
          b
  | This a;
let matchThese = \these ->
   case these of 
       This (\a ->
        a)
     | That (\b ->
        b)
     | These (\a ->
        \b ->
           a <> b);
infix >> = compose;
let addStr = \s ->
   s <> s;
let exclaim = \s ->
   s <> "!!!";
let d = (1, 2);
let cc = if True
  then "horsesdfsdfsdfsdfs"
  else "courssdfsdfsdfsdfes";
let bb = if True
  then ({bat: 100
  ,cat: 2
  ,dog: 100
  ,sadness: "NON"})
  else ({bat: 100
  ,cat: 2
  ,dog: 1
  ,sadness: "NEVERENDING"});
let f = addStr >> exclaim >> addStr
>>
exclaim
>>
exclaim;
f("dog")
```

after:

```haskell
type These a b 
  = That b
  | These a
          b
  | This a;

let matchThese =
  \these ->
    case these of 
        This (\a -> a)
      | That (\b -> b)
      | These (\a -> \b -> a <> b);

infix >> = compose;

let addStr =
  \s -> s <> s;

let exclaim =
  \s -> s <> "!!!";

let d =
  (1, 2);

let cc =
  if True
  then
    "horsesdfsdfsdfsdfs"
  else
    "courssdfsdfsdfsdfes";

let bb =
  if True
  then
    ({ bat: 100,
       cat: 2,
       dog: 100,
       sadness: "NON" })
  else
    ({ bat: 100,
       cat: 2,
       dog: 1,
       sadness: "NEVERENDING" });

let f =
  addStr >> exclaim
         >> addStr
         >> exclaim
         >> exclaim;

f("dog")
```