### PR TITLE
ES modules backend

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -28,7 +28,7 @@ you should then see:
 :bind <name> = <expr> - binds <expr> to <name> and saves it in the environment
 :bindType type Either a b = Left a | Right b - binds a new type and saves it in the environment
 :list - show a list of current bindings in the environment
-:outputJS <expr> - show JS code for <expr>
+:outputJS <commonjs|es-modules> <expr> - show JS code for <expr>
 :tree <expr> - draw a dependency tree for <expr>
 :graph <expr> - output graphviz dependency tree for <expr>
 :search <mt> - search for exprs that match type

--- a/compiler/mimsa.cabal
+++ b/compiler/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 339a9f244c3164089cb6447c0e9047778bd252b927c915d63b582871790e14bf
+-- hash: a1cdc718ee9820a1322f5046e2939e3535b551547adc224a927c0d4c97cd5765
 
 name:           mimsa
 version:        0.1.0.0
@@ -375,6 +375,7 @@ test-suite mimsa-test
     , envy
     , exceptions
     , file-embed
+    , hashable
     , haskeline
     , hspec
     , http-types

--- a/compiler/mimsa.cabal
+++ b/compiler/mimsa.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 382c31d4da6ae02fcf7998c5efc0ea2c7ea6bf0674e267d58e16cbc1453f963f
+-- hash: 339a9f244c3164089cb6447c0e9047778bd252b927c915d63b582871790e14bf
 
 name:           mimsa
 version:        0.1.0.0
@@ -327,6 +327,7 @@ test-suite mimsa-test
       Test.Actions.Evaluate
       Test.Actions.RemoveBinding
       Test.Backend.BackendJS
+      Test.Backend.RunNode
       Test.Backend.Runtimes
       Test.Codegen
       Test.Codegen.Applicative
@@ -392,6 +393,7 @@ test-suite mimsa-test
     , stm
     , text
     , transformers
+    , typed-process
     , wai
     , wai-cors
     , warp

--- a/compiler/package.yaml
+++ b/compiler/package.yaml
@@ -86,4 +86,5 @@ tests:
     dependencies:
     - mimsa
     - hspec
+    - hashable
     - typed-process

--- a/compiler/package.yaml
+++ b/compiler/package.yaml
@@ -86,3 +86,4 @@ tests:
     dependencies:
     - mimsa
     - hspec
+    - typed-process

--- a/compiler/src/Language/Mimsa/Actions/Compile.hs
+++ b/compiler/src/Language/Mimsa/Actions/Compile.hs
@@ -76,7 +76,7 @@ transpileModule be se = do
   dataTypes <- liftEither $ first StoreErr (resolveTypeDeps (prjStore project) (storeTypeBindings se))
   let path = Actions.SavePath (T.pack $ transpiledModuleOutputPath be)
   let filename = Actions.SaveFilename (moduleFilename be (getStoreExpressionHash se))
-  js <- liftEither $ first BackendErr (outputCommonJS dataTypes se)
+  js <- liftEither $ first BackendErr (outputJavascript be dataTypes se)
   let jsOutput = Actions.SaveContents (coerce js)
   Actions.appendWriteFile path filename jsOutput
 
@@ -86,8 +86,9 @@ transpileModule be se = do
 createIndex ::
   Runtime Javascript -> ExprHash -> Actions.ActionM ()
 createIndex runtime exprHash = do
-  let path = Actions.SavePath (T.pack $ transpiledIndexOutputPath (rtBackend runtime))
-      outputContent = Actions.SaveContents (coerce $ outputIndexFile runtime exprHash)
+  let be = rtBackend runtime
+      path = Actions.SavePath (T.pack $ transpiledIndexOutputPath be)
+      outputContent = Actions.SaveContents (coerce $ outputIndexFile be runtime exprHash)
       filename = Actions.SaveFilename (indexFilename runtime exprHash)
   Actions.appendWriteFile path filename outputContent
 

