### PR TITLE
Context test

### DIFF
--- a/compiler/mimsa.cabal
+++ b/compiler/mimsa.cabal
@@ -117,6 +117,7 @@ library
       Language.Mimsa.Typechecker.Environment
       Language.Mimsa.Typechecker.Exhaustiveness
       Language.Mimsa.Typechecker.Generalise
+      Language.Mimsa.Typechecker.HoistContext
       Language.Mimsa.Typechecker.KindChecker
       Language.Mimsa.Typechecker.NormaliseTypes
       Language.Mimsa.Typechecker.OutputTypes

--- a/compiler/src/Language/Mimsa/Backend/Typescript/FromExpr.hs
+++ b/compiler/src/Language/Mimsa/Backend/Typescript/FromExpr.hs
@@ -354,3 +354,5 @@ toTSBody expr' =
       fnExpr <- toTSExpr fn
       addInfix op fnExpr
       toTSBody body
+    (MyFromContext _ _) ->
+      error "need to implement MyFromContext in TS FromExpr"

--- a/compiler/src/Language/Mimsa/Backend/Typescript/FromExpr.hs
+++ b/compiler/src/Language/Mimsa/Backend/Typescript/FromExpr.hs
@@ -110,6 +110,8 @@ toTSType (MTRecordRow _ as rest) = do
   (tsItems, generics) <- toTSTypeRecord as
   (tsRest, genRest) <- toTSType rest
   pure (TSTypeAnd tsItems tsRest, generics <> genRest)
+toTSType (MTContext _ _ctx _inner) =
+  error "Haven't worked out how contexts work in TS"
 
 toTSDataType :: DataType -> TypescriptM TSDataType
 toTSDataType (DataType name gens cons) = do

--- a/compiler/src/Language/Mimsa/Interpreter/UseSwaps.hs
+++ b/compiler/src/Language/Mimsa/Interpreter/UseSwaps.hs
@@ -77,6 +77,8 @@ useSwaps' (MyDefineInfix ann infixOp bindExpr expr) =
     infixOp
     <$> useSwaps' bindExpr
     <*> useSwaps' expr
+useSwaps' (MyFromContext ann name) =
+  pure $ MyFromContext ann name
 
 useSwapsInIdentifier :: Identifier Variable ann -> App ann (Identifier Name ann)
 useSwapsInIdentifier (Identifier ann var) =

--- a/compiler/src/Language/Mimsa/Parser/Helpers.hs
+++ b/compiler/src/Language/Mimsa/Parser/Helpers.hs
@@ -24,6 +24,7 @@ import Data.Bifunctor (first)
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
+import Language.Mimsa.ExprUtils
 import Language.Mimsa.Parser.Types
 import Language.Mimsa.Types.AST
 import Text.Megaparsec
@@ -54,29 +55,6 @@ withLocation withP p = do
 -- | wraps any parser of Exprs and adds location information
 addLocation :: Parser ParserExpr -> Parser ParserExpr
 addLocation = withLocation (mapOuterExprAnnotation . const)
-
--- | modify the outer annotation of an expression
--- useful for adding line numbers during parsing
-mapOuterExprAnnotation :: (ann -> ann) -> Expr a ann -> Expr a ann
-mapOuterExprAnnotation f expr' =
-  case expr' of
-    MyInfix ann a op b -> MyInfix (f ann) a op b
-    MyLiteral ann a -> MyLiteral (f ann) a
-    MyVar ann a -> MyVar (f ann) a
-    MyLet ann a b c -> MyLet (f ann) a b c
-    MyLetPattern ann a b c -> MyLetPattern (f ann) a b c
-    MyLambda ann a b -> MyLambda (f ann) a b
-    MyApp ann a b -> MyApp (f ann) a b
-    MyIf ann a b c -> MyIf (f ann) a b c
-    MyPair ann a b -> MyPair (f ann) a b
-    MyRecord ann as -> MyRecord (f ann) as
-    MyRecordAccess ann a b -> MyRecordAccess (f ann) a b
-    MyArray ann as -> MyArray (f ann) as
-    MyData ann a b -> MyData (f ann) a b
-    MyConstructor ann a -> MyConstructor (f ann) a
-    MyTypedHole ann a -> MyTypedHole (f ann) a
-    MyDefineInfix ann a b c -> MyDefineInfix (f ann) a b c
-    MyPatternMatch ann a b -> MyPatternMatch (f ann) a b
 
 -----
 

