### PR TITLE
Simplify typed expression

### DIFF
--- a/compiler/src/Language/Mimsa/Actions/Evaluate.hs
+++ b/compiler/src/Language/Mimsa/Actions/Evaluate.hs
@@ -14,7 +14,6 @@ import qualified Language.Mimsa.Actions.Shared as Actions
 import Language.Mimsa.Interpreter (interpret)
 import Language.Mimsa.Printer
 import Language.Mimsa.Store.DepGraph
-import Language.Mimsa.Typechecker.Elaborate
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
@@ -30,7 +29,7 @@ evaluate ::
       Expr Name Annotation,
       StoreExpression Annotation,
       [Graphviz],
-      Expr Variable TypedAnnotation,
+      Expr Variable MonoType,
       Text
     )
 evaluate input expr = do

--- a/compiler/src/Language/Mimsa/Actions/Shared.hs
+++ b/compiler/src/Language/Mimsa/Actions/Shared.hs
@@ -52,7 +52,7 @@ getType ::
     (Error ann)
     ( Substitutions,
       [Constraint],
-      Expr Variable (MonoType, Annotation),
+      Expr Variable MonoType,
       MonoType
     )
 getType typeMap swaps scope' source expr =

--- a/compiler/src/Language/Mimsa/Server/ExpressionData.hs
+++ b/compiler/src/Language/Mimsa/Server/ExpressionData.hs
@@ -33,6 +33,7 @@ import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Project.SourceItem
 import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.Typechecker
 import Servant
 
 data UnitTestData = UnitTestData
@@ -86,7 +87,7 @@ data ExpressionData = ExpressionData
 expressionDataHandler ::
   Project Annotation ->
   StoreExpression Annotation ->
-  Expr Variable TypedAnnotation ->
+  Expr Variable MonoType ->
   [Graphviz] ->
   Text ->
   Handler ExpressionData

--- a/compiler/src/Language/Mimsa/Typechecker/Typecheck.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Typecheck.hs
@@ -23,7 +23,13 @@ import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Swaps
 import Language.Mimsa.Types.Typechecker
 
-type ElabM = ExceptT TypeError (WriterT [Constraint] (ReaderT Swaps (State TypecheckState)))
+type ElabM =
+  ExceptT
+    TypeError
+    ( WriterT
+        [Constraint]
+        (ReaderT Swaps (State TypecheckState))
+    )
 
 runElabM ::
   Swaps ->
@@ -46,7 +52,13 @@ typecheck ::
   Swaps ->
   Environment ->
   Expr Variable Annotation ->
-  Either TypeError (Substitutions, [Constraint], Expr Variable (MonoType, Annotation), MonoType)
+  Either
+    TypeError
+    ( Substitutions,
+      [Constraint],
+      Expr Variable MonoType,
+      MonoType
+    )
 typecheck typeMap swaps env expr = do
   let tcAction = do
         (elabExpr, constraints) <- listen (elab (envWithBuiltInTypes <> env) expr)

--- a/compiler/src/Language/Mimsa/Types/ResolvedExpression.hs
+++ b/compiler/src/Language/Mimsa/Types/ResolvedExpression.hs
@@ -8,7 +8,6 @@ module Language.Mimsa.Types.ResolvedExpression where
 import qualified Data.Aeson as JSON
 import Data.Text (Text)
 import GHC.Generics
-import Language.Mimsa.Typechecker.Elaborate
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Scope
@@ -22,7 +21,7 @@ data ResolvedExpression ann = ResolvedExpression
     reExpression :: Expr Variable ann,
     reScope :: Scope ann,
     reSwaps :: Swaps,
-    reTypedExpression :: Expr Variable TypedAnnotation,
+    reTypedExpression :: Expr Variable MonoType,
     reInput :: Text
   }
   deriving stock (Eq, Ord, Show, Functor, Generic)

--- a/compiler/src/Language/Mimsa/Types/Typechecker/Substitutions.hs
+++ b/compiler/src/Language/Mimsa/Types/Typechecker/Substitutions.hs
@@ -8,7 +8,6 @@ module Language.Mimsa.Types.Typechecker.Substitutions
   )
 where
 
-import Data.Bifunctor (first)
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
@@ -73,6 +72,6 @@ instance Substitutable MonoType where
     MTConstructor ann cn -> MTConstructor ann cn
     MTPrim ann a -> MTPrim ann a
 
-instance Substitutable (Expr Variable (MonoType, Annotation)) where
+instance Substitutable (Expr Variable MonoType) where
   applySubst subst elabExpr =
-    first (applySubst subst) <$> elabExpr
+    applySubst subst <$> elabExpr

--- a/compiler/test/Test/Typechecker/Elaborate.hs
+++ b/compiler/test/Test/Typechecker/Elaborate.hs
@@ -15,7 +15,7 @@ import Test.Utils.Helpers
 
 startElaborate ::
   Expr Variable Annotation ->
-  Expr Variable (MonoType, Annotation) ->
+  Expr Variable MonoType ->
   IO ()
 startElaborate input expected = do
   let result = fmap (\(_, _, a, _) -> a) . typecheck mempty mempty mempty $ input
@@ -31,37 +31,42 @@ spec = do
     describe "basic cases" $ do
       it "infers int" $ do
         let expr = int 1
-            expected = MyLiteral (MTPrim mempty MTInt, mempty) (MyInt 1)
+            expected = MyLiteral (MTPrim mempty MTInt) (MyInt 1)
         startElaborate expr expected
 
       it "infers bool" $ do
         let expr = bool True
