### PR TITLE
Compile by hash

### DIFF
--- a/src/Language/Mimsa/Project/Helpers.hs
+++ b/src/Language/Mimsa/Project/Helpers.hs
@@ -5,6 +5,7 @@ module Language.Mimsa.Project.Helpers
     fromType,
     fromUnitTest,
     fromStoreExpression,
+    fromStore,
     findBindingNameForExprHash,
     lookupExprHash,
     bindingsToVersioned,
@@ -88,6 +89,9 @@ fromUnitTest test storeExpr =
     { prjUnitTests = M.singleton (utExprHash test) test,
       prjStore = Store $ M.singleton (getStoreExpressionHash storeExpr) storeExpr
     }
+
+fromStore :: Store ann -> Project ann
+fromStore store' = mempty {prjStore = store'}
 
 lookupExprHash :: Project ann -> ExprHash -> Maybe (StoreExpression ann)
 lookupExprHash project exprHash' =

--- a/src/Language/Mimsa/Project/Persistence.hs
+++ b/src/Language/Mimsa/Project/Persistence.hs
@@ -8,6 +8,7 @@ module Language.Mimsa.Project.Persistence
     saveProjectInStore,
     getCurrentBindings,
     getCurrentTypeBindings,
+    recursiveLoadBoundExpressions,
   )
 where
 

--- a/src/Language/Mimsa/Server/Compile.hs
+++ b/src/Language/Mimsa/Server/Compile.hs
@@ -51,17 +51,17 @@ data CompileExpressionRequest = CompileExpressionRequest
   }
   deriving (Eq, Ord, Show, Generic, JSON.FromJSON, ToSchema)
 
-newtype CompileExpressionResponse = CompileExpressionResponse LBS.ByteString
+newtype ZipFileResponse = ZipFileResponse LBS.ByteString
   deriving newtype (MimeRender OctetStream)
 
-instance ToSchema CompileExpressionResponse where
+instance ToSchema ZipFileResponse where
   declareNamedSchema _cer = pure (NamedSchema Nothing binarySchema)
 
 -- return type of a ZIP file download with a filename in it's header
 type CompileResponse =
   ( Headers
       '[Header "Content-Disposition" String]
-      CompileExpressionResponse
+      ZipFileResponse
   )
 
 type CompileExpression =
@@ -85,7 +85,7 @@ compileExpressionEndpoint
     let filename = "mimsa-" <> show rootExprHash <> ".zip"
         contentDisposition = "attachment; filename=\"" <> filename <> "\""
     bs <- doCreateZipFile mimsaEnv runtime exprHashes rootExprHash
-    pure (addHeader contentDisposition (CompileExpressionResponse bs))
+    pure (addHeader contentDisposition (ZipFileResponse bs))
 
 -----
 
@@ -99,7 +99,7 @@ newtype CompileHashRequest = CompileHashRequest
 type CompileHashResponse =
   ( Headers
       '[Header "Content-Disposition" String]
-      CompileExpressionResponse
+      ZipFileResponse
   )
 
 type CompileHash =
@@ -127,7 +127,7 @@ compileHashEndpoint
     let filename = "mimsa-" <> show rootExprHash <> ".zip"
         contentDisposition = "attachment; filename=\"" <> filename <> "\""
     bs <- doCreateZipFile mimsaEnv runtime exprHashes rootExprHash
-    pure (addHeader contentDisposition (CompileExpressionResponse bs))
+    pure (addHeader contentDisposition (ZipFileResponse bs))
 
 -----
 

--- a/src/Language/Mimsa/Server/Compile.hs
+++ b/src/Language/Mimsa/Server/Compile.hs
@@ -10,6 +10,7 @@ module Language.Mimsa.Server.Compile (CompileAPI, compileEndpoints) where
 
 import qualified Data.Aeson as JSON
 import qualified Data.ByteString.Lazy as LBS
+import Data.Functor
 import qualified Data.Map as M
 import Data.Set (Set)
 import Data.Swagger (NamedSchema (..), ToSchema, binarySchema, declareNamedSchema)
