### PR TITLE
Unused let pattern

### DIFF
--- a/compiler/server/Server/Helpers/ExpressionData.hs
+++ b/compiler/server/Server/Helpers/ExpressionData.hs
@@ -66,8 +66,9 @@ makeExpressionData ::
   Expr Name MonoType ->
   [Graphviz] ->
   Text ->
+  [Warning] ->
   ExpressionData
-makeExpressionData se typedExpr gv input =
+makeExpressionData se typedExpr gv input warnings =
   let mt = getTypeFromAnn typedExpr
       exprHash = getStoreExpressionHash se
 
@@ -84,4 +85,4 @@ makeExpressionData se typedExpr gv input =
         (prettyGraphviz gv)
         (getExpressionSourceItems input typedExpr)
         input
-        (prettyPrint <$> getWarnings se)
+        (prettyPrint <$> warnings)

--- a/compiler/server/Server/Project/BindExpression.hs
+++ b/compiler/server/Server/Project/BindExpression.hs
@@ -20,6 +20,7 @@ import qualified Language.Mimsa.Actions.BindExpression as Actions
 import qualified Language.Mimsa.Actions.Graph as Actions
 import qualified Language.Mimsa.Actions.Helpers.Parse as Actions
 import qualified Language.Mimsa.Actions.Helpers.Swaps as Actions
