### PR TITLE
Remove repeated generics in constructors

### DIFF
--- a/compiler/src/Language/Mimsa/Backend/Typescript/DataType.hs
+++ b/compiler/src/Language/Mimsa/Backend/Typescript/DataType.hs
@@ -44,7 +44,7 @@ createConstructorFunctions :: TSDataType -> [TSStatement]
 createConstructorFunctions (TSDataType typeName dtArgs constructors) =
   createConstructorFunction typeName dtArgs <$> constructors
 
--- because we build constructors outside -> in, we can't look at the generics
+-- | because we build constructors inside -> out, we can't look at the generics
 -- we've used, so instead, we take the whole thing and remove them where
 -- needed
 removeRepeatedGenerics :: TSExpr -> TSExpr

--- a/compiler/src/Language/Mimsa/Backend/Typescript/FromExpr.hs
+++ b/compiler/src/Language/Mimsa/Backend/Typescript/FromExpr.hs
@@ -62,7 +62,10 @@ consToTSType mt =
   case varsFromDataType mt of
     Just (TyCon n, vars) -> do
       imported <- typeNameIsImport (TyCon n)
-      let namespace = if imported then Just n else Nothing
+      let namespace =
+            if imported
+              then Just n
+              else Nothing
       tsTypes <- traverse toTSType vars
       let (types, generics) = unzip tsTypes
       pure (TSType namespace n types, mconcat generics)

--- a/compiler/src/Language/Mimsa/Backend/Typescript/Types.hs
+++ b/compiler/src/Language/Mimsa/Backend/Typescript/Types.hs
@@ -27,11 +27,12 @@ import Data.Set (Set)
 import Data.String
 import Data.Text (Text)
 import qualified Data.Text as T
+import Language.Mimsa.Printer
 import Language.Mimsa.Types.Identifiers.TyCon
 
 -- | which generics have been used already?
 newtype TSGeneric = TSGeneric Text
-  deriving newtype (Eq, Ord, Show)
+  deriving newtype (Eq, Ord, Show, Printer)
 
 data TSType
   = TSType (Maybe Text) Text [TSType] -- namespace, typeName, inner types

--- a/compiler/test/Test/Backend/Typescript.hs
+++ b/compiler/test/Test/Backend/Typescript.hs
@@ -246,7 +246,8 @@ fullTestCases =
     ("1 < 2", "true"),
     ("2 < 1", "false"),
     ("2 <= 2", "true"),
-    ("3 <= 2", "false")
+    ("3 <= 2", "false"),
+    ("Monoid", "[Function: Monoid]")
   ]
 
 spec :: Spec
@@ -480,6 +481,19 @@ spec = do
                   TSConstructor "That" [TSTypeVar "B"],
                   TSConstructor "These" [TSTypeVar "A", TSTypeVar "B"]
                 ]
+            tsMonoid =
+              TSDataType
+                "Monoid"
+                ["A"]
+                [ TSConstructor
+                    "Monoid"
+                    [ TSTypeFun
+                        "arg"
+                        (TSTypeVar "A")
+                        (TSTypeFun "arg" (TSTypeVar "A") (TSTypeVar "A")),
+                      TSTypeVar "A"
+                    ]
+                ]
 
         it "Maybe" $ do
           printStatement <$> createConstructorFunctions tsMaybe
@@ -491,6 +505,10 @@ spec = do
             `shouldBe` [ "const This = <A>(a: A): These<A,never> => ({ type: \"This\", vars: [a] }); ",
                          "const That = <B>(b: B): These<never,B> => ({ type: \"That\", vars: [b] }); ",
                          "const These = <A>(a: A) => <B>(b: B): These<A,B> => ({ type: \"These\", vars: [a,b] }); "
+                       ]
+        it "Monoid" $ do
+          printStatement <$> createConstructorFunctions tsMonoid
+            `shouldBe` [ "const Monoid = <A>(u1: (arg: A) => (arg: A) => A) => (a: A): Monoid<A> => ({ type: \"Monoid\", vars: [u1,a] }); "
                        ]
 
     describe "from parsed input" $ do


### PR DESCRIPTION
When building up Typescript functions in codegen we are careful not to re-use generics. However, we build up constructor functions slightly differently, and start with the datatype and work outwards adding functions that introduce the data inside. This adds a quick function that goes through the generated function and knocks out any duplicates to stop Typescript getting confused.

Resolves #448 