### PR TITLE
Start detecting recursion

### DIFF
--- a/compiler/src/Language/Mimsa/Backend/Core/TailCall.hs
+++ b/compiler/src/Language/Mimsa/Backend/Core/TailCall.hs
@@ -1,17 +1,70 @@
 {-# LANGUAGE DerivingStrategies #-}
 
-module Language.Mimsa.Backend.Core.TailCall where
+module Language.Mimsa.Backend.Core.TailCall
+  ( isTailRecursive,
+    listReturns,
+    RecursionType (..),
+    RecursionOccurrence (..),
+  )
+where
 
+import qualified Data.Set as S
+import Language.Mimsa.ExprUtils
+import Language.Mimsa.Transform.FindUnused
 import Language.Mimsa.Types.AST
 
 -- nice
 
-data RecursionType ann
+-- | does this let expression use recursion?
+data RecursionType var ann
   = NoRecursion
-  | TailRecursion
-  | NonTailRecursion {rootLetAnn :: ann, nonTailRecurseAnns :: [ann]}
+  | Recursion
+      { rootLetAnn :: ann,
+        variableName :: var,
+        recursionAnns :: [RecursionOccurrence ann]
+      }
+  deriving stock (Eq, Ord, Show)
+
+-- | if so, is it the optimisable kind?
+data RecursionOccurrence ann
+  = TailRecursion ann
+  | NonTailRecursion ann
   deriving stock (Eq, Ord, Show)
 
 -- | detect what kind of recursion we are dealing with here
-isTailRecursive :: Expr var ann -> RecursionType ann
-isTailRecursive _ = NoRecursion
+isTailRecursive ::
+  (Ord var) =>
+  Expr var ann ->
+  var ->
+  ann ->
+  RecursionType var ann
+isTailRecursive expr var ann =
+  let exprsWithRecursion = filter (containsVar var) (listReturns expr)
+      recType exp' =
+        if isDirectRecursion var exp'
+          then TailRecursion (getAnnotation exp')
+          else NonTailRecursion (getAnnotation exp')
+   in if null exprsWithRecursion
+        then NoRecursion
+        else Recursion ann var (recType <$> exprsWithRecursion)
+
+-- | `fn 1 2` is direct, `1 + fn 2` is not
+isDirectRecursion :: (Eq var) => var -> Expr var ann -> Bool
+isDirectRecursion var (MyApp _ (MyVar _ var') _) | var == var' = True
+isDirectRecursion var (MyApp _ first _) = isDirectRecursion var first
+isDirectRecursion _ _ = False
+
+containsVar :: (Ord var) => var -> Expr var ann -> Bool
+containsVar var expr = S.member var (findUses expr)
+
+listReturns :: Expr var ann -> [Expr var ann]
+listReturns = withMonoid f
+  where
+    f (MyLet _ _ _ body) = (False, listReturns body)
+    f (MyLetPattern _ _ _ body) = (False, listReturns body)
+    f (MyData _ _ body) = (False, listReturns body)
+    f (MyDefineInfix _ _ _ body) = (False, listReturns body)
+    f (MyIf _ _ thenExpr elseExpr) = (False, listReturns thenExpr <> listReturns elseExpr)
+    f (MyPatternMatch _ _ pats) = (False, mconcat (listReturns . snd <$> pats))
+    f (MyLambda _ _ body) = (False, listReturns body)
+    f other = (False, [other])

--- a/compiler/src/Language/Mimsa/Backend/Core/TailCall.hs
+++ b/compiler/src/Language/Mimsa/Backend/Core/TailCall.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE DerivingStrategies #-}
+
+module Language.Mimsa.Backend.Core.TailCall where
+
+import Language.Mimsa.Types.AST
+
+-- nice
+
+data RecursionType ann
+  = NoRecursion
+  | TailRecursion
+  | NonTailRecursion {rootLetAnn :: ann, nonTailRecurseAnns :: [ann]}
+  deriving stock (Eq, Ord, Show)
+
+-- | detect what kind of recursion we are dealing with here
+isTailRecursive :: Expr var ann -> RecursionType ann
+isTailRecursive _ = NoRecursion

--- a/compiler/test/Spec.hs
+++ b/compiler/test/Spec.hs
@@ -15,6 +15,8 @@ import qualified Test.Actions.Typecheck as TypecheckAction
 import qualified Test.Actions.Upgrade as Upgrade
 import qualified Test.Backend.ESModulesJS as ESModulesJS
 import qualified Test.Backend.RunNode as RunNode
+import qualified Test.Backend.Runtimes as Runtimes
+import qualified Test.Backend.TailCall as TailCall
 import qualified Test.Backend.Typescript as Typescript
 import qualified Test.Codegen as Codegen
 import Test.Hspec
@@ -110,3 +112,5 @@ main =
     NumberVars.spec
     CheckModule.spec
     RenderErrors.spec
+    Helpers.spec
+    TailCall.spec

--- a/compiler/test/Test/Backend/TailCall.hs
+++ b/compiler/test/Test/Backend/TailCall.hs
@@ -6,6 +6,7 @@ module Test.Backend.TailCall
 where
 
 import Language.Mimsa.Backend.Core.TailCall
+import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers ()
 import Test.Hspec
 import Test.Utils.Helpers
@@ -13,11 +14,68 @@ import Test.Utils.Helpers
 spec :: Spec
 spec = do
   describe "TailCall" $ do
-    it "Detects a let with no recursion" $ do
-      let expr = unsafeParseExpr "let fn = 1 in True"
-          result = isTailRecursive expr
-      result `shouldBe` NoRecursion
-    it "Detects a let with tail recursion" $ do
-      let expr = unsafeParseExpr "let fn a = \\value -> \\count -> if count == 0 then value else fn (value + 1) (count - 1)"
-          result = isTailRecursive expr
-      result `shouldBe` TailRecursion
+    describe "listReturns" $ do
+      it "Simple value returns itself" $ do
+        let expr = unsafeParseExpr "True"
+        listReturns expr `shouldBe` [expr]
+      it "Let returns it's body" $ do
+        let expr = unsafeParseExpr "let a = 1 in True"
+            expected = unsafeParseExpr "True"
+        listReturns expr `shouldBe` [expected]
+      it "Let pattern returns it's body" $ do
+        let expr = unsafeParseExpr "let (a,b) = (1,2) in True"
+            expected = unsafeParseExpr "True"
+        listReturns expr `shouldBe` [expected]
+      it "Data declaration returns body" $ do
+        let expr = unsafeParseExpr "type Dog = Dog in True"
+            expected = unsafeParseExpr "True"
+        listReturns expr `shouldBe` [expected]
+      it "Infix declaration returns body" $ do
+        let expr = unsafeParseExpr "infix >>>>> = id in True"
+            expected = unsafeParseExpr "True"
+        listReturns expr `shouldBe` [expected]
+      it "Pattern match returns all it's branches" $ do
+        let expr = unsafeParseExpr "match True with True -> 1 | False -> 2"
+            expected = [unsafeParseExpr "1", unsafeParseExpr "2"]
+        listReturns expr `shouldBe` expected
+      it "If returns both branches" $ do
+        let expr = unsafeParseExpr "if True then 1 else 2"
+            expected = [unsafeParseExpr "1", unsafeParseExpr "2"]
+        listReturns expr `shouldBe` expected
+      it "Array returns itself" $ do
+        let expr = unsafeParseExpr "[1,2]"
+        listReturns expr `shouldBe` [expr]
+      it "Application returns itself" $ do
+        let expr = unsafeParseExpr "fn 1 2"
+        listReturns expr `shouldBe` [expr]
+      it "Lambdas return result" $ do
+        let expr = unsafeParseExpr "\\a -> \\b -> 1"
+            expected = unsafeParseExpr "1"
+        listReturns expr `shouldBe` [expected]
+    describe "isTailRecursive" $ do
+      it "Detects a let with no recursion" $ do
+        let expr = unsafeParseExpr "True"
+            result = isTailRecursive expr "fn" mempty
+        result `shouldBe` NoRecursion
+      it "Detects a let with no tail recursion" $ do
+        let expr =
+              unsafeParseExprWithAnn
+                "\\a -> \\value -> \\count -> if count == 0 then value else (1 + fn (value) (count - 1))"
+            result = isTailRecursive expr "fn" mempty
+        result
+          `shouldBe` Recursion
+            mempty
+            "fn"
+            [ NonTailRecursion (Location 57 83)
+            ]
+      it "Detects a let with simple tail recursion" $ do
+        let expr =
+              unsafeParseExprWithAnn
+                "\\a -> \\value -> \\count -> if count == 0 then value else (fn (value + 1) (count - 1))"
+            result = isTailRecursive expr "fn" mempty
+        result
+          `shouldBe` Recursion
+            mempty
+            "fn"
+            [ TailRecursion (Location 56 84)
+            ]

--- a/compiler/test/Test/Backend/TailCall.hs
+++ b/compiler/test/Test/Backend/TailCall.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Backend.TailCall
+  ( spec,
+  )
+where
+
+import Language.Mimsa.Backend.Core.TailCall
+import Language.Mimsa.Types.Identifiers ()
+import Test.Hspec
+import Test.Utils.Helpers
+
+spec :: Spec
+spec = do
+  describe "TailCall" $ do
+    it "Detects a let with no recursion" $ do
+      let expr = unsafeParseExpr "let fn = 1 in True"
+          result = isTailRecursive expr
+      result `shouldBe` NoRecursion
+    it "Detects a let with tail recursion" $ do
+      let expr = unsafeParseExpr "let fn a = \\value -> \\count -> if count == 0 then value else fn (value + 1) (count - 1)"
+          result = isTailRecursive expr
+      result `shouldBe` TailRecursion

--- a/compiler/test/Test/Utils/Helpers.hs
+++ b/compiler/test/Test/Utils/Helpers.hs
@@ -21,6 +21,7 @@ import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.ResolvedExpression
 import Language.Mimsa.Types.Store
 import Language.Mimsa.Types.Typechecker
+import Text.Megaparsec
 
 fromRight :: (Printer e) => Either e a -> a
 fromRight either' = case either' of
@@ -32,13 +33,17 @@ fromLeft either' = case either' of
   Left e -> e
   Right _ -> error "Expected a Left!"
 
-unsafeParseExpr :: Text -> Expr Name ()
-unsafeParseExpr t = case parseExpr t of
-  Right a -> a $> ()
-  Left _ ->
+unsafeParseExprWithAnn :: Text -> Expr Name Annotation
+unsafeParseExprWithAnn t = case parseExpr t of
+  Right a -> a
+  Left e ->
     error $
-      "Error parsing expr for Prettier tests:"
+      "Error parsing expr in unsafeParseExpr:"
         <> T.unpack t
+        <> errorBundlePretty e
+
+unsafeParseExpr :: Text -> Expr Name ()
+unsafeParseExpr t = unsafeParseExprWithAnn t $> ()
 
 unsafeParseMonoType :: Text -> Type ()
 unsafeParseMonoType t = case parseMonoType t of


### PR DESCRIPTION
Part 2 of #488 - actually detecting them and replacing the code with trampolines in JS/TS output. The same code should be able to give us some good warnings for the user too, telling them that recursion is being used without optimisation.