-            expected = MyLiteral (MTPrim mempty MTBool, mempty) (MyBool True)
+            expected = MyLiteral (MTPrim mempty MTBool) (MyBool True)
         startElaborate expr expected
 
       it "infers string" $ do
         let expr = str (StringType "hello")
-            expected = MyLiteral (MTPrim mempty MTString, mempty) (MyString (StringType "hello"))
+            expected =
+              MyLiteral
+                (MTPrim mempty MTString)
+                ( MyString
+                    (StringType "hello")
+                )
         startElaborate expr expected
 
       it "infers let binding" $ do
         let expr = MyLet mempty (named "x") (int 42) (bool True)
             expected =
               MyLet
-                (MTPrim mempty MTBool, mempty)
+                (MTPrim mempty MTBool)
                 (named "x")
-                (MyLiteral (MTPrim mempty MTInt, mempty) (MyInt 42))
-                (MyLiteral (MTPrim mempty MTBool, mempty) (MyBool True))
+                (MyLiteral (MTPrim mempty MTInt) (MyInt 42))
+                (MyLiteral (MTPrim mempty MTBool) (MyBool True))
         startElaborate expr expected
 
       it "infers let binding with usage" $ do
         let expr = MyLet mempty (named "x") (int 42) (MyVar mempty (named "x"))
             expected =
               MyLet
-                (MTPrim mempty MTInt, mempty)
+                (MTPrim mempty MTInt)
                 (named "x")
-                (MyLiteral (MTPrim mempty MTInt, mempty) (MyInt 42))
-                ( MyVar (MTPrim mempty MTInt, mempty) (named "x")
+                (MyLiteral (MTPrim mempty MTInt) (MyInt 42))
+                ( MyVar (MTPrim mempty MTInt) (named "x")
                 )
         startElaborate expr expected
 
@@ -87,26 +92,26 @@ spec = do
                 (MyVar mempty (named "dec"))
             expected =
               MyLet
-                (MTFunction mempty mtBool mtBool, mempty)
+                (MTFunction mempty mtBool mtBool)
                 (named "dec")
                 ( MyLambda
-                    (MTFunction mempty mtBool mtBool, mempty)
+                    (MTFunction mempty mtBool mtBool)
                     (named "bool")
                     ( MyIf
-                        (mtBool, mempty)
-                        (MyVar (mtBool, mempty) (named "bool"))
-                        (MyLiteral (mtBool, mempty) (MyBool True))
+                        mtBool
+                        (MyVar mtBool (named "bool"))
+                        (MyLiteral mtBool (MyBool True))
                         ( MyApp
-                            (mtBool, mempty)
+                            mtBool
                             ( MyVar
-                                (MTFunction mempty mtBool mtBool, mempty)
+                                (MTFunction mempty mtBool mtBool)
                                 (named "dec")
                             )
-                            (MyLiteral (mtBool, mempty) (MyBool False))
+                            (MyLiteral mtBool (MyBool False))
                         )
                     )
                 )
-                (MyVar (MTFunction mempty mtBool mtBool, mempty) (named "dec"))
+                (MyVar (MTFunction mempty mtBool mtBool) (named "dec"))
         startElaborate expr expected
 
       it "infers let binding with recursion 1" $ do
@@ -131,28 +136,28 @@ spec = do
                 (MyApp mempty (MyVar mempty (named "dec")) (bool False))
             expected =
               MyLet
-                (mtBool, mempty)
+                mtBool
                 (named "dec")
                 ( MyLambda
-                    (MTFunction mempty mtBool mtBool, mempty)
+                    (MTFunction mempty mtBool mtBool)
                     (named "bool")
                     ( MyIf
-                        (mtBool, mempty)
-                        (MyVar (mtBool, mempty) (named "bool"))
-                        (MyLiteral (mtBool, mempty) (MyBool True))
+                        mtBool
+                        (MyVar mtBool (named "bool"))
+                        (MyLiteral mtBool (MyBool True))
                         ( MyApp
-                            (mtBool, mempty)
-                            (MyVar (MTFunction mempty mtBool mtBool, mempty) (named "dec"))
-                            (MyLiteral (mtBool, mempty) (MyBool False))
+                            mtBool
+                            (MyVar (MTFunction mempty mtBool mtBool) (named "dec"))
+                            (MyLiteral mtBool (MyBool False))
                         )
                     )
                 )
                 ( MyApp
-                    (mtBool, mempty)
+                    mtBool
                     ( MyVar
-                        (MTFunction mempty mtBool mtBool, mempty)
+                        (MTFunction mempty mtBool mtBool)
                         (named "dec")
                     )
-                    (MyLiteral (mtBool, mempty) (MyBool False))
+                    (MyLiteral mtBool (MyBool False))
                 )
         startElaborate expr expected

--- a/compiler/test/Test/Typechecker/OutputTypes.hs
+++ b/compiler/test/Test/Typechecker/OutputTypes.hs
@@ -32,7 +32,7 @@ spec = do
       getExpressionSourceItems
         "True"
         ( MyLiteral
-            (MTPrim (Location 1 4) MTBool, Location 1 4)
+            (MTPrim (Location 1 4) MTBool)
             (MyBool True)
         )
         `shouldBe` [ SourceItem


### PR DESCRIPTION
We don't need `(MonoType, Annotation)` when `MonoType` has an `Annotation` inside already, this removes.