### PR TITLE
Punned record

### DIFF
--- a/compiler/server/Server/Handlers.hs
+++ b/compiler/server/Server/Handlers.hs
@@ -277,7 +277,7 @@ runTestsHandler ::
   MimsaEnvironment ->
   Project Annotation ->
   [Test] ->
-  Handler [TestResult Variable Annotation]
+  Handler [TestResult Annotation]
 runTestsHandler mimsaEnv project tests = do
   handleMimsaM
     (mimsaConfig mimsaEnv)

--- a/compiler/server/Server/Helpers/TestData.hs
+++ b/compiler/server/Server/Helpers/TestData.hs
@@ -70,7 +70,7 @@ data PropertyTestData = PropertyTestData
 mkPropertyTestData ::
   Project ann ->
   PropertyTest ->
-  PropertyTestResult Variable ann ->
+  PropertyTestResult ann ->
   PropertyTestData
 mkPropertyTestData project propertyTest result = do
   let getDep = (`findBindingNameForExprHash` project)
@@ -97,9 +97,9 @@ data RuntimeData = RuntimeData
   deriving anyclass (JSON.ToJSON, ToSchema)
 
 splitTestResults ::
-  [TestResult var ann] ->
+  [TestResult ann] ->
   ( [UnitTest],
-    [(PropertyTest, PropertyTestResult var ann)]
+    [(PropertyTest, PropertyTestResult ann)]
   )
 splitTestResults results =
   let f res = case res of
@@ -112,7 +112,7 @@ splitTestResults results =
 
 makeTestData ::
   Project Annotation ->
-  [TestResult Variable Annotation] ->
+  [TestResult Annotation] ->
   TestData
 makeTestData project testResults =
   let (uts, pts) = splitTestResults testResults

--- a/compiler/src/Language/Mimsa/Interpreter/UseSwaps.hs
+++ b/compiler/src/Language/Mimsa/Interpreter/UseSwaps.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 
-module Language.Mimsa.Interpreter.UseSwaps (useSwaps) where
+module Language.Mimsa.Interpreter.UseSwaps (useSwaps, usePatternSwaps) where
 
 import Control.Monad.Except
 import Control.Monad.Reader
@@ -83,6 +83,12 @@ useSwapsInIdentifier (Identifier ann var) =
   Identifier ann <$> lookupSwap var
 useSwapsInIdentifier (AnnotatedIdentifier mt var) =
   AnnotatedIdentifier mt <$> lookupSwap var
+
+usePatternSwaps ::
+  Swaps ->
+  Pattern Variable ann ->
+  Either (InterpreterError ann) (Pattern Name ann)
+usePatternSwaps swaps pat' = runReaderT (useSwapsInPattern pat') swaps
 
 useSwapsInPattern :: Pattern Variable ann -> App ann (Pattern Name ann)
 useSwapsInPattern (PWildcard ann) = pure (PWildcard ann)

--- a/compiler/src/Language/Mimsa/Parser/Language.hs
+++ b/compiler/src/Language/Mimsa/Parser/Language.hs
@@ -168,9 +168,12 @@ appParser = addLocation $ do
 
 recordParser :: Parser ParserExpr
 recordParser = withLocation MyRecord $ do
+  let itemParser =
+        try recordItemParser
+          <|> punnedRecordItemParser
   _ <- string "{"
   _ <- space
-  args <- sepBy (optionalSpaceThen recordItemParser) (string ",")
+  args <- sepBy (optionalSpaceThen itemParser) (string ",")
   _ <- space
   _ <- string "}"
   pure (M.fromList args)
@@ -181,6 +184,11 @@ recordItemParser = do
   literalWithSpace ":"
   expr <- optionalSpaceThen expressionParser
   pure (name, expr)
+
+punnedRecordItemParser :: Parser (Name, ParserExpr)
+punnedRecordItemParser = do
+  name <- nameParser
+  pure (name, MyVar mempty name)
 
 -----
 