--- a/compiler/src/Language/Mimsa/Backend/Backend.hs
+++ b/compiler/src/Language/Mimsa/Backend/Backend.hs
@@ -1,8 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Language.Mimsa.Backend.Backend
-  ( outputCommonJS,
-    getStdlib,
+  ( outputJavascript,
     copyLocalOutput,
     Backend (..),
   )
@@ -10,7 +9,6 @@ where
 
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Lazy.Char8 as LB
-import Data.Coerce
 import Data.Foldable (traverse_)
 import Data.Set (Set)
 import Language.Mimsa.Backend.Javascript
@@ -23,9 +21,6 @@ import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Store
 
 ------
-
-getStdlib :: Backend -> LBS.ByteString
-getStdlib CommonJS = coerce commonJSStandardLibrary
 
 -- given output type and list of expressions, copy everything to local
 -- folder for output in repl

--- a/compiler/src/Language/Mimsa/Backend/Types.hs
+++ b/compiler/src/Language/Mimsa/Backend/Types.hs
@@ -14,7 +14,7 @@ import Language.Mimsa.Types.Store
 
 type BackendM ann = Either (BackendError ann)
 
-data Backend = CommonJS
+data Backend = CommonJS | ESModulesJS
   deriving stock (Eq, Ord, Show)
 
 data Renderer ann a = Renderer

--- a/compiler/src/Language/Mimsa/Backend/ZipFile.hs
+++ b/compiler/src/Language/Mimsa/Backend/ZipFile.hs
@@ -25,8 +25,8 @@ import System.Directory
 
 -- each expression is symlinked from the store to ./output/<exprhash>/<filename.ext>
 createZipFolder :: Backend -> ExprHash -> MimsaM e FilePath
-createZipFolder CommonJS exprHash = do
-  let outputPath = zipFileOutputPath CommonJS
+createZipFolder be exprHash = do
+  let outputPath = zipFileOutputPath be
   let path = outputPath <> "/" <> show exprHash
   liftIO $ createDirectoryIfMissing True path
   pure (path <> "/")

--- a/compiler/src/Language/Mimsa/Repl/Actions.hs
+++ b/compiler/src/Language/Mimsa/Repl/Actions.hs
@@ -52,8 +52,8 @@ doReplAction env input action =
       catchMimsaError env (doBind env input name expr)
     (BindType dt) ->
       catchMimsaError env (doBindType env input dt)
-    (OutputJS expr) ->
-      catchMimsaError env (doOutputJS env input expr $> env)
+    (OutputJS be expr) ->
+      catchMimsaError env (doOutputJS env input be expr $> env)
     (TypeSearch mt) ->
       catchMimsaError env (doTypeSearch env mt $> env)
     (AddUnitTest testName testExpr) ->
@@ -71,7 +71,7 @@ doHelp = do
   replOutput @Text ":bind <name> = <expr> - binds <expr> to <name> and saves it in the environment"
   replOutput @Text ":bindType type Either a b = Left a | Right b - binds a new type and saves it in the environment"
   replOutput @Text ":list - show a list of current bindings in the environment"
-  replOutput @Text ":outputJS <expr> - show JS code for <expr>"
+  replOutput @Text ":outputJS <commonjs|es-modules> <expr> - show JS code for <expr>"
   replOutput @Text ":tree <expr> - draw a dependency tree for <expr>"
   replOutput @Text ":graph <expr> - output graphviz dependency tree for <expr>"
   replOutput @Text ":search <mt> - search for exprs that match type"

--- a/compiler/src/Language/Mimsa/Repl/Parser.hs
+++ b/compiler/src/Language/Mimsa/Repl/Parser.hs
@@ -5,6 +5,8 @@ module Language.Mimsa.Repl.Parser
   )
 where
 
+import Data.Functor (($>))
+import Language.Mimsa.Backend.Types
 import Language.Mimsa.Parser
 import Language.Mimsa.Parser.Literal
 import Language.Mimsa.Repl.Types
@@ -78,10 +80,17 @@ versionsParser = do
   _ <- thenSpace (string ":versions")
   Versions <$> nameParser
 
+backendParser :: Parser (Maybe Backend)
+backendParser =
+  thenSpace (string "commonjs") $> Just CommonJS
+    <|> thenSpace (string "es-modules") $> Just ESModulesJS
+    <|> pure Nothing
+
 outputJSParser :: Parser ReplActionAnn
 outputJSParser = do
   _ <- thenSpace (string ":outputJS")
-  OutputJS <$> expressionParser
+  be <- backendParser
+  OutputJS be <$> expressionParser
 
 typeSearchParser :: Parser ReplActionAnn
 typeSearchParser = do

--- a/compiler/src/Language/Mimsa/Repl/Types.hs
+++ b/compiler/src/Language/Mimsa/Repl/Types.hs
@@ -3,6 +3,7 @@ module Language.Mimsa.Repl.Types
   )
 where
 
+import Language.Mimsa.Backend.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
@@ -16,7 +17,7 @@ data ReplAction ann
   | Graph (Expr Name ann)
   | ProjectGraph
   | Bind Name (Expr Name ann)
-  | OutputJS (Expr Name ann)
+  | OutputJS (Maybe Backend) (Expr Name ann)
   | TypeSearch MonoType
   | BindType (DataType ann)
   | Versions Name

--- a/compiler/static/backend/es-modules-js/stdlib.mjs
+++ b/compiler/static/backend/es-modules-js/stdlib.mjs
@@ -1,0 +1,13 @@
+export const __patternMatch = (val, patterns) => {
+  const checked = patterns.map(([pat,expr]) => [pat(val),expr])
+  const match = checked.find(([a,_])=>a)
+  if (match === undefined) {
+    throw new Error("pattern matching broken")
+  }
+  return match[1](match[0])
+}
+
+export const __concat = (a,b) => [...a,...b]
+
+// very cheap eq function, forgive me padre
+export const __eq = (a, b) => JSON.stringify(a) === JSON.stringify(b);

