### PR TITLE
Interpret all

### DIFF
--- a/compiler/src/Language/Mimsa/Actions/Interpret.hs
+++ b/compiler/src/Language/Mimsa/Actions/Interpret.hs
@@ -38,6 +38,9 @@ interpreter se = do
     Just re -> pure (bimap fst edAnnotation re)
     _ -> throwError (StoreErr (CouldNotFindStoreExpression (getStoreExpressionHash se)))
 
+squashify :: (Ord e) => Map e (Map e a) -> Map e a
+squashify = mconcat . M.elems
+
 -- Interpret a group of StoreExpressions
 -- This means each sub dep is only interpreted once
 interpretAll ::
@@ -45,10 +48,16 @@ interpretAll ::
   Actions.ActionM (Map ExprHash (InterpretExpr Name Annotation))
 interpretAll inputStoreExpressions = do
   let action depMap se = do
+        -- get us out of this Map of Maps situation
+        let flatDeps = squashify depMap
         -- tag each `var` with it's location if it is an import
         let withImports = addEmptyStackFrames (convertImports se)
         -- interpret se
-        liftEither (first InterpreterErr (interpret depMap withImports))
+        interpreted <- liftEither (first InterpreterErr (interpret flatDeps withImports))
+        -- we need to accumulate all deps
+        -- as we go, so pass them up too
+        let allDeps = flatDeps <> M.singleton (getStoreExpressionHash se) interpreted
+        pure allDeps
 
   -- create initial state for builder
   -- we tag each StoreExpression we've found with the deps it needs
@@ -68,4 +77,5 @@ interpretAll inputStoreExpressions = do
                 <$> inputStoreExpressions,
             Build.stOutputs = mempty -- we use caches here if we wanted
           }
-  Build.stOutputs <$> Build.doJobs action state
+  splat <- Build.stOutputs <$> Build.doJobs action state
+  pure (squashify splat)

--- a/compiler/test/Test/Actions/Evaluate.hs
+++ b/compiler/test/Test/Actions/Evaluate.hs
@@ -36,3 +36,9 @@ spec = do
       expr $> () `shouldBe` int 2
       -- optimised version in store
       additionalStoreItems testStdlib newProject `shouldBe` 1
+    it "Should evaluate an expression with a nested dependency" $ do
+      let expr = unsafeParseExpr "incrementInt 1 + id 10" $> mempty
+      let action = Actions.evaluate (prettyPrint expr) expr
+      let (_, _, (mt, newExpr, _, _, _)) = fromRight (Actions.run testStdlib action)
+      mt $> () `shouldBe` MTPrim mempty MTInt
+      newExpr $> () `shouldBe` int 12

--- a/compiler/test/Test/Project/Stdlib.hs
+++ b/compiler/test/Test/Project/Stdlib.hs
@@ -5,6 +5,7 @@ module Test.Project.Stdlib
   )
 where
 
+import Control.Monad.IO.Class
 import Data.Coerce
 import Data.Either
 import Data.Foldable
@@ -39,9 +40,13 @@ spec = do
   describe "Stdlib" $ do
     it "Builds" $ do
       buildStdlib `shouldSatisfy` isRight
+
   describe "Can evaluate each top-level item" $ do
     case buildStdlib of
       Right prj ->
         let bindingNames = M.keys . getVersionedMap . prjBindings $ prj
          in traverse_ (evaluatesSuccessfully prj . coerce) bindingNames
-      Left e -> error (T.unpack (prettyPrint e))
+      Left e ->
+        it "could not create stdlib" $ do
+          liftIO (putStrLn (T.unpack (prettyPrint e)))
+          False `shouldBe` True


### PR DESCRIPTION
Interpret all dependencies of an expression before interpreting the expression itself.

Before:
```
benchmarking evaluate/evaluate big looping thing
time                 145.4 ms   (140.4 ms .. 150.2 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 144.7 ms   (143.0 ms .. 147.6 ms)
std dev              3.087 ms   (1.651 ms .. 4.432 ms)
variance introduced by outliers: 12% (moderately inflated)

benchmarking evaluate/evaluate parsing
time                 108.1 ms   (104.9 ms .. 110.0 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 109.9 ms   (108.4 ms .. 112.9 ms)
std dev              3.344 ms   (1.594 ms .. 5.177 ms)

benchmarking evaluate/evaluate parsing 2
time                 29.80 s    (29.51 s .. 29.97 s)
                     1.000 R²   (NaN R² .. 1.000 R²)
mean                 29.72 s    (29.63 s .. 29.77 s)
std dev              92.37 ms   (37.94 ms .. 127.6 ms)
variance introduced by outliers: 19% (moderately inflated)
```

After:

```
benchmarking evaluate/evaluate big looping thing
time                 145.7 ms   (142.6 ms .. 149.4 ms)
                     0.999 R²   (0.996 R² .. 1.000 R²)
mean                 146.7 ms   (144.2 ms .. 148.8 ms)
std dev              3.370 ms   (2.261 ms .. 5.449 ms)
variance introduced by outliers: 12% (moderately inflated)

benchmarking evaluate/evaluate parsing
time                 102.7 ms   (99.77 ms .. 105.4 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 109.0 ms   (106.7 ms .. 112.7 ms)
std dev              4.731 ms   (2.242 ms .. 7.810 ms)

benchmarking evaluate/evaluate parsing 2
time                 27.53 s    (24.46 s .. 29.15 s)
                     0.999 R²   (0.996 R² .. 1.000 R²)
mean                 28.02 s    (27.59 s .. 28.34 s)
std dev              428.5 ms   (205.0 ms .. 583.7 ms)
variance introduced by outliers: 19% (moderately inflated)
```