+import Language.Mimsa.Transform.Warnings
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.ResolvedExpression
@@ -60,11 +61,12 @@ bindExpression ::
 bindExpression mimsaEnv (BindExpressionRequest projectHash name' input) = runMimsaHandlerT $ do
   let action = do
         expr <- Actions.parseExpr input
-        (_, _, ResolvedExpression _ se _ _ swaps typedExpr input') <-
+        (_, _, resolved@(ResolvedExpression _ se _ _ swaps typedExpr input')) <-
           Actions.bindExpression expr name' input
         gv <- Actions.graphExpression se
         typedNameExpr <- Actions.useSwaps swaps typedExpr
-        pure $ makeExpressionData se typedNameExpr gv input'
+        let warnings = getWarnings resolved
+        pure $ makeExpressionData se typedNameExpr gv input' warnings
   store' <- lift $ readStoreHandler mimsaEnv
   project <- lift $ loadProjectHandler mimsaEnv store' projectHash
   response <-

--- a/compiler/server/Server/Project/BindType.hs
+++ b/compiler/server/Server/Project/BindType.hs
@@ -20,6 +20,7 @@ import qualified Language.Mimsa.Actions.Helpers.Parse as Actions
 import qualified Language.Mimsa.Actions.Helpers.Swaps as Actions
 import Language.Mimsa.Codegen
 import Language.Mimsa.Printer
+import Language.Mimsa.Transform.Warnings
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.ResolvedExpression
@@ -73,7 +74,8 @@ bindType mimsaEnv (BindTypeRequest projectHash input) = runMimsaHandlerT $ do
                 (reSwaps resolvedExpr)
                 (reTypedExpression resolvedExpr)
             gv <- Actions.graphExpression se
-            let ed' = makeExpressionData se typedNameExpr gv input
+            let warnings = getWarnings resolvedExpr
+            let ed' = makeExpressionData se typedNameExpr gv input warnings
             pure (Just ed')
           Nothing -> pure Nothing
         pure (ed, typeClasses, dt)

--- a/compiler/server/Server/Project/GetExpression.hs
+++ b/compiler/server/Server/Project/GetExpression.hs
@@ -14,6 +14,7 @@ import qualified Data.Aeson as JSON
 import Data.OpenApi
 import GHC.Generics
 import qualified Language.Mimsa.Actions.Graph as Actions
+import Language.Mimsa.Transform.Warnings
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.ResolvedExpression
 import Language.Mimsa.Types.Store
@@ -63,6 +64,7 @@ getExpression mimsaEnv (GetExpressionRequest projectHash exprHash') = do
     useSwapsHandler
       (reSwaps resolvedExpr)
       (reTypedExpression resolvedExpr)
+  let warnings = getWarnings resolvedExpr
   pure $
     GetExpressionResponse
-      (makeExpressionData se typedExpr graphviz (reInput resolvedExpr))
+      (makeExpressionData se typedExpr graphviz (reInput resolvedExpr) warnings)

--- a/compiler/server/Server/Project/Optimise.hs
+++ b/compiler/server/Server/Project/Optimise.hs
@@ -20,6 +20,7 @@ import GHC.Generics
 import qualified Language.Mimsa.Actions.Graph as Actions
 import qualified Language.Mimsa.Actions.Helpers.Swaps as Actions
 import qualified Language.Mimsa.Actions.Optimise as Actions
+import Language.Mimsa.Transform.Warnings
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.ResolvedExpression
@@ -71,12 +72,14 @@ optimise mimsaEnv (OptimiseRequest bindingName projectHash) =
           let (ResolvedExpression _ se _ _ swaps typedExpr input) = resolvedExpr
           typedNameExpr <- Actions.useSwaps swaps typedExpr
           graphviz <- Actions.graphExpression se
+          let warnings = getWarnings resolvedExpr
           pure
             ( makeExpressionData
                 se
                 typedNameExpr
                 graphviz
                 input
+                warnings
             )
 
     store' <- lift $ readStoreHandler mimsaEnv

--- a/compiler/server/Server/Project/Upgrade.hs
+++ b/compiler/server/Server/Project/Upgrade.hs
@@ -23,6 +23,7 @@ import qualified Language.Mimsa.Actions.Graph as Actions
 import qualified Language.Mimsa.Actions.Helpers.Swaps as Actions
 import qualified Language.Mimsa.Actions.Upgrade as Actions
 import Language.Mimsa.Printer
+import Language.Mimsa.Transform.Warnings
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.ResolvedExpression
@@ -84,9 +85,10 @@ upgrade mimsaEnv (UpgradeRequest bindingName projectHash) =
           let (ResolvedExpression _ se _ _ swaps typedExpr input) = resolvedExpr
           typedNameExpr <- Actions.useSwaps swaps typedExpr
           gv <- Actions.graphExpression se
+          let warnings = getWarnings resolvedExpr
           pure
             ( mapUpgradedDeps depUpdates,
-              makeExpressionData se typedNameExpr gv input
+              makeExpressionData se typedNameExpr gv input warnings
             )
 
     store' <- lift $ readStoreHandler mimsaEnv

--- a/compiler/src/Language/Mimsa/Actions/BindExpression.hs
+++ b/compiler/src/Language/Mimsa/Actions/BindExpression.hs
@@ -42,7 +42,7 @@ bindExpression expr name input = do
   let storeExpr = reStoreExpression resolvedExpr
 
   -- print any warnings
-  traverse_ (Actions.appendMessage . prettyPrint) (getWarnings storeExpr)
+  traverse_ (Actions.appendMessage . prettyPrint) (getWarnings resolvedExpr)
 
   Actions.bindStoreExpression storeExpr name
   case lookupBindingName project name of

--- a/compiler/src/Language/Mimsa/Actions/Evaluate.hs
+++ b/compiler/src/Language/Mimsa/Actions/Evaluate.hs
@@ -36,7 +36,7 @@ evaluate ::
     )
 evaluate input expr = do
   project <- Actions.getProject
-  (ResolvedExpression mt se expr' scope' swaps typedExpr input') <-
+  resolved@(ResolvedExpression mt se expr' scope' swaps typedExpr input') <-
     liftEither $ Actions.getTypecheckedStoreExpression input project expr
   typedNameExpr <-
     liftEither
@@ -48,7 +48,7 @@ evaluate input expr = do
     liftEither (first InterpreterErr (interpret scope' swaps expr'))
 
   -- print any warnings
-  traverse_ (Actions.appendMessage . prettyPrint) (getWarnings se)
+  traverse_ (Actions.appendMessage . prettyPrint) (getWarnings resolved)
 
   -- print
   Actions.appendDocMessage

--- a/compiler/src/Language/Mimsa/Actions/Helpers/Swaps.hs
+++ b/compiler/src/Language/Mimsa/Actions/Helpers/Swaps.hs
@@ -11,12 +11,11 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Swaps
-import Language.Mimsa.Types.Typechecker
 
 useSwaps ::
   Swaps ->
-  Expr Variable MonoType ->
-  ActionM (Expr Name MonoType)
+  Expr Variable ann ->
+  ActionM (Expr Name ann)
 useSwaps swaps expr =
   case Swaps.useSwaps swaps expr of
     Right tyExpr -> pure tyExpr

--- a/compiler/src/Language/Mimsa/Transform/FindUnused.hs
+++ b/compiler/src/Language/Mimsa/Transform/FindUnused.hs
@@ -24,6 +24,12 @@ removeUnused remove = f
               removeUnused remove patExpr
             )
        in MyPatternMatch ann tidyExpr (tidyPattern <$> patterns)
+    f (MyLetPattern ann pat expr body) =
+      MyLetPattern
+        ann
+        (removeUnusedInPattern remove pat)
+        (removeUnused remove expr)
+        (removeUnused remove body)
     f other = mapExpr f other
 
 removeUnusedInPattern :: (Ord var) => Set var -> Pattern var ann -> Pattern var ann
@@ -53,6 +59,8 @@ findVariables = withMonoid f
       (True, S.singleton (a, getAnnotationForType mt))
     f (MyPatternMatch _ _ patterns) =
       (True, mconcat (findVariableInPattern . fst <$> patterns))
+    f (MyLetPattern _ pat _ _) =
+      (True, findVariableInPattern pat)
     f _other = (True, mempty)
 
 -- | Find all variables in pattern match

--- a/compiler/src/Language/Mimsa/Transform/FindUnused.hs
+++ b/compiler/src/Language/Mimsa/Transform/FindUnused.hs
@@ -5,9 +5,10 @@ import Data.Set (Set)
 import qualified Data.Set as S
 import Language.Mimsa.ExprUtils
 import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Typechecker
 
-removeUnused :: (Ord var) => Set var -> Expr var ann -> Expr var ann
+removeUnused :: Set Variable -> Expr Variable ann -> Expr Variable ann
 removeUnused remove = f
   where
     f wholeExpr@(MyLet _ ident _ letBody) =
@@ -32,7 +33,10 @@ removeUnused remove = f
         (removeUnused remove body)
     f other = mapExpr f other
 
-removeUnusedInPattern :: (Ord var) => Set var -> Pattern var ann -> Pattern var ann
+removeUnusedInPattern ::
+  Set Variable ->
+  Pattern Variable ann ->
+  Pattern Variable ann
 removeUnusedInPattern remove = f
   where
     f wholePat@(PVar ann a) =
@@ -41,7 +45,7 @@ removeUnusedInPattern remove = f
         else wholePat
     f other = mapPattern f other
 
-findUnused :: (Ord var, Ord ann) => Expr var ann -> Set (var, ann)
+findUnused :: (Ord ann) => Expr Variable ann -> Set (Variable, ann)
 findUnused expr =
   let uses = findUses expr
    in S.filter (\(var, _) -> not $ S.member var uses) (findVariables expr)
@@ -50,7 +54,7 @@ findUnused expr =
 -- | we don't need to worry about shadowing because we'll have made everything
 -- unique that needs to be in a previous step (otherwise typechecking would
 -- choke)
-findVariables :: (Ord var, Ord ann) => Expr var ann -> Set (var, ann)
+findVariables :: (Ord ann) => Expr Variable ann -> Set (Variable, ann)
 findVariables = withMonoid f
   where
     f (MyLet _ (Identifier ann a) _ _) =
@@ -64,7 +68,7 @@ findVariables = withMonoid f
     f _other = (True, mempty)
 
 -- | Find all variables in pattern match
-findVariableInPattern :: (Ord var, Ord ann) => Pattern var ann -> Set (var, ann)
+findVariableInPattern :: (Ord ann) => Pattern Variable ann -> Set (Variable, ann)
 findVariableInPattern (PVar ann a) =
   S.singleton (a, ann)
 findVariableInPattern (PPair _ a b) =

--- a/compiler/src/Language/Mimsa/Transform/Warnings.hs
+++ b/compiler/src/Language/Mimsa/Transform/Warnings.hs
@@ -3,11 +3,14 @@
 
 module Language.Mimsa.Transform.Warnings (Warning (..), getWarnings) where
 
+import qualified Data.Map as M
+import Data.Maybe
 import qualified Data.Set as S
 import Language.Mimsa.Printer
 import Language.Mimsa.Transform.FindUnused
 import Language.Mimsa.Types.Identifiers
-import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.ResolvedExpression
+import Language.Mimsa.Types.Swaps
 
 -- | given an expression, generate a bunch of warnings for it like unused
 -- variables etc
@@ -20,7 +23,11 @@ instance Printer Warning where
   prettyPrint (UnusedVariable name) =
     "Unused variable: " <> prettyPrint name
 
-getWarnings :: (Ord ann) => StoreExpression ann -> [Warning]
-getWarnings se =
-  let unused = findUnused (storeExpression se)
-   in UnusedVariable . fst <$> S.toList unused
+unusedWarning :: Swaps -> Variable -> Maybe Warning
+unusedWarning swaps var =
+  UnusedVariable <$> M.lookup var swaps
+
+getWarnings :: (Ord ann) => ResolvedExpression ann -> [Warning]
+getWarnings resolved =
+  let unused = findUnused (reVarExpression resolved)
+   in catMaybes $ unusedWarning (reSwaps resolved) . fst <$> S.toList unused

--- a/compiler/test/Test/Transform/FindUnused.hs
+++ b/compiler/test/Test/Transform/FindUnused.hs
@@ -32,6 +32,11 @@ spec = do
         findUnused @Name @Annotation
           (MyPatternMatch mempty (bool True) [(PVar mempty "a", bool True)])
           `shouldBe` S.singleton ("a", mempty)
+      it "Finds `a` in a let pattern match" $ do
+        findUnused @Name @Annotation
+          (MyLetPattern mempty (PVar mempty "a") (bool True) (bool True))
+          `shouldBe` S.singleton ("a", mempty)
+
       it "Does not find `a` when it is used in a pattern match" $ do
         findUnused @Name @Annotation
           (MyPatternMatch mempty (bool True) [(PVar mempty "a", MyVar mempty "a")])
@@ -49,6 +54,11 @@ spec = do
     it "Turns `a` in pattern match to PWildcard" $ do
       let expr = MyPatternMatch mempty (bool True) [(PVar mempty "a", bool True)]
           expected = MyPatternMatch mempty (bool True) [(PWildcard mempty, bool True)]
+      removeUnused @Name @Annotation (S.singleton "a") expr
+        `shouldBe` expected
+    it "Turns `a` in let pattern match to PWildcard" $ do
+      let expr = MyLetPattern mempty (PVar mempty "a") (bool True) (bool True)
+          expected = MyLetPattern mempty (PWildcard mempty) (bool True) (bool True)
       removeUnused @Name @Annotation (S.singleton "a") expr
         `shouldBe` expected
     it "Removes let behind a lambda" $ do


### PR DESCRIPTION
# Two fixes:

## One

Fixes let patterns:

```haskell
:> :bind whoa = \pair -> let (a,b) = pair in a
Unused variable: b
Bound whoa.

:> :optimise whoa
Optimised whoa. New expression: \pair ->
  let (a, _) = pair in a
```

## Two

Uses `Variable` in comparison so this:

```haskell
match Right 1 with
    (Right a) -> 1
 |  (Left a) -> a
 ```
 
 becomes:

 ```haskell
 match Right 1 with
    (Right _) -> 1
 |  (Left a) -> a
 ```
 
... as we can tell the difference between different `a` values.