### PR TITLE
Include type signatures in JS output

### DIFF
--- a/compiler/.gitignore
+++ b/compiler/.gitignore
@@ -4,5 +4,7 @@ store/*.json
 result
 result/
 
+output/
+
 *.hie
 swagger.json

--- a/compiler/src/Language/Mimsa/Actions/Compile.hs
+++ b/compiler/src/Language/Mimsa/Actions/Compile.hs
@@ -73,10 +73,22 @@ transpileModule ::
   Actions.ActionM ()
 transpileModule be se = do
   project <- Actions.getProject
-  dataTypes <- liftEither $ first StoreErr (resolveTypeDeps (prjStore project) (storeTypeBindings se))
+  dataTypes <-
+    liftEither $
+      first
+        StoreErr
+        (resolveTypeDeps (prjStore project) (storeTypeBindings se))
+  monoType <-
+    liftEither $
+      Actions.typecheckStoreExpression (prjStore project) se
   let path = Actions.SavePath (T.pack $ transpiledModuleOutputPath be)
-  let filename = Actions.SaveFilename (moduleFilename be (getStoreExpressionHash se))
-  js <- liftEither $ first BackendErr (outputJavascript be dataTypes se)
+  let filename =
+        Actions.SaveFilename
+          ( moduleFilename
+              be
+              (getStoreExpressionHash se)
+          )
+  js <- liftEither $ first BackendErr (outputJavascript be dataTypes monoType se)
   let jsOutput = Actions.SaveContents (coerce js)
   Actions.appendWriteFile path filename jsOutput
 

--- a/compiler/src/Language/Mimsa/Backend/Javascript.hs
+++ b/compiler/src/Language/Mimsa/Backend/Javascript.hs
@@ -492,7 +492,7 @@ esModulesRenderer dts =
     { renderFunc = renderWithFunction ESModulesJS dts,
       renderImport = \(name, hash') ->
         pure $
-          "import { "
+          "import { main as "
             <> textToJS (coerce name)
             <> " } from \"./"
             <> Javascript (moduleFilename ESModulesJS hash')

--- a/compiler/src/Language/Mimsa/Backend/Types.hs
+++ b/compiler/src/Language/Mimsa/Backend/Types.hs
@@ -11,6 +11,7 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.Typechecker
 
 type BackendM ann = Either (BackendError ann)
 
@@ -19,7 +20,9 @@ data Backend = CommonJS | ESModulesJS
 
 data Renderer ann a = Renderer
   { renderFunc :: Name -> Expr Name ann -> BackendM ann a,
-    renderImport :: Backend -> (Name, ExprHash) -> BackendM ann a,
-    renderStdLib :: Backend -> BackendM ann a,
-    renderExport :: Backend -> Name -> BackendM ann a
+    renderImport :: (Name, ExprHash) -> BackendM ann a,
+    renderStdLib :: BackendM ann a,
+    renderExport :: Name -> BackendM ann a,
+    renderTypeSignature :: MonoType -> BackendM ann a,
+    renderNewline :: a
   }

--- a/compiler/test/Test/Backend/BackendJS.hs
+++ b/compiler/test/Test/Backend/BackendJS.hs
@@ -61,8 +61,8 @@ evalModule :: Project Annotation -> Text -> IO (Either Text Javascript)
 evalModule env input =
   case Actions.evaluateText env input of
     Left e -> pure $ Left $ prettyPrint e
-    Right (ResolvedExpression _ storeExpr _ _ _) -> do
-      let a = first prettyPrint (outputJavascript CommonJS dataTypes storeExpr)
+    Right (ResolvedExpression mt storeExpr _ _ _) -> do
+      let a = first prettyPrint (outputJavascript CommonJS dataTypes mt storeExpr)
        in do
             T.putStrLn (prettyPrint a)
             pure a


### PR DESCRIPTION
Resolves #58 

EXAMPLE:

```typescript
const { __eq, __concat, __patternMatch } = require("./cjs-stdlib.js");

/* 
(a -> b -> c) -> b -> [ a ] -> b
 */
const main = (function () {
  const arrayReduce = (f) => (def) => (as) =>
    __patternMatch(as, [
```