### PR TITLE
Pattern matching sloppiness fix

### DIFF
--- a/compiler/src/Language/Mimsa/Typechecker/Infer.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Infer.hs
@@ -358,7 +358,7 @@ inferPatternMatch env ann expr patterns = do
   -- match patterns with match expr
   s3 <- unify tyMatchedPattern (applySubst (s2 <> subs) tyExpr)
   -- combine all output expr types
-  (s4, tyMatchedExprs) <- matchList (applySubst s3 <$> (getC <$> tyPatterns))
+  (s4, tyMatchedExprs) <- matchList (applySubst (subs <> s3) <$> (getC <$> tyPatterns))
   -- get all the subs we've learned about
   let allSubs = s4 <> s3 <> s2 <> subs <> s1
   -- perform exhaustiveness checking at end so it doesn't mask more basic errors

--- a/compiler/test/Test/Typechecker/Typechecker.hs
+++ b/compiler/test/Test/Typechecker/Typechecker.hs
@@ -545,6 +545,29 @@ spec = do
                 MTPrim mempty MTBool
               ]
           )
+    it "Typechecking pattern matching after lambda" $ do
+      let expr =
+            MyData
+              mempty
+              dtMaybe
+              ( MyLambda
+                  mempty
+                  (named "maybe")
+                  ( MyPatternMatch
+                      mempty
+                      (MyVar mempty (named "maybe"))
+                      [ ( PConstructor mempty "Just" [PVar mempty (named "a")],
+                          MyVar mempty (named "a")
+                        ),
+                        ( PWildcard mempty,
+                          MyVar mempty (named "maybe")
+                        )
+                      ]
+                  )
+              )
+      startInference mempty mempty expr
+        `shouldSatisfy` isLeft
+
     it "Simpler Either example" $ do
       let expr =
             MyData


### PR DESCRIPTION
This typechecked, and should not have done:

```haskell
\a -> match a with (Just b) -> b | _ -> a
```

This makes `b` === `Just b`, which is nonsense.