--- a/compiler/src/Language/Mimsa/Project/TypeSearch.hs
+++ b/compiler/src/Language/Mimsa/Project/TypeSearch.hs
@@ -54,6 +54,8 @@ isSimple (MTRecordRow _ as b) =
 isSimple (MTArray _ as) = isSimple as
 isSimple (MTConstructor _ _) = True
 isSimple (MTTypeApp _ fn val) = isSimple fn && isSimple val
+isSimple (MTContext _ ctx inner) =
+  isSimple inner && isSimple ctx
 
 unify' :: MonoType -> MonoType -> Either TypeError Substitutions
 unify' mtA mtB = runUnifyM mempty (unify mtA mtB)

--- a/compiler/src/Language/Mimsa/Store/ExtractTypes.hs
+++ b/compiler/src/Language/Mimsa/Store/ExtractTypes.hs
@@ -92,7 +92,7 @@ extractConstructors (DataType _ _ cons) = mconcat (extractFromCons . snd <$> M.t
     extractFromCon (MTRecordRow _ items rest) =
       mconcat (extractFromCon <$> M.elems items) <> extractFromCon rest
     extractFromCon (MTContext _ ctx inner) =
-      extractFromCon ctx
+      mconcat (extractFromCon <$> M.elems ctx)
         <> extractFromCon inner
 
 -- get all the names of constructors (type and data) declared in the datatype
@@ -158,7 +158,7 @@ extractTypenames MTVar {} = mempty
 extractTypenames (MTFunction _ a b) =
   extractTypenames a <> extractTypenames b
 extractTypenames (MTContext _ ctx inner) =
-  extractTypenames ctx
+  mconcat (extractTypenames <$> M.elems ctx)
     <> extractTypenames inner
 
 -----
@@ -182,5 +182,5 @@ extractNamedTypeVars MTPrim {} = mempty
 extractNamedTypeVars (MTFunction _ a b) =
   extractNamedTypeVars a <> extractNamedTypeVars b
 extractNamedTypeVars (MTContext _ ctx inner) =
-  extractNamedTypeVars ctx
+  mconcat (extractNamedTypeVars <$> M.elems ctx)
     <> extractNamedTypeVars inner

--- a/compiler/src/Language/Mimsa/Store/ExtractTypes.hs
+++ b/compiler/src/Language/Mimsa/Store/ExtractTypes.hs
@@ -51,6 +51,7 @@ extractTypes_ (MyConstructor _ t) = S.singleton t
 extractTypes_ (MyTypedHole _ _) = mempty
 extractTypes_ (MyDefineInfix _ _ a b) =
   extractTypes_ a <> extractTypes_ b
+extractTypes_ (MyFromContext _ _) = mempty
 extractTypes_ (MyPatternMatch _ expr patterns) =
   extractTypes_ expr
     <> mconcat (extractTypes_ . snd <$> patterns)
@@ -129,6 +130,7 @@ withDataTypes _ (MyConstructor _ _) = mempty
 withDataTypes _ (MyTypedHole _ _) = mempty
 withDataTypes f (MyDefineInfix _ _ infixA a) =
   withDataTypes f infixA <> withDataTypes f a
+withDataTypes _ (MyFromContext _ _) = mempty
 withDataTypes f (MyPatternMatch _ expr patterns) =
   withDataTypes f expr
     <> mconcat (withDataTypes f . snd <$> patterns)

--- a/compiler/src/Language/Mimsa/Store/ExtractTypes.hs
+++ b/compiler/src/Language/Mimsa/Store/ExtractTypes.hs
@@ -90,6 +90,9 @@ extractConstructors (DataType _ _ cons) = mconcat (extractFromCons . snd <$> M.t
     extractFromCon (MTRecord _ items) = mconcat (extractFromCon <$> M.elems items)
     extractFromCon (MTRecordRow _ items rest) =
       mconcat (extractFromCon <$> M.elems items) <> extractFromCon rest
+    extractFromCon (MTContext _ ctx inner) =
+      extractFromCon ctx
+        <> extractFromCon inner
 
 -- get all the names of constructors (type and data) declared in the datatype
 extractLocalTypeDeclarations :: DataType -> Set TyCon
@@ -152,6 +155,9 @@ extractTypenames MTPrim {} = mempty
 extractTypenames MTVar {} = mempty
 extractTypenames (MTFunction _ a b) =
   extractTypenames a <> extractTypenames b
+extractTypenames (MTContext _ ctx inner) =
+  extractTypenames ctx
+    <> extractTypenames inner
 
 -----
 
@@ -173,3 +179,6 @@ extractNamedTypeVars (MTRecordRow _ as a) =
 extractNamedTypeVars MTPrim {} = mempty
 extractNamedTypeVars (MTFunction _ a b) =
   extractNamedTypeVars a <> extractNamedTypeVars b
+extractNamedTypeVars (MTContext _ ctx inner) =
+  extractNamedTypeVars ctx
+    <> extractNamedTypeVars inner

--- a/compiler/src/Language/Mimsa/Store/ExtractVars.hs
+++ b/compiler/src/Language/Mimsa/Store/ExtractVars.hs
@@ -38,6 +38,7 @@ extractVars_ (MyData _ _ a) = extractVars_ a
 extractVars_ (MyConstructor _ _) = mempty
 extractVars_ (MyTypedHole _ _) = mempty
 extractVars_ (MyDefineInfix _ _ a b) = extractVars_ a <> extractVars_ b
+extractVars_ (MyFromContext _ _) = mempty
 extractVars_ (MyPatternMatch _ match patterns) =
   extractVars match <> mconcat patternVars
   where

--- a/compiler/src/Language/Mimsa/Store/Substitutor.hs
+++ b/compiler/src/Language/Mimsa/Store/Substitutor.hs
@@ -249,6 +249,7 @@ mapVar chg (MyPatternMatch ann expr' patterns) = do
   patterns' <- traverse mapVarPair patterns
   MyPatternMatch ann <$> mapVar chg expr' <*> pure patterns'
 mapVar _ (MyTypedHole ann a) = pure $ MyTypedHole ann a
+mapVar _ (MyFromContext ann name) = pure (MyFromContext ann name)
 mapVar chg (MyDefineInfix ann infixOp bindExpr expr) =
   MyDefineInfix
     ann

--- a/compiler/src/Language/Mimsa/Tests/Generate.hs
+++ b/compiler/src/Language/Mimsa/Tests/Generate.hs
@@ -59,6 +59,8 @@ fromMonoType gs mt =
     mtCons@MTConstructor {} -> case varsFromDataType mtCons of
       Just (typeName, args) -> fromType gs typeName args
       Nothing -> error "could not work out datatype"
+    MTContext _ _ctx _inner ->
+      error "cannot generate for context"
 
 -- | take the args for the type and apply them to the type
 typeApply :: [MonoType] -> DataType -> Map TyCon [Type NullUnit]

--- a/compiler/src/Language/Mimsa/Typechecker/DataTypes.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/DataTypes.hs
@@ -141,6 +141,9 @@ getVariablesForField (MTVar _ (TVUnificationVar _)) = S.empty
 getVariablesForField MTPrim {} = S.empty
 getVariablesForField MTConstructor {} = S.empty
 getVariablesForField (MTTypeApp _ a b) = getVariablesForField a <> getVariablesForField b
+getVariablesForField (MTContext _ ctx inner) =
+  getVariablesForField ctx
+    <> getVariablesForField inner
 
 validateConstructors ::
   (MonadError TypeError m) =>
@@ -213,6 +216,10 @@ inferConstructorTypes (DataType typeName tyVarNames constructors) = do
           MTTypeApp mempty <$> findType func <*> findType arg
         MTVar _ (TVUnificationVar _) ->
           throwError UnknownTypeError -- should not happen but yolo
+        MTContext _ ctx inner ->
+          MTContext mempty <$> findType ctx
+            <*> findType inner
+
   let inferConstructor (consName, tyArgs) = do
         tyCons <- traverse findType tyArgs
         let constructor = TypeConstructor typeName (snd <$> tyVars) tyCons

--- a/compiler/src/Language/Mimsa/Typechecker/Generalise.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Generalise.hs
@@ -14,14 +14,16 @@ freeTypeVars :: MonoType -> [TypeIdentifier]
 freeTypeVars (MTVar _ b) = [b]
 freeTypeVars (MTFunction _ t1 t2) = freeTypeVars t1 <> freeTypeVars t2
 freeTypeVars (MTPair _ a b) = freeTypeVars a <> freeTypeVars b
-freeTypeVars (MTRecord _ as) = mconcat (freeTypeVars . snd <$> M.toList as)
+freeTypeVars (MTRecord _ as) = mconcat (freeTypeVars <$> M.elems as)
 freeTypeVars (MTRecordRow _ as rest) =
-  mconcat (freeTypeVars . snd <$> M.toList as)
+  mconcat (freeTypeVars <$> M.elems as)
     <> freeTypeVars rest
 freeTypeVars (MTArray _ a) = freeTypeVars a
 freeTypeVars (MTPrim _ _) = mempty
 freeTypeVars (MTConstructor _ _) = mempty
 freeTypeVars (MTTypeApp _ a b) = freeTypeVars a <> freeTypeVars b
+freeTypeVars (MTContext _ ctx inner) =
+  freeTypeVars ctx <> freeTypeVars inner
 
 freeTypeVarsScheme :: Scheme -> [TypeIdentifier]
 freeTypeVarsScheme (Scheme vars t) =

--- a/compiler/src/Language/Mimsa/Typechecker/Generalise.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Generalise.hs
@@ -22,8 +22,8 @@ freeTypeVars (MTArray _ a) = freeTypeVars a
 freeTypeVars (MTPrim _ _) = mempty
 freeTypeVars (MTConstructor _ _) = mempty
 freeTypeVars (MTTypeApp _ a b) = freeTypeVars a <> freeTypeVars b
-freeTypeVars (MTContext _ ctx inner) =
-  freeTypeVars ctx <> freeTypeVars inner
+freeTypeVars (MTContext _ _ inner) =
+  freeTypeVars inner -- vars in context aren't free
 
 freeTypeVarsScheme :: Scheme -> [TypeIdentifier]
 freeTypeVarsScheme (Scheme vars t) =

--- a/compiler/src/Language/Mimsa/Typechecker/HoistContext.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/HoistContext.hs
@@ -1,0 +1,38 @@
+module Language.Mimsa.Typechecker.HoistContext where
+
+import Data.Map (Map)
+import qualified Data.Map as M
+import Language.Mimsa.ExprUtils
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Typechecker
+
+mtBool :: MonoType
+mtBool = MTPrim mempty MTBool
+
+addCtx :: MonoType -> Map Name MonoType -> MonoType
+addCtx mt items | M.null items = mt
+addCtx (MTContext ann (MTRecordRow rrAnn existingItems restRow) restMt) items =
+  MTContext ann (MTRecordRow rrAnn (existingItems <> items) restRow) restMt
+addCtx mt items =
+  let existingAnn = getAnnotationForType mt
+   in MTContext existingAnn (MTRecordRow existingAnn items mtBool) mt
+
+-- chop out any contexts and put them on the top of the expr
+hoistContext :: Expr var MonoType -> Expr var MonoType
+hoistContext expr =
+  let (newExpr, newCtx) = hoistContext' expr
+   in mapOuterExprAnnotation (`addCtx` newCtx) newExpr
+  where
+    hoistContext' :: Expr var MonoType -> (Expr var MonoType, Map Name MonoType)
+    hoistContext' (MyLet mt ident letExpr letBody) =
+      let (letExpr', inner1) = hoistContext' letExpr
+          (letBody', inner2) = hoistContext' letBody
+          newCtx = inner1 <> inner2
+       in (MyLet (addCtx mt newCtx) ident letExpr' letBody', newCtx)
+    hoistContext' (MyFromContext mt name) =
+      let (newCtx, newInner) = case mt of
+            (MTContext _ (MTRecordRow _ items _) actualMt) -> (items, actualMt)
+            _ -> (mempty, mt)
+       in (MyFromContext newInner name, newCtx)
+    hoistContext' other = (other, mempty)

--- a/compiler/src/Language/Mimsa/Typechecker/HoistContext.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/HoistContext.hs
@@ -12,11 +12,11 @@ mtBool = MTPrim mempty MTBool
 
 addCtx :: MonoType -> Map Name MonoType -> MonoType
 addCtx mt items | M.null items = mt
-addCtx (MTContext ann (MTRecordRow rrAnn existingItems restRow) restMt) items =
-  MTContext ann (MTRecordRow rrAnn (existingItems <> items) restRow) restMt
+addCtx (MTContext ann existingItems restMt) items =
+  MTContext ann (existingItems <> items) restMt
 addCtx mt items =
   let existingAnn = getAnnotationForType mt
-   in MTContext existingAnn (MTRecordRow existingAnn items mtBool) mt
+   in MTContext existingAnn items mt
 
 -- chop out any contexts and put them on the top of the expr
 hoistContext :: Expr var MonoType -> Expr var MonoType
@@ -32,7 +32,7 @@ hoistContext expr =
        in (MyLet (addCtx mt newCtx) ident letExpr' letBody', newCtx)
     hoistContext' (MyFromContext mt name) =
       let (newCtx, newInner) = case mt of
-            (MTContext _ (MTRecordRow _ items _) actualMt) -> (items, actualMt)
+            (MTContext _ items actualMt) -> (items, actualMt)
             _ -> (mempty, mt)
        in (MyFromContext newInner name, newCtx)
     hoistContext' other = (other, mempty)

--- a/compiler/src/Language/Mimsa/Typechecker/NormaliseTypes.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/NormaliseTypes.hs
@@ -50,5 +50,5 @@ normaliseType' mt = case mt of
   MTTypeApp ann func arg ->
     MTTypeApp ann <$> normaliseType' func <*> normaliseType' arg
   MTContext ann ctx inner ->
-    MTContext ann <$> normaliseType' ctx
+    MTContext ann <$> traverse normaliseType' ctx
       <*> normaliseType' inner

--- a/compiler/src/Language/Mimsa/Typechecker/NormaliseTypes.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/NormaliseTypes.hs
@@ -49,3 +49,6 @@ normaliseType' mt = case mt of
     pure (MTConstructor ann name)
   MTTypeApp ann func arg ->
     MTTypeApp ann <$> normaliseType' func <*> normaliseType' arg
+  MTContext ann ctx inner ->
+    MTContext ann <$> normaliseType' ctx
+      <*> normaliseType' inner

--- a/compiler/src/Language/Mimsa/Typechecker/OutputTypes.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/OutputTypes.hs
@@ -99,4 +99,5 @@ foldExpr fn expression =
     foldExpr' (MyData ann _ body) =
       f ann <> foldExpr fn body
     foldExpr' (MyConstructor ann _) = f ann
+    foldExpr' (MyFromContext ann _) = f ann
     foldExpr' (MyTypedHole ann _) = f ann

--- a/compiler/src/Language/Mimsa/Typechecker/ScopeTypeVar.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/ScopeTypeVar.hs
@@ -72,5 +72,5 @@ freshenNamedTypeVars known =
     freshen (MTFunction ann a b) =
       MTFunction ann <$> freshen a <*> freshen b
     freshen (MTContext ann ctx inner) =
-      MTContext ann <$> freshen ctx
+      MTContext ann <$> traverse freshen ctx
         <*> freshen inner

--- a/compiler/src/Language/Mimsa/Typechecker/ScopeTypeVar.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/ScopeTypeVar.hs
@@ -71,3 +71,6 @@ freshenNamedTypeVars known =
     freshen mtP@MTPrim {} = pure mtP
     freshen (MTFunction ann a b) =
       MTFunction ann <$> freshen a <*> freshen b
+    freshen (MTContext ann ctx inner) =
+      MTContext ann <$> freshen ctx
+        <*> freshen inner

--- a/compiler/src/Language/Mimsa/Typechecker/Unify.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Unify.hs
@@ -37,6 +37,8 @@ freeTypeVars ty = case ty of
   MTPrim _ _ -> S.empty
   MTConstructor _ _ -> S.empty
   MTTypeApp _ a b -> freeTypeVars a <> freeTypeVars b
+  MTContext _ ctx inner ->
+    freeTypeVars ctx <> freeTypeVars inner
 
 -- | Creates a fresh unification variable and binds it to the given type
 varBind ::
@@ -71,8 +73,8 @@ isNamedVar _ = False
 
 -- these are tricky to deal with, so flatten them on the way in
 flattenRow :: MonoType -> MonoType
-flattenRow (MTRecordRow ann as (MTRecordRow _ann' bs rest)) =
-  flattenRow (MTRecordRow ann (as <> bs) rest)
+flattenRow (MTRecordRow ann as (MTRecordRow ann' bs rest)) =
+  flattenRow (MTRecordRow (ann <> ann') (as <> bs) rest)
 flattenRow other = other
 
 checkMatching ::

--- a/compiler/src/Language/Mimsa/Typechecker/Unify.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Unify.hs
@@ -37,8 +37,8 @@ freeTypeVars ty = case ty of
   MTPrim _ _ -> S.empty
   MTConstructor _ _ -> S.empty
   MTTypeApp _ a b -> freeTypeVars a <> freeTypeVars b
-  MTContext _ ctx inner ->
-    freeTypeVars ctx <> freeTypeVars inner
+  MTContext _ _ctx inner ->
+    freeTypeVars inner -- vars in context aren't free
 
 -- | Creates a fresh unification variable and binds it to the given type
 varBind ::
@@ -196,6 +196,12 @@ unify tyA tyB =
     (MTArray _ a, MTArray _ b) -> unify a b
     (MTVar ann u, t) -> varBind ann u t
     (t, MTVar ann u) -> varBind ann u t
+    (MTContext _ ctxA restA, MTContext _ ctxB restB) ->
+      unifyPairs (ctxA, restA) (ctxB, restB)
+    (MTContext _ _ctxA rest, b) ->
+      unify rest b
+    (a, MTContext _ _ctxB rest) ->
+      unify a rest
     (a, b) ->
       throwError $ UnificationError a b
 

--- a/compiler/src/Language/Mimsa/Typechecker/Unify.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Unify.hs
@@ -196,8 +196,10 @@ unify tyA tyB =
     (MTArray _ a, MTArray _ b) -> unify a b
     (MTVar ann u, t) -> varBind ann u t
     (t, MTVar ann u) -> varBind ann u t
-    (MTContext _ ctxA restA, MTContext _ ctxB restB) ->
-      unifyPairs (ctxA, restA) (ctxB, restB)
+    (MTContext ann ctxA restA, MTContext ann' ctxB restB) -> do
+      subs <- unifyRecords (ann, ctxA) (ann', ctxB)
+      subsInner <- unify restA restB
+      pure (subs <> subsInner)
     (MTContext _ _ctxA rest, b) ->
       unify rest b
     (a, MTContext _ _ctxB rest) ->

--- a/compiler/src/Language/Mimsa/Types/AST/Expr.hs
+++ b/compiler/src/Language/Mimsa/Types/AST/Expr.hs
@@ -130,6 +130,11 @@ data Expr var ann
         expPatterns :: [(Pattern var ann, Expr var ann)]
       }
   | -- | name
+    MyFromContext
+      { expAnn :: ann,
+        expCtxItemName :: Name
+      }
+  | -- | name
     MyTypedHole {expAnn :: ann, expTypedHoleName :: Name}
   deriving stock (Eq, Ord, Show, Functor, Generic)
   deriving anyclass (JSON.FromJSON, JSON.ToJSON)
@@ -374,6 +379,7 @@ instance (Show var, Printer var) => Printer (Expr var ann) where
   prettyDoc (MyTypedHole _ name) = "?" <> prettyDoc name
   prettyDoc (MyPatternMatch _ expr matches) =
     prettyPatternMatch expr matches
+  prettyDoc (MyFromContext _ name) = "!" <> prettyDoc name
 
 wrapInfix :: (Show var, Printer var) => Expr var ann -> Doc style
 wrapInfix val = case val of

--- a/compiler/src/Language/Mimsa/Types/Typechecker/MonoType.hs
+++ b/compiler/src/Language/Mimsa/Types/Typechecker/MonoType.hs
@@ -88,7 +88,7 @@ data Type ann
       }
   | MTContext
       { typAnn :: ann,
-        typContext :: Type ann, -- row of items
+        typContext :: Map Name (Type ann), -- row of items
         typInner :: Type ann -- type using the context
       }
   deriving stock (Eq, Ord, Show, Functor, Foldable, Generic)
@@ -165,7 +165,24 @@ renderMonoType mt@(MTTypeApp _ func arg) =
     Nothing ->
       align $ sep [renderMonoType func, renderMonoType arg]
 renderMonoType (MTContext _ ctx inner) =
-  renderMonoType ctx <+> "=>" <+> renderMonoType inner
+  let renderItem (Name k, v) = pretty k <> ":" <+> withParens v
+      prettyCtx =
+        group $
+          "{"
+            <> nest
+              2
+              ( line
+                  <> mconcat
+                    ( punctuate
+                        ("," <> line)
+                        ( renderItem
+                            <$> M.toList ctx
+                        )
+                    )
+              )
+            <> line
+            <> "}"
+   in prettyCtx <+> "=>" <+> renderMonoType inner
 
 -- turn nested shit back into something easy to pretty print (ie, easy to
 -- bracket)

--- a/compiler/src/Language/Mimsa/Types/Typechecker/MonoType.hs
+++ b/compiler/src/Language/Mimsa/Types/Typechecker/MonoType.hs
@@ -86,6 +86,11 @@ data Type ann
         typFunc :: Type ann,
         typArg :: Type ann -- func arg, apply arg to func
       }
+  | MTContext
+      { typAnn :: ann,
+        typContext :: Type ann, -- row of items
+        typInner :: Type ann -- type using the context
+      }
   deriving stock (Eq, Ord, Show, Functor, Foldable, Generic)
   deriving anyclass (JSON.ToJSON, JSON.FromJSON)
 
@@ -99,6 +104,7 @@ getAnnotationForType (MTRecordRow ann _ _) = ann
 getAnnotationForType (MTConstructor ann _) = ann
 getAnnotationForType (MTArray ann _) = ann
 getAnnotationForType (MTTypeApp ann _ _) = ann
+getAnnotationForType (MTContext ann _ _) = ann
 
 instance Printer (Type ann) where
   prettyDoc = renderMonoType
@@ -158,6 +164,8 @@ renderMonoType mt@(MTTypeApp _ func arg) =
     Just (TyCon n, vars) -> align $ sep ([pretty n] <> (withParens <$> vars))
     Nothing ->
       align $ sep [renderMonoType func, renderMonoType arg]
+renderMonoType (MTContext _ ctx inner) =
+  renderMonoType ctx <+> "=>" <+> renderMonoType inner
 
 -- turn nested shit back into something easy to pretty print (ie, easy to
 -- bracket)

--- a/compiler/src/Language/Mimsa/Types/Typechecker/Substitutions.hs
+++ b/compiler/src/Language/Mimsa/Types/Typechecker/Substitutions.hs
@@ -74,6 +74,8 @@ instance Substitutable (Type ann) where
       MTTypeApp ann (applySubst subst func) (applySubst subst arg)
     MTConstructor ann cn -> MTConstructor ann cn
     MTPrim ann a -> MTPrim ann a
+    MTContext ann ctx inner ->
+      MTContext ann (applySubst subst ctx) (applySubst subst inner)
 
 instance (Substitutable a) => Substitutable (Map k a) where
   applySubst subst as = applySubst subst <$> as

--- a/compiler/test/Test/Actions/Upgrade.hs
+++ b/compiler/test/Test/Actions/Upgrade.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Actions.Upgrade

--- a/compiler/test/Test/Typechecker/Typecheck.hs
+++ b/compiler/test/Test/Typechecker/Typecheck.hs
@@ -1153,7 +1153,12 @@ spec = do
               (Identifier mempty $ named "this")
               (MyIf mempty (MyTypedHole mempty "what") (int 1) (int 2))
       startInference expr $ Left (TypedHoles (M.singleton "what" (MTPrim mempty MTBool, S.singleton "this")))
-
+    {-
+      describe "Contexts" $ do
+        xit "Context spreads from let binding" $ do
+          let expr
+            = MyLet mempty (Identifier mempty "a")
+    -}
     describe "type annotations" $ do
       it "Let annotation matches value" $ do
         let expr =

--- a/compiler/test/Test/Typechecker/Typecheck.hs
+++ b/compiler/test/Test/Typechecker/Typecheck.hs
@@ -1198,6 +1198,42 @@ spec = do
         startInference expr $
           Left (UnificationError mtString mtInt)
 
+      it "Finds context for MyFromContext" $ do
+        let expr =
+              MyFromContext mempty "true"
+        startInference expr $
+          Right
+            ( MTContext
+                mempty
+                ( MTRecordRow
+                    mempty
+                    ( M.singleton "true" (mtUniVar 0)
+                    )
+                    (mtUniVar 1)
+                )
+                (mtUniVar 0)
+            )
+      it "Pass context to parent typ" $ do
+        let expr =
+              MyLet
+                mempty
+                (Identifier mempty (named "a"))
+                ( MyFromContext mempty "true"
+                )
+                (bool True)
+        startInference expr $
+          Right
+            ( MTContext
+                mempty
+                ( MTRecordRow
+                    mempty
+                    ( M.singleton "true" (mtUniVar 0)
+                    )
+                    (mtUniVar 1)
+                )
+                (mtUniVar 0)
+            )
+
     -- needs type annotations to make this make sense
     xit "Lambda variable as constructor" $ do
       let expr =

--- a/compiler/test/Test/Typechecker/Unify.hs
+++ b/compiler/test/Test/Typechecker/Unify.hs
@@ -32,7 +32,7 @@ runUnifier (a, b) =
 
 spec :: Spec
 spec =
-  describe "Unify" $ do
+  fdescribe "Unify" $ do
     it "Two same things teach us nothing" $
       runUnifier (MTPrim mempty MTInt, MTPrim mempty MTInt) `shouldBe` Right mempty
     it "Combines a known with an unknown" $
@@ -50,6 +50,20 @@ spec =
                   (TVUnificationVar 2, MTPrim mempty MTInt)
                 ]
           )
+    describe "Contexts" $ do
+      it "Empty combines with itself" $
+        runUnifier
+          ( MTContext mempty (MTRecord mempty mempty) mtInt,
+            MTContext mempty (MTRecord mempty mempty) mtInt
+          )
+          `shouldBe` Right mempty
+      it "Empty context unifies using item inside" $
+        runUnifier
+          ( MTContext mempty (MTRecord mempty mempty) mtInt,
+            mtInt
+          )
+          `shouldBe` Right mempty
+
     describe "Constructors" $ do
       it "Combines a Maybe" $ do
         runUnifier

--- a/compiler/test/Test/Utils/Helpers.hs
+++ b/compiler/test/Test/Utils/Helpers.hs
@@ -111,6 +111,9 @@ mtString = MTPrim mempty MTString
 mtVar :: Text -> MonoType
 mtVar n = MTVar mempty (tvNamed n)
 
+mtUniVar :: Int -> MonoType
+mtUniVar i = MTVar mempty (tvNum i)
+
 ----
 
 additionalTests :: Project ann -> Project ann -> Int


### PR DESCRIPTION
Test implementation of #453

This is going to be a mess, I can feel it.

Stuff like this is called `coeffects`, incidentally.

So far this extends the `MonoType` with more stuff, perhaps we should have a second round of typechecking that adds another layer, so it becomes `(MonoType, Context)`, or similar, where we make each context use raise up to the top (unless it is provided).