### PR TITLE
Better if error

### DIFF
--- a/compiler/errors/Spec.hs
+++ b/compiler/errors/Spec.hs
@@ -60,6 +60,8 @@ spec =
         printError stdlib "if 1 then True else False"
       it "Non-boolean in If predicate with annotation" $ do
         printError stdlib "let (a: Boolean) = if 1 then True else False; 1"
+      it "Non-boolean from function in if predicate" $ do
+        printError stdlib "let f a = if a then 1 else 2; f 1"
       it "Non-matching if branches" $ do
         printError stdlib "if True then 1 else False"
       it "Patterns do not match input" $ do

--- a/compiler/errors/Spec.hs
+++ b/compiler/errors/Spec.hs
@@ -58,6 +58,8 @@ spec =
     describe "Type errors" $ do
       it "Non-boolean in If predicate" $ do
         printError stdlib "if 1 then True else False"
+      it "Non-boolean in If predicate with annotation" $ do
+        printError stdlib "let (a: Boolean) = if 1 then True else False; 1"
       it "Non-matching if branches" $ do
         printError stdlib "if True then 1 else False"
       it "Patterns do not match input" $ do

--- a/compiler/test/Test/Interpreter/Repl.hs
+++ b/compiler/test/Test/Interpreter/Repl.hs
@@ -1097,6 +1097,11 @@ spec =
         result <- eval testStdlib "let (id1: a -> (a,a)) a = (a,a); let (id2: a -> a) b = b; id1 (id2 True)"
         result `shouldSatisfy` isRight
 
+    describe "check if" $ do
+      it "spots mismatched predicate type" $ do
+        result <- eval testStdlib "let (a: Int) = if 1 then 2 else 3; a"
+        result `shouldSatisfy` textErrorContains "Predicate for an if expression"
+
     describe "optimisations" $ do
       it "should do all optimisations in one pass" $ do
         result <- eval testStdlib "\\opts -> let d = \"dog\"; match [\"a\", \"b\"] with [a, b, c] -> (Just ((a, d))) | _ -> (Nothing)"


### PR DESCRIPTION
```
let (a: Boolean) = if 1 then True else False; 1
[error]: Predicate for an if expression should be a Boolean. This has type Int
     ╭──▶ <repl>@1:23-1:25
     │
   1 │ let (a: Boolean) = if 1 then True else False; 1
     •                    ┬──┬─────────────────────
     •                    │  ╰╸ This has type Int but should have type Boolean
     •                    ╰╸ error in this expression
     •
     │ Hint: Change the predicate to be a Boolean type (True or False)
```