--- a/compiler/static/test/test.js
+++ b/compiler/static/test/test.js
@@ -1,0 +1,1 @@
+console.log('i am a test')

--- a/compiler/test/Spec.hs
+++ b/compiler/test/Spec.hs
@@ -13,6 +13,7 @@ import qualified Test.Actions.Compile as Compile
 import qualified Test.Actions.Evaluate as Evaluate
 import qualified Test.Actions.RemoveBinding as RemoveBinding
 import qualified Test.Backend.BackendJS as JS
+import qualified Test.Backend.RunNode as RunNode
 import qualified Test.Backend.Runtimes as Runtimes
 import qualified Test.Codegen as Codegen
 import Test.Hspec
@@ -71,3 +72,4 @@ main =
     Pattern.spec
     RemoveBinding.spec
     Typecheck.spec
+    RunNode.spec

--- a/compiler/test/Test/Actions/Compile.hs
+++ b/compiler/test/Test/Actions/Compile.hs
@@ -36,14 +36,14 @@ spec = do
           expr = MyLiteral mempty (MyInt 1)
       let action = do
             (_, _, storeExpr, _) <- Actions.evaluate (prettyPrint expr) expr
-            Actions.compile consoleRuntime "1" storeExpr
+            Actions.compile cjsConsoleRuntime "1" storeExpr
       let result = Actions.run testStdlib action
       result `shouldSatisfy` isLeft
     it "Simplest compilation creates four files" $ do
       let expr = MyVar mempty "id"
       let action = do
             (_, _, storeExpr, _) <- Actions.evaluate (prettyPrint expr) expr
-            Actions.compile exportRuntime "id" storeExpr
+            Actions.compile cjsExportRuntime "id" storeExpr
       let (newProject, outcomes, (_, hashes)) =
             fromRight (Actions.run testStdlib action)
       -- creates three files
@@ -64,7 +64,7 @@ spec = do
       let expr = MyVar mempty "evalState"
       let action = do
             (_, _, storeExpr, _) <- Actions.evaluate (prettyPrint expr) expr
-            Actions.compile exportRuntime "evalState" storeExpr
+            Actions.compile cjsExportRuntime "evalState" storeExpr
       let (newProject, outcomes, _) = fromRight (Actions.run testStdlib action)
       -- creates six files
       length (Actions.writeFilesFromOutcomes outcomes) `shouldBe` 7
@@ -83,5 +83,5 @@ spec = do
       let bindings = Bindings (M.singleton "id2" exprHashForId)
       let storeExpr = StoreExpression expr bindings mempty
       let action = do
-            Actions.compile exportRuntime "id2" storeExpr
+            Actions.compile cjsExportRuntime "id2" storeExpr
       Actions.run testStdlib action `shouldSatisfy` isRight

--- a/compiler/test/Test/Backend/BackendJS.hs
+++ b/compiler/test/Test/Backend/BackendJS.hs
@@ -1,4 +1,7 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Test.Backend.BackendJS
@@ -7,8 +10,11 @@ module Test.Backend.BackendJS
 where
 
 import Data.Bifunctor (first)
+import Data.Coerce
 import Data.Either (isRight)
 import Data.Foldable (traverse_)
+import Data.Hashable
+import Data.List (intersperse)
 import qualified Data.Map as M
 import Data.Maybe (fromJust)
 import Data.Text (Text)
@@ -26,19 +32,26 @@ import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.ResolvedExpression
 import Language.Mimsa.Types.Store
+import System.Exit
+import Test.Backend.RunNode (lbsToString, runScriptFromFile, runScriptInline)
 import Test.Data.Project
 import Test.Hspec
 import Test.Utils.Helpers
+import Test.Utils.Serialisation
+  ( createOutputFolder,
+  )
 