@@ -19,6 +20,8 @@ import qualified Language.Mimsa.Actions.Compile as Actions
 import Language.Mimsa.Backend.Javascript
 import Language.Mimsa.Backend.Runtimes
 import Language.Mimsa.Backend.ZipFile
+import Language.Mimsa.Printer
+import Language.Mimsa.Project
 import Language.Mimsa.Server.Handlers
 import Language.Mimsa.Server.Helpers
 import Language.Mimsa.Server.Types
@@ -30,21 +33,16 @@ import Servant
 
 type CompileAPI =
   "compile"
-    :> CompileExpression
+    :> (CompileExpression :<|> CompileHash)
 
 compileEndpoints ::
   MimsaEnvironment ->
   Server CompileAPI
-compileEndpoints =
-  compileExpressionEndpoint
+compileEndpoints mimsaEnv =
+  compileExpressionEndpoint mimsaEnv
+    :<|> compileHashEndpoint mimsaEnv
 
-newtype CompileExpressionResponse = CompileExpressionResponse LBS.ByteString
-  deriving newtype (MimeRender OctetStream)
-
-instance ToSchema CompileExpressionResponse where
-  declareNamedSchema _cer = pure (NamedSchema Nothing binarySchema)
-
-------
+-----
 
 data CompileExpressionRequest = CompileExpressionRequest
   { ceProjectHash :: ProjectHash,
@@ -52,6 +50,12 @@ data CompileExpressionRequest = CompileExpressionRequest
     ceRuntime :: RuntimeName
   }
   deriving (Eq, Ord, Show, Generic, JSON.FromJSON, ToSchema)
+
+newtype CompileExpressionResponse = CompileExpressionResponse LBS.ByteString
+  deriving newtype (MimeRender OctetStream)
+
+instance ToSchema CompileExpressionResponse where
+  declareNamedSchema _cer = pure (NamedSchema Nothing binarySchema)
 
 -- return type of a ZIP file download with a filename in it's header
 type CompileResponse =
@@ -82,6 +86,50 @@ compileExpressionEndpoint
         contentDisposition = "attachment; filename=\"" <> filename <> "\""
     bs <- doCreateZipFile mimsaEnv runtime exprHashes rootExprHash
     pure (addHeader contentDisposition (CompileExpressionResponse bs))
+
+-----
+
+newtype CompileHashRequest = CompileHashRequest
+  { chExprHash :: ExprHash
+  }
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving anyclass (JSON.FromJSON, ToSchema)
+
+-- return type of a ZIP file download with a filename in it's header
+type CompileHashResponse =
+  ( Headers
+      '[Header "Content-Disposition" String]
+      CompileExpressionResponse
+  )
+
+type CompileHash =
+  "hash"
+    :> ReqBody '[JSON] CompileHashRequest
+    :> Post
+         '[OctetStream]
+         CompileHashResponse
+
+compileHashEndpoint ::
+  MimsaEnvironment ->
+  CompileHashRequest ->
+  Handler CompileHashResponse
+compileHashEndpoint
+  mimsaEnv
+  (CompileHashRequest exprHash) = do
+    store <- storeFromExprHashHandler mimsaEnv exprHash
+    let project = fromStore store $> mempty
+    pd <- projectDataHandler mimsaEnv project
+    expr <- findExprHandler project exprHash
+    let input = prettyPrint (storeExpression expr)
+    runtime <- getRuntime (RuntimeName "export")
+    (_, (rootExprHash, exprHashes)) <-
+      fromActionM mimsaEnv (pdHash pd) (Actions.compile runtime input (storeExpression expr))
+    let filename = "mimsa-" <> show rootExprHash <> ".zip"
+        contentDisposition = "attachment; filename=\"" <> filename <> "\""
+    bs <- doCreateZipFile mimsaEnv runtime exprHashes rootExprHash
+    pure (addHeader contentDisposition (CompileExpressionResponse bs))
+
+-----
 
 getRuntime :: RuntimeName -> Handler (Runtime Javascript)
 getRuntime runtimeName =


### PR DESCRIPTION
To help test the deployment feature, this adds an endpoint that compiles simply by the hash, no need for project context or anything.