### PR TITLE
Optimise before evaluate

### DIFF
--- a/compiler/src/Language/Mimsa/Actions/Typecheck.hs
+++ b/compiler/src/Language/Mimsa/Actions/Typecheck.hs
@@ -156,7 +156,11 @@ getDepsForStoreExpression ::
   Actions.ActionM (Map ExprHash (StoreExpression Annotation, Text))
 getDepsForStoreExpression storeExpr = do
   project <- Actions.getProject
-  depsList <- liftEither $ first StoreErr (recursiveResolve (prjStore project) storeExpr)
+  depsList <-
+    liftEither $
+      first
+        StoreErr
+        (recursiveResolve (prjStore project) storeExpr)
   pure $
     M.singleton (getStoreExpressionHash storeExpr) (storeExpr, prettyPrint storeExpr)
       <> M.fromList


### PR DESCRIPTION
Optimise everything each time we evaluate.

Before:
```
benchmarking build stdlib/allFns
time                 191.1 ms   (179.0 ms .. 206.4 ms)
                     0.997 R²   (0.993 R² .. 1.000 R²)
mean                 191.6 ms   (186.6 ms .. 199.8 ms)
std dev              8.574 ms   (4.304 ms .. 12.14 ms)
variance introduced by outliers: 14% (moderately inflated)

benchmarking compilation/compile either fmap test
time                 11.00 ms   (10.80 ms .. 11.20 ms)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 11.12 ms   (10.99 ms .. 11.40 ms)
std dev              485.0 μs   (269.3 μs .. 802.3 μs)
variance introduced by outliers: 19% (moderately inflated)

benchmarking evaluate/evaluate big looping thing
time                 577.9 ms   (524.6 ms .. 642.7 ms)
                     0.999 R²   (0.995 R² .. 1.000 R²)
mean                 560.2 ms   (549.9 ms .. 570.4 ms)
std dev              12.49 ms   (5.088 ms .. 15.67 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking evaluate/evaluate parsing
time                 42.46 ms   (40.40 ms .. 44.46 ms)
                     0.995 R²   (0.991 R² .. 0.999 R²)
mean                 45.91 ms   (44.50 ms .. 49.62 ms)
std dev              3.764 ms   (1.207 ms .. 5.514 ms)
variance introduced by outliers: 27% (moderately inflated)
```

After:
```
benchmarking build stdlib/allFns
time                 152.8 ms   (142.5 ms .. 183.0 ms)
                     0.972 R²   (0.872 R² .. 1.000 R²)
mean                 158.6 ms   (152.0 ms .. 169.8 ms)
std dev              12.11 ms   (6.757 ms .. 16.61 ms)
variance introduced by outliers: 14% (moderately inflated)

benchmarking compilation/compile either fmap test
time                 11.33 ms   (11.21 ms .. 11.43 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 11.38 ms   (11.29 ms .. 11.68 ms)
std dev              391.7 μs   (91.95 μs .. 781.3 μs)
variance introduced by outliers: 13% (moderately inflated)

benchmarking evaluate/evaluate big looping thing
time                 437.8 ms   (407.8 ms .. 460.2 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 442.1 ms   (438.5 ms .. 448.1 ms)
std dev              5.985 ms   (2.291 ms .. 8.215 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking evaluate/evaluate parsing
time                 68.23 ms   (67.26 ms .. 69.34 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 69.05 ms   (68.61 ms .. 69.93 ms)
std dev              1.062 ms   (494.5 μs .. 1.695 ms)
```