-eval :: Project Annotation -> Text -> Either Text Javascript
-eval env input =
+deriving newtype instance Hashable Javascript
+
+eval :: Backend -> Project Annotation -> Text -> Either Text Javascript
+eval be env input =
   case Actions.evaluateText env input of
     Left e -> Left $ prettyPrint e
     Right (ResolvedExpression _ storeExpr _ _ _) ->
       first
         prettyPrint
         ( renderWithFunction
-            CommonJS
+            be
             dataTypes
             "main"
             (storeExpression storeExpr)
@@ -54,50 +67,102 @@ evalModule env input =
             T.putStrLn (prettyPrint a)
             pure a
 
-successes :: [(Text, Javascript)]
+successes :: [(Text, Javascript, String)]
 successes =
-  [ ("True", "const main = true;\n"),
-    ("False", "const main = false;\n"),
-    ("123", "const main = 123;\n"),
-    ("\"Poo\"", "const main = \"Poo\";\n"),
-    ("id", "const main = id;\n"),
-    ("\\a -> a", "const main = a => a;\n"),
-    ("id(1)", "const main = id(1);\n"),
-    ("if True then 1 else 2", "const main = true ? 1 : 2;\n"),
-    ("let a = \"dog\" in 123", "const main = function() { const a = \"dog\";\nreturn 123 }();\n"),
-    ("let a = \"dog\" in let b = \"horse\" in 123", "const main = function() { const a = \"dog\";\nconst b = \"horse\";\nreturn 123 }();\n"),
-    ("{ a: 123, b: \"horse\" }", "const main = { a: 123, b: \"horse\" };\n"),
-    ("let (a,b) = aPair in a", "const main = function() { const [a, b] = aPair;\nreturn a }();\n"),
-    ("\\a -> let b = 123 in a", "const main = a => { const b = 123;\nreturn a };\n"),
-    ("(1,2)", "const main = [1,2];\n"),
-    ("aRecord.a", "const main = aRecord.a;\n"),
-    ("Just", "const main = a => ({ type: \"Just\", vars: [a] });\n"),
-    ("Just 1", "const main = { type: \"Just\", vars: [1] };\n"),
-    ("Nothing", "const main = { type: \"Nothing\", vars: [] };\n"),
-    ("These", "const main = a => b => ({ type: \"These\", vars: [a,b] });\n"),
-    ("True == False", "const main = __eq(true, false);\n"),
-    ("2 + 2", "const main = 2 + 2;\n"),
-    ("10 - 2", "const main = 10 - 2;\n"),
-    ("\"dog\" ++ \"log\"", "const main = \"dog\" + \"log\";\n"),
-    ("{ fn: (\\a -> let d = 1 in a) }", "const main = { fn: a => { const d = 1;\nreturn a } };\n"),
-    ("[1,2] <> [3,4]", "const main = __concat([1, 2], [3, 4]);\n"),
+  [ ("True", "const main = true;\n", "true"),
+    ("False", "const main = false;\n", "false"),
+    ("123", "const main = 123;\n", "123"),
+    ("\"Poo\"", "const main = \"Poo\";\n", "Poo"),
+    ("id", "const main = id;\n", "[Function: id]"),
+    ( "\\a -> a",
+      "const main = a => a;\n",
+      "[Function: main]"
+    ),
+    ( "id(1)",
+      "const main = id(1);\n",
+      "1"
+    ),
+    ( "if True then 1 else 2",
+      "const main = true ? 1 : 2;\n",
+      "1"
+    ),
+    ( "let a = \"dog\" in 123",
+      "const main = function() { const a = \"dog\";\nreturn 123 }();\n",
+      "123"
+    ),
+    ( "let a = \"dog\" in let b = \"horse\" in 123",
+      "const main = function() { const a = \"dog\";\nconst b = \"horse\";\nreturn 123 }();\n",
+      "123"
+    ),
+    ( "{ a: 123, b: \"horse\" }",
+      "const main = { a: 123, b: \"horse\" };\n",
+      "{ a: 123, b: 'horse' }"
+    ),
+    ( "let (a,b) = aPair in a",
+      "const main = function() { const [a, b] = aPair;\nreturn a }();\n",
+      "1"
+    ),
+    ( "\\a -> let b = 123 in a",
+      "const main = a => { const b = 123;\nreturn a };\n",
+      "[Function: main]"
+    ),
+    ("(1,2)", "const main = [1,2];\n", "[ 1, 2 ]"),
+    ("aRecord.a", "const main = aRecord.a;\n", "100"),
+    ( "Just",
+      "const main = a => ({ type: \"Just\", vars: [a] });\n",
+      "[Function: main]"
+    ),
+    ( "Just 1",
+      "const main = { type: \"Just\", vars: [1] };\n",
+      "{ type: 'Just', vars: [ 1 ] }"
+    ),
+    ( "Nothing",
+      "const main = { type: \"Nothing\", vars: [] };\n",
+      "{ type: 'Nothing', vars: [] }"
+    ),
+    ( "These",
+      "const main = a => b => ({ type: \"These\", vars: [a,b] });\n",
+      "[Function: main]"
+    ),
+    ("True == False", "const main = __eq(true, false);\n", "false"),
+    ("2 + 2", "const main = 2 + 2;\n", "4"),
+    ("10 - 2", "const main = 10 - 2;\n", "8"),
+    ( "\"dog\" ++ \"log\"",
+      "const main = \"dog\" + \"log\";\n",
+      "doglog"
+    ),
+    ( "{ fn: (\\a -> let d = 1 in a) }",
+      "const main = { fn: a => { const d = 1;\nreturn a } };\n",
+      "{ fn: [Function: fn] }"
+    ),
+    ("[1,2] <> [3,4]", "const main = __concat([1, 2], [3, 4]);\n", "[ 1, 2, 3, 4 ]"),
     ( "match Just True with (Just a) -> a | _ -> False",
-      "const main = __patternMatch({ type: \"Just\", vars: [true] }, [ [ pat => __eq(pat.type, \"Just\") ? { a: pat.vars[0] } : null, ({ a }) => a ], [ pat => ({}), () => false ] ]);\n"
+      "const main = __patternMatch({ type: \"Just\", vars: [true] }, [ [ pat => __eq(pat.type, \"Just\") ? { a: pat.vars[0] } : null, ({ a }) => a ], [ pat => ({}), () => false ] ]);\n",
+      "true"
     ),
     ( "match Just True with (Just a) -> Just a | _ -> Nothing",
-      "const main = __patternMatch({ type: \"Just\", vars: [true] }, [ [ pat => __eq(pat.type, \"Just\") ? { a: pat.vars[0] } : null, ({ a }) => ({ type: \"Just\", vars: [a] }) ], [ pat => ({}), () => ({ type: \"Nothing\", vars: [] }) ] ]);\n"
+      "const main = __patternMatch({ type: \"Just\", vars: [true] }, [ [ pat => __eq(pat.type, \"Just\") ? { a: pat.vars[0] } : null, ({ a }) => ({ type: \"Just\", vars: [a] }) ], [ pat => ({}), () => ({ type: \"Nothing\", vars: [] }) ] ]);\n",
+      "{ type: 'Just', vars: [ true ] }"
+    ),
+    ( "match Just True with (Just a) -> let b = 1; Just a | _ -> Nothing",
+      "const main = __patternMatch({ type: \"Just\", vars: [true] }, [ [ pat => __eq(pat.type, \"Just\") ? { a: pat.vars[0] } : null, ({ a }) => { const b = 1;\nreturn { type: \"Just\", vars: [a] } } ], [ pat => ({}), () => ({ type: \"Nothing\", vars: [] }) ] ]);\n",
+      "{ type: 'Just', vars: [ true ] }"
     ),
     ( "let (a, b) = (1,2) in a",
-      "const main = function() { const [a, b] = [1,2];\nreturn a }();\n"
+      "const main = function() { const [a, b] = [1,2];\nreturn a }();\n",
+      "1"
     ),
     ( "let { dog: a, cat: b } = { dog: 1, cat: 2} in (a,b)",
-      "const main = function() { const { cat: b, dog: a } = { cat: 2, dog: 1 };\nreturn [a,b] }();\n"
+      "const main = function() { const { cat: b, dog: a } = { cat: 2, dog: 1 };\nreturn [a,b] }();\n",
+      "[ 1, 2 ]"
     ),
     ( "let (Ident a) = Ident 1 in a",
-      "const main = function() { const { vars: [a] } = { type: \"Ident\", vars: [1] };\nreturn a }();\n"
+      "const main = function() { const { vars: [a] } = { type: \"Ident\", vars: [1] };\nreturn a }();\n",
+      "1"
     ),
     ( "let (Pair a b) = Pair 1 2 in (a,b)",
-      "const main = function() { const { vars: [a, b] } = { type: \"Pair\", vars: [1,2] };\nreturn [a,b] }();\n"
+      "const main = function() { const { vars: [a, b] } = { type: \"Pair\", vars: [1,2] };\nreturn [a,b] }();\n",
+      "[ 1, 2 ]"
     )
   ]
 
@@ -148,10 +213,78 @@ patterns =
     )
   ]
 
