### PR TITLE
Function syntax

### DIFF
--- a/compiler/src/Language/Mimsa/Types/AST/Expr.hs
+++ b/compiler/src/Language/Mimsa/Types/AST/Expr.hs
@@ -107,14 +107,25 @@ prettyLet ::
   Expr var ann ->
   Doc style
 prettyLet var expr1 expr2 =
-  group
-    ( "let" <+> prettyDoc var
-        <+> "="
-        <> line
-        <> indentMulti 2 (prettyDoc expr1)
-        <> newlineOrIn
-        <> prettyDoc expr2
-    )
+  let (args, letExpr) = splitExpr expr1
+   in group
+        ( "let" <+> prettyDoc var <> prettyArgs args
+            <+> "="
+            <> line
+            <> indentMulti 2 (prettyDoc letExpr)
+            <> newlineOrIn
+            <> prettyDoc expr2
+        )
+  where
+    prettyArgs [] = ""
+    prettyArgs as = space <> hsep (prettyDoc <$> as)
+
+    splitExpr expr =
+      case expr of
+        (MyLambda _ a rest) ->
+          let (as, expr') = splitExpr rest
+           in ([a] <> as, expr')
+        other -> ([], other)
 
 prettyLetPattern ::
   (Show var, Printer var) =>

--- a/compiler/test/Test/Parser/Syntax.hs
+++ b/compiler/test/Test/Parser/Syntax.hs
@@ -96,6 +96,15 @@ spec = do
                 "a"
                 (MyLambda mempty "b" (MyVar mempty "a"))
             )
+      it "Recognises minimal function syntax in let" $
+        testParse "let const a b = a in True"
+          `shouldBe` Right
+            ( MyLet
+                mempty
+                "const"
+                (MyLambda mempty "a" (MyLambda mempty "b" (MyVar mempty "a")))
+                (bool True)
+            )
       it "Recognises function application" $
         testParse "add 1"
           `shouldBe` Right

--- a/compiler/test/Test/Prettier.hs
+++ b/compiler/test/Test/Prettier.hs
@@ -81,7 +81,11 @@ spec =
             doc = prettyDoc expr'
         renderWithWidth 50 doc `shouldBe` "type These a    = That a in 1"
         renderWithWidth 5 doc `shouldBe` "type These a \n  = That\n  a;\n\n1"
-
+      it "Renders new function syntax nicely" $ do
+        let expr' = unsafeParseExpr "let const a b = a in 1"
+            doc = prettyDoc expr'
+        renderWithWidth 50 doc `shouldBe` "let const a b = a in 1"
+        renderWithWidth 5 doc `shouldBe` "let const a b =\n  a;\n\n1"
     describe
       "MonoType"
       $ do

--- a/compiler/test/golden/PrettyPrint/9c3737063ce1b1804c2a214e284f710e56de09ced60336cfcdf02f1e619e3e66.mimsa
+++ b/compiler/test/golden/PrettyPrint/9c3737063ce1b1804c2a214e284f710e56de09ced60336cfcdf02f1e619e3e66.mimsa
@@ -1,0 +1,1 @@
+let id = (\a -> a) in (id 1)

--- a/compiler/test/golden/StoreExpr/9c3737063ce1b1804c2a214e284f710e56de09ced60336cfcdf02f1e619e3e66.json
+++ b/compiler/test/golden/StoreExpr/9c3737063ce1b1804c2a214e284f710e56de09ced60336cfcdf02f1e619e3e66.json
@@ -1,0 +1,1 @@
+{"storeBindings":{},"storeExpression":{"contents":[[],{"contents":[[],"id"],"tag":"PVar"},{"contents":[[],"a",{"contents":[[],"a"],"tag":"MyVar"}],"tag":"MyLambda"},{"contents":[[],{"contents":[[],"id"],"tag":"MyVar"},{"contents":[[],{"contents":1,"tag":"MyInt"}],"tag":"MyLiteral"}],"tag":"MyApp"}],"tag":"MyLetPattern"},"storeTypeBindings":{}}


### PR DESCRIPTION
Allows functions to be defined like:

```haskell
let const a b = a in ....
```

Resolves #299 