### PR TITLE
Scoped type hole fits

### DIFF
--- a/compiler/src/Language/Mimsa/Typechecker/TcMonad.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/TcMonad.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Language.Mimsa.Typechecker.TcMonad
   ( defaultTcState,
     getUnknown,
+    instantiate,
     addTypedHole,
     getTypedHoles,
     TypecheckState (..),
@@ -10,18 +12,30 @@ module Language.Mimsa.Typechecker.TcMonad
   )
 where
 
+import Control.Monad.Except
+import Control.Monad.Reader
 import Control.Monad.State (MonadState, gets, modify)
 import Data.Coerce
 import Data.Map (Map)
 import qualified Data.Map as M
 import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Swaps
 import Language.Mimsa.Types.Typechecker
 
 data TypecheckState = TypecheckState
   { tcsNum :: Int,
-    tcsTypedHoles :: Map Name (Annotation, Int)
+    tcsTypedHoles :: Map Name (Annotation, Int, Map Name MonoType)
   }
+
+instantiate ::
+  (MonadState TypecheckState m) => Scheme -> m MonoType
+instantiate (Scheme vars ty) = do
+  newVars <- traverse (const $ getUnknown mempty) vars
+  let pairs = zip vars newVars
+  let subst = Substitutions $ M.fromList pairs
+  pure (applySubst subst ty)
 
 defaultTcState :: TypecheckState
 defaultTcState = TypecheckState 0 mempty
@@ -40,25 +54,67 @@ getUnknown ann = typeFromUniVar ann <$> getNextUniVar
 
 -- | Get a new unknown for a typed hole and return it's monotype
 addTypedHole ::
-  (MonadState TypecheckState m) =>
+  ( MonadState TypecheckState m,
+    MonadError TypeError m,
+    MonadReader Swaps m
+  ) =>
+  Environment ->
   Annotation ->
   Name ->
   m MonoType
-addTypedHole ann name = do
+addTypedHole env ann name = do
   i <- getNextUniVar
-  modify (\s -> s {tcsTypedHoles = tcsTypedHoles s <> M.singleton name (ann, i)})
+  localTypeMap <- schemesToTypeMap (getSchemes env)
+  modify
+    ( \s ->
+        s
+          { tcsTypedHoles =
+              tcsTypedHoles s
+                <> M.singleton name (ann, i, localTypeMap)
+          }
+    )
   pure $ MTVar ann (TVNum i)
+
+-- | if we have a `Variable`, lookup it's original `Name` in Reader context
+lookupSwap ::
+  ( MonadReader Swaps m,
+    MonadError TypeError m
+  ) =>
+  Variable ->
+  m Name
+lookupSwap var = do
+  swaps <- ask
+  case M.lookup var swaps of
+    Just a -> pure a
+    _ -> throwError UnknownTypeError -- forgive me, Padre
+
+-- capture type schemes currently in scope
+-- instantiate them now
+schemesToTypeMap ::
+  (MonadState TypecheckState m, MonadError TypeError m, MonadReader Swaps m) =>
+  Map TypeIdentifier Scheme ->
+  m (Map Name MonoType)
+schemesToTypeMap schemes = do
+  let fn =
+        ( \(k, v) ->
+            let leName = case k of
+                  TVName n -> pure (Name $ coerce n)
+                  TVNum i -> lookupSwap (NumberedVar i)
+             in (,) <$> leName <*> instantiate v
+        )
+  typeMap <- traverse fn (M.toList schemes)
+  pure (M.fromList typeMap)
 
 -- todo - look up index in substitutions to get type
 getTypedHoles ::
   (MonadState TypecheckState m) =>
   Substitutions ->
-  m (Map Name MonoType)
-getTypedHoles (Substitutions subs) = do
+  m (Map Name (MonoType, Map Name MonoType))
+getTypedHoles subs'@(Substitutions subs) = do
   holes <- gets tcsTypedHoles
-  let getMonoType = \(ann, i) -> case M.lookup (TVNum i) subs of
-        Just a -> a
-        Nothing -> MTVar ann (TVNum i)
+  let getMonoType = \(ann, i, localTypeMap) -> case M.lookup (TVNum i) subs of
+        Just a -> (applySubst subs' a, applySubst subs' localTypeMap)
+        Nothing -> (applySubst subs' (MTVar ann (TVNum i)), applySubst subs' localTypeMap)
   pure $ fmap getMonoType holes
 
 variableToTypeIdentifier :: Variable -> TypeIdentifier