-testIt :: (Text, Javascript) -> Spec
-testIt (q, a) =
-  it (T.unpack q) $
-    eval testStdlib q `shouldBe` Right a
+commonJSImports :: String
+commonJSImports =
+  "const { __eq, __concat, __patternMatch } = require('./static/backend/commonjs/stdlib.js')"
+
+esModulesImports :: String
+esModulesImports =
+  "import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'"
+
+testJSCode :: [String]
+testJSCode =
+  [ "const id = a => a",
+    "const aRecord = {a:100}",
+    "const aPair = [1,2]"
+  ]
+
+createCommonJSOutput :: String -> String
+createCommonJSOutput js =
+  mconcat $
+    intersperse
+      "\n"
+      ( [commonJSImports]
+          <> testJSCode
+          <> [js, "console.log(main)"]
+      )
+
+createESModulesOutput :: String -> String
+createESModulesOutput js =
+  mconcat $
+    intersperse
+      "\n"
+      ( [esModulesImports]
+          <> testJSCode
+          <> [ js,
+               "console.log(main)"
+             ]
+      )
+
+-- test that we have a valid ESModule by saving it and running it
+testESModulesInNode :: Javascript -> IO String
+testESModulesInNode js = do
+  -- write file
+  esPath <- createOutputFolder "ESModules"
+  let esFilename = esPath <> show (hash js) <> ".mjs"
+  let jsString = createESModulesOutput (lbsToString $ coerce js)
+  writeFile esFilename jsString
+  (ec, err) <- runScriptFromFile esFilename
+  case ec of
+    ExitFailure _ -> fail err
+    _ -> pure err
+
+testCommonJSInNode :: Javascript -> IO String
+testCommonJSInNode js = do
+  (ec, err) <- runScriptInline (createCommonJSOutput (lbsToString $ coerce js))
+  case ec of
+    ExitFailure _ -> fail err
+    _ -> pure err
+
+testIt :: (Text, Javascript, String) -> Spec
+testIt (expr, expectedJS, expectedValue) =
+  it (T.unpack expr) $ do
+    case eval CommonJS testStdlib expr of
+      Left e -> fail (T.unpack e)
+      Right js -> do
+        js `shouldBe` expectedJS
+        val <- testCommonJSInNode js
+        val `shouldBe` expectedValue
+
+    case eval ESModulesJS testStdlib expr of
+      Left e -> fail (T.unpack e)
+      Right js -> do
+        val <- testESModulesInNode js
+        val `shouldBe` expectedValue
 
 dataTypes :: ResolvedTypeDeps Annotation
 dataTypes = fromJust $ case resolveTypeDeps