--- a/compiler/src/Language/Mimsa/Parser/Pattern.hs
+++ b/compiler/src/Language/Mimsa/Parser/Pattern.hs
@@ -75,9 +75,12 @@ litParser = withLocation PLit lit
 
 recordParser :: Parser ParserPattern
 recordParser = withLocation PRecord $ do
+  let itemParser =
+        try recordItemParser
+          <|> punnedRecordItemParser
   _ <- string "{"
   _ <- space
-  args <- sepBy (withOptionalSpace recordItemParser) (literalWithSpace ",")
+  args <- sepBy (withOptionalSpace itemParser) (literalWithSpace ",")
   _ <- space
   _ <- string "}"
   pure (M.fromList args)
@@ -88,6 +91,11 @@ recordItemParser = do
   literalWithSpace ":"
   expr <- withOptionalSpace patternParser
   pure (name, expr)
+
+punnedRecordItemParser :: Parser (Name, ParserPattern)
+punnedRecordItemParser = do
+  name <- nameParser
+  pure (name, PVar mempty name)
 
 ---
 

--- a/compiler/src/Language/Mimsa/Project/Versions.hs
+++ b/compiler/src/Language/Mimsa/Project/Versions.hs
@@ -46,7 +46,7 @@ findVersions ::
     (Error Annotation)
     ( NonEmpty
         ( Int,
-          Expr Variable Annotation,
+          Expr Name Annotation,
           MonoType,
           Set Usage,
           ExprHash
@@ -58,7 +58,10 @@ findVersions project name = do
   let numbered = NE.zip (NE.fromList [1 ..]) as
   pure $ NE.reverse $ (\(i, (a, b, c, d)) -> (i, a, b, c, d)) <$> numbered
 
-findInProject :: Project ann -> Name -> Either StoreError (NonEmpty ExprHash)
+findInProject ::
+  Project ann ->
+  Name ->
+  Either StoreError (NonEmpty ExprHash)
 findInProject project name =
   case M.lookup name (getVersionedMap $ prjBindings project) of
     Just versioned -> Right versioned
@@ -76,7 +79,9 @@ getStoreExpression (Project store' _ _ _) exprHash =
 getExprDetails ::
   Project Annotation ->
   ExprHash ->
-  Either (Error Annotation) (Expr Variable Annotation, MonoType, Set Usage, ExprHash)
+  Either
+    (Error Annotation)
+    (Expr Name Annotation, MonoType, Set Usage, ExprHash)
 getExprDetails project exprHash = do
   usages <-
     first StoreErr (findUsages project exprHash)
@@ -85,4 +90,9 @@ getExprDetails project exprHash = do
   typeMap <- Actions.getTypeMap project
   resolvedExpr <-
     Actions.resolveStoreExpression (prjStore project) typeMap "" storeExpr
-  pure (reExpression resolvedExpr, reMonoType resolvedExpr, usages, exprHash)
+  pure
+    ( storeExpression (reStoreExpression resolvedExpr),
+      reMonoType resolvedExpr,
+      usages,
+      exprHash
+    )

--- a/compiler/src/Language/Mimsa/Tests/Test.hs
+++ b/compiler/src/Language/Mimsa/Tests/Test.hs
@@ -24,7 +24,6 @@ import Language.Mimsa.Tests.Types
 import Language.Mimsa.Tests.UnitTest
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
-import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Store
 
@@ -140,7 +139,7 @@ runTests ::
   (MonadIO m, MonadError (Error Annotation) m) =>
   Project Annotation ->
   Test ->
-  m (TestResult Variable Annotation)
+  m (TestResult Annotation)
 runTests _ (UTest ut) = pure (UTestResult ut)
 runTests project (PTest pt) =
   PTestResult pt <$> runPropertyTest project pt

--- a/compiler/src/Language/Mimsa/Tests/Types.hs
+++ b/compiler/src/Language/Mimsa/Tests/Types.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -24,6 +25,7 @@ import qualified Data.Text as T
 import GHC.Generics
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Store
 
 newtype TestName = TestName Text
@@ -48,9 +50,9 @@ newtype UnitTestSuccess = UnitTestSuccess Bool
       JSON.FromJSON
     )
 
-data PropertyTestResult var ann
+data PropertyTestResult ann
   = PropertyTestSuccess
-  | PropertyTestFailures (Set (Expr var ann))
+  | PropertyTestFailures (Set (Expr Name ann))
   deriving stock
     ( Eq,
       Ord,
@@ -96,15 +98,15 @@ instance Printer UnitTest where
           _ -> "--- FAIL ---"
      in tickOrCross <> " " <> prettyPrint (utName test)
 
-data TestResult var ann
+data TestResult ann
   = -- | unit test is run once and contains its result
     UTestResult UnitTest
   | -- | property test is effectful and run when returning results
-    PTestResult PropertyTest (PropertyTestResult var ann)
+    PTestResult PropertyTest (PropertyTestResult ann)
   deriving stock (Eq, Ord, Show, Generic)
   deriving anyclass (JSON.ToJSON, JSON.FromJSON)
 
-instance (Show var, Printer var) => Printer (TestResult var ann) where
+instance Printer (TestResult ann) where
   prettyPrint (UTestResult ut) = prettyPrint ut
   prettyPrint (PTestResult pt ptRes) =
     let tickOrCross = case ptRes of

--- a/compiler/src/Language/Mimsa/Typechecker/Exhaustiveness.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Exhaustiveness.hs
@@ -44,14 +44,14 @@ validatePatterns env ann patterns = do
     _ -> case traverse (usePatternSwaps swaps) missing of
       Right missing' ->
         throwError (PatternMatchErr (MissingPatterns ann missing'))
-      Left _ -> error "Can't replace swaps in validate pattern error"
+      Left _ -> throwError SwapsChangingError
   redundant <- redundantCases env patterns
   case redundant of
     [] -> pure ()
     _ -> case traverse (usePatternSwaps swaps) redundant of
       Right redundant' ->
         throwError (PatternMatchErr (RedundantPatterns ann redundant'))
-      Left _ -> error "Can't replace swaps in validate pattern error"
+      Left _ -> throwError SwapsChangingError
 
 withSwap :: Swaps -> Variable -> Name
 withSwap _ (NamedVar n) = n

--- a/compiler/src/Language/Mimsa/Typechecker/Exhaustiveness.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Exhaustiveness.hs
@@ -20,6 +20,7 @@ import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as S
+import Language.Mimsa.Interpreter.UseSwaps
 import Language.Mimsa.Printer
 import Language.Mimsa.Typechecker.Environment
 import Language.Mimsa.Types.AST
@@ -35,15 +36,22 @@ validatePatterns ::
   [Pattern Variable Annotation] ->
   m ()
 validatePatterns env ann patterns = do
+  swaps <- ask
   traverse_ noDuplicateVariables patterns
   missing <- isExhaustive env patterns
   _ <- case missing of
     [] -> pure ()
-    _ -> throwError (PatternMatchErr (MissingPatterns ann missing))
+    _ -> case traverse (usePatternSwaps swaps) missing of
+      Right missing' ->
+        throwError (PatternMatchErr (MissingPatterns ann missing'))
+      Left _ -> error "Can't replace swaps in validate pattern error"
   redundant <- redundantCases env patterns
   case redundant of
     [] -> pure ()
-    _ -> throwError (PatternMatchErr (RedundantPatterns ann redundant))
+    _ -> case traverse (usePatternSwaps swaps) redundant of
+      Right redundant' ->
+        throwError (PatternMatchErr (RedundantPatterns ann redundant'))
+      Left _ -> error "Can't replace swaps in validate pattern error"
 
 withSwap :: Swaps -> Variable -> Name
 withSwap _ (NamedVar n) = n

--- a/compiler/src/Language/Mimsa/Types/Error/InterpreterError.hs
+++ b/compiler/src/Language/Mimsa/Types/Error/InterpreterError.hs
@@ -16,7 +16,6 @@ data InterpreterError ann
   = UnknownInterpreterError
   | CouldNotFindVar (Scope ann) Variable
   | CouldNotFindInfixOp InfixOp
-  | CannotDestructureAsPair (Expr Variable ann)
   | CannotDestructureAsRecord (Expr Variable ann) Name
   | CannotApplyToNonFunction (Expr Variable ann)
   | CannotFindMemberInRecord (Map Name (Expr Variable ann)) Name
@@ -44,34 +43,32 @@ instance (Show ann, Printer ann) => Printer (InterpreterError ann) where
     "Could not find var " <> prettyPrint name
   prettyPrint (CouldNotFindInfixOp op) =
     "Could not find infixOp " <> prettyPrint op
-  prettyPrint (CannotDestructureAsPair expr) =
-    "Expected a pair. Cannot destructure: " <> prettyPrint expr
   prettyPrint (CannotDestructureAsRecord expr name) =
-    "Expected a record with a member " <> prettyPrint name <> ". Cannot destructure: " <> prettyPrint expr
+    "Expected a record with a member " <> prettyPrint name <> ". Cannot destructure: " <> T.pack (show expr)
   prettyPrint (CannotApplyToNonFunction expr) =
-    "Expected a function. Cannot apply a value to " <> prettyPrint expr
+    "Expected a function. Cannot apply a value to " <> T.pack (show expr)
   prettyPrint (CannotFindMemberInRecord items name) =
     "Could not find member " <> prettyPrint name <> " in " <> itemList
     where
       itemList = "[ " <> T.intercalate ", " (prettyPrint <$> M.keys items) <> " ]"
   prettyPrint (PredicateForIfMustBeABoolean expr) =
-    "Expected a boolean as a predicate. Cannot use: " <> prettyPrint expr
+    "Expected a boolean as a predicate. Cannot use: " <> T.pack (show expr)
   prettyPrint (PatternMatchFailure expr') =
-    "Could not pattern match on value " <> prettyPrint expr'
+    "Could not pattern match on value " <> T.pack (show expr')
   prettyPrint (SelfReferencingBinding b) =
     "Could not bind variable " <> prettyPrint b <> " to itself."
   prettyPrint (AdditionWithNonNumber a) =
-    "Addition expected number but got this: " <> prettyPrint a
+    "Addition expected number but got this: " <> T.pack (show a)
   prettyPrint (SubtractionWithNonNumber a) =
-    "Subtraction expected number but got this: " <> prettyPrint a
+    "Subtraction expected number but got this: " <> T.pack (show a)
   prettyPrint (ComparisonWithNonNumber op a) =
-    "Operator " <> prettyPrint op <> " expected number but got this: " <> prettyPrint a
+    "Operator " <> prettyPrint op <> " expected number but got this: " <> T.pack (show a)
   prettyPrint (StringConcatenationFailure a b) =
-    "Concatenation expected string + string but got this: " <> prettyPrint a <> " and " <> prettyPrint b
+    "Concatenation expected string + string but got this: " <> T.pack (show a) <> " and " <> T.pack (show b)
   prettyPrint (ArrayConcatenationFailure a b) =
-    "Concatenation expected array + array but got this: " <> prettyPrint a <> " and " <> prettyPrint b
+    "Concatenation expected array + array but got this: " <> T.pack (show a) <> " and " <> T.pack (show b)
   prettyPrint (TypedHoleFound a) =
-    "Typed hole found " <> prettyPrint a
+    "Typed hole found " <> T.pack (show a)
   prettyPrint (CouldNotFindSwapForVariable var swaps) =
     "Could not find swap for variable " <> prettyPrint var <> " in " <> itemList
     where

--- a/compiler/src/Language/Mimsa/Types/Error/PatternMatchError.hs
+++ b/compiler/src/Language/Mimsa/Types/Error/PatternMatchError.hs
@@ -26,9 +26,9 @@ data PatternMatchErrorF ann
     ConstructorArgumentLengthMismatch ann TyCon Int Int
   | -- | Cases not covered in pattern matches
     -- | ann, [missing patterns]
-    MissingPatterns ann [Pattern Variable ann]
+    MissingPatterns ann [Pattern Name ann]
   | -- | Unnecessary cases covered by previous matches
-    RedundantPatterns ann [Pattern Variable ann]
+    RedundantPatterns ann [Pattern Name ann]
   | -- | Multiple instances of the same variable
     DuplicateVariableUse ann (Set Name)
   deriving stock (Eq, Ord, Show, Foldable)

--- a/compiler/src/Language/Mimsa/Types/Error/TypeError.hs
+++ b/compiler/src/Language/Mimsa/Types/Error/TypeError.hs
@@ -52,6 +52,7 @@ data TypeErrorF ann
   | CannotUseBuiltInTypeAsConstructor ann TyCon
   | InternalConstructorUsedOutsidePatternMatch ann TyCon
   | PatternMatchErr (PatternMatchErrorF ann)
+  | SwapsChangingError
   deriving stock (Eq, Ord, Show, Foldable)
 
 type TypeError = TypeErrorF Annotation
@@ -155,6 +156,7 @@ renderTypeError (TypeConstructorNotInScope env _ constructor) =
     "The following are available:"
   ]
     <> printDataTypes env
+renderTypeError SwapsChangingError = ["Error swapping names back for pattern match error"]
 renderTypeError (TypeNameNotInScope env _ typeName) =
   [ "Type name" <+> prettyDoc typeName
       <+> "not found in scope.",

--- a/compiler/src/Language/Mimsa/Types/Scope.hs
+++ b/compiler/src/Language/Mimsa/Types/Scope.hs
@@ -27,4 +27,4 @@ newtype Scope ann = Scope
 instance (Show ann, Printer ann) => Printer (Scope ann) where
   prettyPrint (Scope s) = "{ " <> T.intercalate ", " (printItem <$> M.toList s) <> " }"
     where
-      printItem (k, a) = prettyPrint k <> ": " <> prettyPrint a
+      printItem (k, a) = prettyPrint k <> ": " <> T.pack (show a)

--- a/compiler/test/Test/Actions/Upgrade.hs
+++ b/compiler/test/Test/Actions/Upgrade.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Actions.Upgrade

--- a/compiler/test/Test/Parser/Syntax.hs
+++ b/compiler/test/Test/Parser/Syntax.hs
@@ -226,6 +226,16 @@ spec = do
                     ("horse", str' "of course")
                   ]
             )
+      it "Parses a record literal with a punned item" $
+        testParse "{dog,cat:True}"
+          `shouldBe` Right
+            ( MyRecord mempty $
+                M.fromList
+                  [ ("dog", MyVar mempty "dog"),
+                    ("cat", bool True)
+                  ]
+            )
+
       it "Parses a destructuring of pairs" $
         testParse "let (a,b) = ((True,1)) in a"
           `shouldBe` Right
@@ -753,6 +763,23 @@ spec = do
                 (MyPair mempty (int 1) (int 2))
                 (MyVar mempty "a")
             )
+      it "parses destructuring a record with puns" $
+        testParse "let {a,b:c} = { a: 1, b: 2}; c"
+          `shouldBe` Right
+            ( MyLetPattern
+                mempty
+                ( PRecord
+                    mempty
+                    ( M.fromList
+                        [ ("a", PVar mempty "a"),
+                          ("b", PVar mempty "c")
+                        ]
+                    )
+                )
+                (MyRecord mempty (M.fromList [("a", int 1), ("b", int 2)]))
+                (MyVar mempty "c")
+            )
+
     describe "Test annotations" $ do
       it "Parses a var with location information" $
         testParseWithAnn "dog" `shouldBe` Right (MyVar (Location 0 3) "dog")


### PR DESCRIPTION
Resolves #444 

This allows record punning. Before we could allow this the pretty printing for Expressions needed to be made more specific so it's for `Expr Name ann` instead of `Expr var ann`, so the `Name` can be compared with the name in the record. This is fine, but required a few `useSwaps` to be used, mostly in error printing.

<img width="295" alt="Screenshot 2022-01-17 at 22 43 59" src="https://user-images.githubusercontent.com/4729125/149844759-26cef161-fc9f-430e-be6f-d7ed0682e6c5.png">

<img width="278" alt="Screenshot 2022-01-17 at 22 44 03" src="https://user-images.githubusercontent.com/4729125/149844757-f0749fc1-92e9-483f-8158-c5a20fff9591.png">


