### PR TITLE
Nicer prettyprinting for pattern matches

### DIFF
--- a/compiler/src/Language/Mimsa/Types/AST/Expr.hs
+++ b/compiler/src/Language/Mimsa/Types/AST/Expr.hs
@@ -328,7 +328,8 @@ prettyPatternMatch sumExpr matches =
         )
   where
     printMatch (construct, expr') =
-      printSubPattern construct <+> "->" <+> printSubExpr expr'
+      printSubPattern construct <+> "->" <+> line
+        <> indentMulti 4 (prettyDoc expr')
 
 prettyDataType ::
   DataType ->


### PR DESCRIPTION
Resolves #511 with some nicer pattern matching pretty printing:

```haskell
match [ 1, 2, 3, 4, 5 ] with 
    [a, b] -> 
      let d =
        1;

      let e =
        1;

      let f = 1000 in [ a, b, d ]
  | _ -> 
      []
```