--- a/compiler/test/Test/Backend/BackendJS.hs
+++ b/compiler/test/Test/Backend/BackendJS.hs
@@ -38,6 +38,7 @@ eval env input =
       first
         prettyPrint
         ( renderWithFunction
+            CommonJS
             dataTypes
             "main"
             (storeExpression storeExpr)
@@ -48,7 +49,7 @@ evalModule env input =
   case Actions.evaluateText env input of
     Left e -> pure $ Left $ prettyPrint e
     Right (ResolvedExpression _ storeExpr _ _ _) -> do
-      let a = first prettyPrint (outputCommonJS dataTypes storeExpr)
+      let a = first prettyPrint (outputJavascript CommonJS dataTypes storeExpr)
        in do
             T.putStrLn (prettyPrint a)
             pure a

--- a/compiler/test/Test/Backend/RunNode.hs
+++ b/compiler/test/Test/Backend/RunNode.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Backend.RunNode (spec) where
+
+import Control.Monad.IO.Class
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Text as T
+import Data.Text.Encoding (decodeUtf8)
+import System.Exit
+import System.Process.Typed
+import Test.Hspec
+
+runScriptInline :: (MonadIO m) => String -> m (ExitCode, String)
+runScriptInline script = do
+  (ec, success, failure) <- readProcess (proc "node" ["-p", script])
+  case ec of
+    ExitSuccess -> pure (ec, binLastLine success)
+    ExitFailure _ -> pure (ec, binLastLine failure)
+
+runScriptFromFile :: (MonadIO m) => String -> m (ExitCode, String)
+runScriptFromFile filename = do
+  (ec, success, failure) <- readProcess (proc "node" [filename])
+  case ec of
+    ExitSuccess -> pure (ec, binNewline success)
+    ExitFailure _ -> pure (ec, binNewline failure)
+
+lbsToString :: LBS.ByteString -> String
+lbsToString = T.unpack . decodeUtf8 . LBS.toStrict
+
+binNewline :: LBS.ByteString -> String
+binNewline = init . lbsToString
+
+binLastLine :: LBS.ByteString -> String
+binLastLine = mconcat . init . lines . lbsToString
+
+spec :: Spec
+spec = do
+  describe "RunNode" $ do
+    describe "runScriptInline" $ do
+      it "Fails with ExitFailure code" $ do
+        (ec, _) <- runScriptInline "sdfsfgjljlksj4r34"
+        ec `shouldBe` ExitFailure 1
+      it "Succeeds with printed value" $ do
+        (ec, bs) <- runScriptInline "console.log('egg')"
+        ec `shouldBe` ExitSuccess
+        bs `shouldBe` "egg"
+
+    describe "runScriptFromFile" $ do
+      it "Succeeds with printed value" $ do
+        (ec, bs) <- runScriptFromFile "static/test/test.js"
+        ec `shouldBe` ExitSuccess
+        bs `shouldBe` "i am a test"

--- a/compiler/test/Test/Backend/RunNode.hs
+++ b/compiler/test/Test/Backend/RunNode.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Test.Backend.RunNode (spec) where
+module Test.Backend.RunNode (spec, runScriptInline, runScriptFromFile, lbsToString) where
 
 import Control.Monad.IO.Class
 import qualified Data.ByteString.Lazy as LBS

--- a/compiler/test/Test/Backend/Runtimes.hs
+++ b/compiler/test/Test/Backend/Runtimes.hs
@@ -16,13 +16,13 @@ spec = do
   describe "Runtimes" $ do
     it "String is allowed by console runtime" $ do
       let mt = MTPrim mempty MTString
-      let result = runtimeIsValid consoleRuntime mt
+      let result = runtimeIsValid cjsConsoleRuntime mt
       result `shouldSatisfy` isRight
     it "Int is not allowed by console runtime" $ do
       let mt = MTPrim mempty MTInt
-      let result = runtimeIsValid consoleRuntime mt
+      let result = runtimeIsValid cjsConsoleRuntime mt
       result `shouldSatisfy` isLeft
     it "Int is allowed by module export runtime" $ do
       let mt = MTPrim mempty MTInt
-      let result = runtimeIsValid exportRuntime mt
+      let result = runtimeIsValid cjsExportRuntime mt
       result `shouldSatisfy` isRight

--- a/compiler/test/golden/ESModules/-1117335091141931317.mjs
+++ b/compiler/test/golden/ESModules/-1117335091141931317.mjs
@@ -1,0 +1,8 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = function() { const { cat: b, dog: a } = { cat: 2, dog: 1 };
+return [a,b] }();
+
+console.log(main)

--- a/compiler/test/golden/ESModules/-1473276730257143519.mjs
+++ b/compiler/test/golden/ESModules/-1473276730257143519.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = true ? 1 : 2;
+
+console.log(main)

--- a/compiler/test/golden/ESModules/-3617003906811446421.mjs
+++ b/compiler/test/golden/ESModules/-3617003906811446421.mjs
@@ -1,0 +1,8 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = function() { const [a, b] = [1,2];
+return a }();
+
+console.log(main)

--- a/compiler/test/golden/ESModules/-4301314873248964026.mjs
+++ b/compiler/test/golden/ESModules/-4301314873248964026.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = aRecord.a;
+
+console.log(main)

--- a/compiler/test/golden/ESModules/-4641304325160836996.mjs
+++ b/compiler/test/golden/ESModules/-4641304325160836996.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = a => a;
+
+console.log(main)

--- a/compiler/test/golden/ESModules/-4845910592913488888.mjs
+++ b/compiler/test/golden/ESModules/-4845910592913488888.mjs
@@ -1,0 +1,8 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = __patternMatch({ type: "Just", vars: [true] }, [ [ pat => __eq(pat.type, "Just") ? { a: pat.vars[0] } : null, ({ a }) => { const b = 1;
+return { type: "Just", vars: [a] } } ], [ pat => ({}), () => ({ type: "Nothing", vars: [] }) ] ]);
+
+console.log(main)

--- a/compiler/test/golden/ESModules/-5271728544636716334.mjs
+++ b/compiler/test/golden/ESModules/-5271728544636716334.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = false;
+
+console.log(main)

--- a/compiler/test/golden/ESModules/-5325698636451979539.mjs
+++ b/compiler/test/golden/ESModules/-5325698636451979539.mjs
@@ -1,0 +1,8 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = function() { const { vars: [a] } = { type: "Ident", vars: [1] };
+return a }();
+
+console.log(main)

--- a/compiler/test/golden/ESModules/-5370637301540718881.mjs
+++ b/compiler/test/golden/ESModules/-5370637301540718881.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = __patternMatch({ type: "Just", vars: [true] }, [ [ pat => __eq(pat.type, "Just") ? { a: pat.vars[0] } : null, ({ a }) => a ], [ pat => ({}), () => false ] ]);
+
+console.log(main)

--- a/compiler/test/golden/ESModules/-7193852541400862151.mjs
+++ b/compiler/test/golden/ESModules/-7193852541400862151.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = __patternMatch({ type: "Just", vars: [true] }, [ [ pat => __eq(pat.type, "Just") ? { a: pat.vars[0] } : null, ({ a }) => ({ type: "Just", vars: [a] }) ], [ pat => ({}), () => ({ type: "Nothing", vars: [] }) ] ]);
+
+console.log(main)

--- a/compiler/test/golden/ESModules/-7723579357268470197.mjs
+++ b/compiler/test/golden/ESModules/-7723579357268470197.mjs
@@ -1,0 +1,9 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = function() { const a = "dog";
+const b = "horse";
+return 123 }();
+
+console.log(main)

--- a/compiler/test/golden/ESModules/-8172773352401693165.mjs
+++ b/compiler/test/golden/ESModules/-8172773352401693165.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = true;
+
+console.log(main)

--- a/compiler/test/golden/ESModules/-8698042866935081911.mjs
+++ b/compiler/test/golden/ESModules/-8698042866935081911.mjs
@@ -1,0 +1,8 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = function() { const { vars: [a, b] } = { type: "Pair", vars: [1,2] };
+return [a,b] }();
+
+console.log(main)

--- a/compiler/test/golden/ESModules/-8788650193047908100.mjs
+++ b/compiler/test/golden/ESModules/-8788650193047908100.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = "dog" + "log";
+
+console.log(main)

--- a/compiler/test/golden/ESModules/1509083228556522207.mjs
+++ b/compiler/test/golden/ESModules/1509083228556522207.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = 10 - 2;
+
+console.log(main)

--- a/compiler/test/golden/ESModules/1821980248092191451.mjs
+++ b/compiler/test/golden/ESModules/1821980248092191451.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = 123;
+
+console.log(main)

--- a/compiler/test/golden/ESModules/2148133893127896236.mjs
+++ b/compiler/test/golden/ESModules/2148133893127896236.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = 2 + 2;
+
+console.log(main)

--- a/compiler/test/golden/ESModules/3545192592633915288.mjs
+++ b/compiler/test/golden/ESModules/3545192592633915288.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = id;
+
+console.log(main)

--- a/compiler/test/golden/ESModules/3843456300479869529.mjs
+++ b/compiler/test/golden/ESModules/3843456300479869529.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = a => b => ({ type: "These", vars: [a,b] });
+
+console.log(main)

--- a/compiler/test/golden/ESModules/4345442697396451829.mjs
+++ b/compiler/test/golden/ESModules/4345442697396451829.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = a => ({ type: "Just", vars: [a] });
+
+console.log(main)

--- a/compiler/test/golden/ESModules/5087505329935373696.mjs
+++ b/compiler/test/golden/ESModules/5087505329935373696.mjs
@@ -1,0 +1,8 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = { fn: a => { const d = 1;
+return a } };
+
+console.log(main)

--- a/compiler/test/golden/ESModules/5506126325390724936.mjs
+++ b/compiler/test/golden/ESModules/5506126325390724936.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = { type: "Just", vars: [1] };
+
+console.log(main)

--- a/compiler/test/golden/ESModules/556358284963518117.mjs
+++ b/compiler/test/golden/ESModules/556358284963518117.mjs
@@ -1,0 +1,8 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = a => { const b = 123;
+return a };
+
+console.log(main)

--- a/compiler/test/golden/ESModules/5615236058530937365.mjs
+++ b/compiler/test/golden/ESModules/5615236058530937365.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = "Poo";
+
+console.log(main)

--- a/compiler/test/golden/ESModules/6241549423625378665.mjs
+++ b/compiler/test/golden/ESModules/6241549423625378665.mjs
@@ -1,0 +1,8 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = function() { const [a, b] = aPair;
+return a }();
+
+console.log(main)

--- a/compiler/test/golden/ESModules/6566739938547991881.mjs
+++ b/compiler/test/golden/ESModules/6566739938547991881.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = __eq(true, false);
+
+console.log(main)

--- a/compiler/test/golden/ESModules/6619018367117601462.mjs
+++ b/compiler/test/golden/ESModules/6619018367117601462.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = { type: "Nothing", vars: [] };
+
+console.log(main)

--- a/compiler/test/golden/ESModules/6888314776130728088.mjs
+++ b/compiler/test/golden/ESModules/6888314776130728088.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = [1,2];
+
+console.log(main)

--- a/compiler/test/golden/ESModules/7755652757855956380.mjs
+++ b/compiler/test/golden/ESModules/7755652757855956380.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = id(1);
+
+console.log(main)

--- a/compiler/test/golden/ESModules/8101861295827256764.mjs
+++ b/compiler/test/golden/ESModules/8101861295827256764.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = __concat([1, 2], [3, 4]);
+
+console.log(main)

--- a/compiler/test/golden/ESModules/828219767974142139.mjs
+++ b/compiler/test/golden/ESModules/828219767974142139.mjs
@@ -1,0 +1,8 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = function() { const a = "dog";
+return 123 }();
+
+console.log(main)

--- a/compiler/test/golden/ESModules/8289518156180960083.mjs
+++ b/compiler/test/golden/ESModules/8289518156180960083.mjs
@@ -1,0 +1,7 @@
+import { __eq, __concat, __patternMatch } from '../../../static/backend/es-modules-js/stdlib.mjs'
+const id = a => a
+const aRecord = {a:100}
+const aPair = [1,2]
+export const main = { a: 123, b: "horse" };
+
+console.log(main)


### PR DESCRIPTION
As per #57 adds optional ES modules backend.

- [x] add tests that run each backend test with `node`, read the result and check it is what we expect, and check they are the same between `commonjs` and `esmodules`.

There are defo some eggy bugs in the output, this will help catch them.