--- a/compiler/src/Language/Mimsa/Typechecker/TypedHoles.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/TypedHoles.hs
@@ -33,7 +33,11 @@ typedHolesCheck typeMap subs = do
     then pure ()
     else throwError (TypedHoles (getTypedHoleSuggestions typeMap <$> holes))
 
-getTypedHoleSuggestions :: Map Name MonoType -> MonoType -> (MonoType, Set Name)
-getTypedHoleSuggestions typeMap mt = (normaliseType mt, suggest)
+getTypedHoleSuggestions ::
+  Map Name MonoType ->
+  (MonoType, Map Name MonoType) ->
+  (MonoType, Set Name)
+getTypedHoleSuggestions typeMap (mt, localTypeMap) = (normaliseType mt, suggestGlobal <> suggestLocal)
   where
-    suggest = M.keysSet $ typeSearch typeMap mt
+    suggestGlobal = M.keysSet $ typeSearch typeMap mt
+    suggestLocal = M.keysSet $ typeSearch localTypeMap mt

--- a/compiler/src/Language/Mimsa/Types/Typechecker/Substitutions.hs
+++ b/compiler/src/Language/Mimsa/Types/Typechecker/Substitutions.hs
@@ -72,6 +72,9 @@ instance Substitutable MonoType where
     MTConstructor ann cn -> MTConstructor ann cn
     MTPrim ann a -> MTPrim ann a
 
+instance (Substitutable a) => Substitutable (Map k a) where
+  applySubst subst as = applySubst subst <$> as
+
 instance Substitutable (Expr Variable MonoType) where
   applySubst subst elabExpr =
     applySubst subst <$> elabExpr

--- a/compiler/test/Test/Project/TypeSearch.hs
+++ b/compiler/test/Test/Project/TypeSearch.hs
@@ -12,7 +12,6 @@ import Language.Mimsa.Actions.Shared
 import Language.Mimsa.Project.TypeSearch
 import Language.Mimsa.Typechecker.DataTypes
 import Language.Mimsa.Typechecker.NormaliseTypes
-import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Typechecker
 import Test.Data.Project (testStdlib)
@@ -32,14 +31,6 @@ spec :: Spec
 spec =
   describe "Typesearch" $ do
     describe "from MonoType" $ do
-      it "Equality works despite annotations" $ do
-        Normalised (MTPrim mempty MTInt)
-          == Normalised (MTPrim (Location 1 2) MTInt)
-          `shouldBe` True
-      it "Inequality works despite annotations" $ do
-        Normalised (MTPrim mempty MTBool)
-          == Normalised (MTPrim (Location 1 2) MTInt)
-          `shouldBe` False
       it "Finds nothing in an empty project" $ do
         typeSearch mempty (MTPrim mempty MTBool) `shouldBe` mempty
       it "Finds the id function in test project" $ do
@@ -60,11 +51,24 @@ spec =
         result
           `shouldBe` M.fromList
             [ ("addInt", addIntType),
-              ("subtractInt", addIntType)
+              ("subtractInt", addIntType),
+              ( "const",
+                MTFunction
+                  mempty
+                  (unknown 0)
+                  ( MTFunction
+                      mempty
+                      (unknown 1)
+                      (MTVar mempty (tvNumbered 0))
+                  )
+              )
             ]
     describe "from text input" $ do
       it "Finds id function" $ do
         typeSearchFromText typeMap "a -> a"
+          `shouldBe` Right (M.singleton "id" (normaliseType idType))
+      it "Finds id function from specialised version" $ do
+        typeSearchFromText typeMap "String -> String"
           `shouldBe` Right (M.singleton "id" (normaliseType idType))
       it "Finds fmapMaybe" $ do
         let fmapMaybe =


### PR DESCRIPTION
Solves this problem:

```haskell
let concat a b = a ++ b;

let liftA2Maybe f mA mB = maybe.ap (maybe.fmap f mA) mB;

let one = Just "Horse";

let two = Just "Time";

liftA2Maybe concat one ?two
```

...now suggests:

```
repl:9:24:
  |
9 | liftA2Maybe concat one ?two
  |                        ^^^^
Typed holes found:
?two : Maybe String 
  Suggestions: [one, two]
```

Resolves #128 