### PR TITLE
Experiment: WASM output

### DIFF
--- a/compiler/mimsa.cabal
+++ b/compiler/mimsa.cabal
@@ -55,6 +55,7 @@ library
       Language.Mimsa.Backend.Typescript.Patterns
       Language.Mimsa.Backend.Typescript.Printer
       Language.Mimsa.Backend.Typescript.Types
+      Language.Mimsa.Backend.Wasm.Compile
       Language.Mimsa.Backend.ZipFile
       Language.Mimsa.ExprUtils
       Language.Mimsa.Interpreter.App
@@ -239,6 +240,7 @@ library
     , servant-server
     , text
     , transformers
+    , wasm
     , zip-archive
   default-language: Haskell2010
 
@@ -294,6 +296,7 @@ executable mimsa
     , servant-server
     , text
     , transformers
+    , wasm
     , zip-archive
   default-language: Haskell2010
 
@@ -364,6 +367,7 @@ executable mimsa-server
     , wai-cors
     , wai-middleware-prometheus
     , warp
+    , wasm
     , zip-archive
   default-language: Haskell2010
 
@@ -378,6 +382,7 @@ test-suite mimsa-test
       Test.Backend.ESModulesJS
       Test.Backend.RunNode
       Test.Backend.Typescript
+      Test.Backend.Wasm
       Test.Codegen.Shared
       Test.Data.Prelude
       Test.Data.Project
@@ -450,6 +455,7 @@ test-suite mimsa-test
     , text
     , transformers
     , typed-process
+    , wasm
     , zip-archive
   default-language: Haskell2010
 
@@ -489,5 +495,6 @@ benchmark mimsa-benchmark
     , servant-server
     , text
     , transformers
+    , wasm
     , zip-archive
   default-language: Haskell2010

--- a/compiler/package.yaml
+++ b/compiler/package.yaml
@@ -46,6 +46,7 @@ dependencies:
 - bifunctors 
 - diagnose # nice errors
 - parallel # zoooooooooom
+- wasm
 
 library:
   source-dirs: src

--- a/compiler/src/Language/Mimsa/Backend/Wasm/Compile.hs
+++ b/compiler/src/Language/Mimsa/Backend/Wasm/Compile.hs
@@ -1,9 +1,33 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 module Language.Mimsa.Backend.Wasm.Compile where
 
+import qualified Data.Text as T
+import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST
+import qualified Language.Wasm.Builder as Wasm
 import qualified Language.Wasm.Structure as Wasm
 
 type WasmModule = Wasm.Module
 
-compile :: Expr var ann -> WasmModule
-compile = undefined
+compile :: (Printer (Expr var ann)) => Expr var ann -> WasmModule
+compile expr =
+  Wasm.genMod (Wasm.export "test" (Wasm.fun Wasm.i32 (mainFn expr)))
+  where
+    mainFn exp' = case exp' of
+      (MyLiteral _ (MyInt i)) ->
+        Wasm.i32c i
+      (MyInfix _ op a b) -> do
+        let valA = mainFn a
+            valB = mainFn b
+        case op of
+          Add -> Wasm.add valA valB
+          Subtract -> Wasm.sub valA valB
+          Equals -> Wasm.eq valA valB
+          GreaterThan -> Wasm.gt_s valA valB
+          LessThan -> Wasm.lt_s valA valB
+          GreaterThanOrEqualTo -> Wasm.ge_s valA valB
+          LessThanOrEqualTo -> Wasm.le_s valA valB
+          op' -> error (T.unpack (prettyPrint op'))
+      other -> error (T.unpack (prettyPrint other))

--- a/compiler/src/Language/Mimsa/Backend/Wasm/Compile.hs
+++ b/compiler/src/Language/Mimsa/Backend/Wasm/Compile.hs
@@ -1,0 +1,9 @@
+module Language.Mimsa.Backend.Wasm.Compile where
+
+import Language.Mimsa.Types.AST
+import qualified Language.Wasm.Structure as Wasm
+
+type WasmModule = Wasm.Module
+
+compile :: Expr var ann -> WasmModule
+compile = undefined

--- a/compiler/src/Language/Mimsa/Backend/Wasm/Compile.hs
+++ b/compiler/src/Language/Mimsa/Backend/Wasm/Compile.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-
+  {-# LANGUAGE DataKinds #-}
+    {-# LANGUAGE ScopedTypeVariables #-}
 module Language.Mimsa.Backend.Wasm.Compile where
 
+import Data.Proxy
 import qualified Data.Text as T
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST
@@ -11,13 +13,20 @@ import qualified Language.Wasm.Structure as Wasm
 
 type WasmModule = Wasm.Module
 
-compile :: (Printer (Expr var ann)) => Expr var ann -> WasmModule
+compile :: forall var ann. (Printer (Expr var ann)) => Expr var ann -> WasmModule
 compile expr =
   Wasm.genMod (Wasm.export "test" (Wasm.fun Wasm.i32 (mainFn expr)))
   where
+    mainFn :: Expr var ann -> Wasm.GenFun (Proxy 'Wasm.I32) 
     mainFn exp' = case exp' of
       (MyLiteral _ (MyInt i)) ->
         Wasm.i32c i
+      (MyLiteral _ (MyBool True)) ->
+        Wasm.i32c (1 :: Integer)
+      (MyLiteral _ (MyBool False)) ->
+        Wasm.i32c (0 :: Integer)
+      (MyIf _ predExpr thenExpr elseExpr) -> 
+          Wasm.select (mainFn predExpr) (mainFn thenExpr) (mainFn elseExpr)
       (MyInfix _ op a b) -> do
         let valA = mainFn a
             valB = mainFn b

--- a/compiler/src/Language/Mimsa/Backend/Wasm/Compile.hs
+++ b/compiler/src/Language/Mimsa/Backend/Wasm/Compile.hs
@@ -1,7 +1,8 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-  {-# LANGUAGE DataKinds #-}
-    {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Language.Mimsa.Backend.Wasm.Compile where
 
 import Data.Proxy
@@ -17,7 +18,7 @@ compile :: forall var ann. (Printer (Expr var ann)) => Expr var ann -> WasmModul
 compile expr =
   Wasm.genMod (Wasm.export "test" (Wasm.fun Wasm.i32 (mainFn expr)))
   where
-    mainFn :: Expr var ann -> Wasm.GenFun (Proxy 'Wasm.I32) 
+    mainFn :: Expr var ann -> Wasm.GenFun (Proxy 'Wasm.I32)
     mainFn exp' = case exp' of
       (MyLiteral _ (MyInt i)) ->
         Wasm.i32c i
@@ -25,8 +26,8 @@ compile expr =
         Wasm.i32c (1 :: Integer)
       (MyLiteral _ (MyBool False)) ->
         Wasm.i32c (0 :: Integer)
-      (MyIf _ predExpr thenExpr elseExpr) -> 
-          Wasm.select (mainFn predExpr) (mainFn thenExpr) (mainFn elseExpr)
+      (MyIf _ predExpr thenExpr elseExpr) ->
+        Wasm.select (mainFn predExpr) (mainFn thenExpr) (mainFn elseExpr)
       (MyInfix _ op a b) -> do
         let valA = mainFn a
             valB = mainFn b

--- a/compiler/src/Language/Mimsa/Backend/Wasm/Compile.hs
+++ b/compiler/src/Language/Mimsa/Backend/Wasm/Compile.hs
@@ -15,23 +15,22 @@ import qualified Data.Text as T
 import GHC.Natural
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST
-import qualified Language.Wasm.Structure as Wasm
 import Language.Mimsa.Types.Typechecker
+import qualified Language.Wasm.Structure as Wasm
 
 type WasmModule = Wasm.Module
 
 data WasmState var = WasmState
   { wsEnv :: Map var (Natural, Wasm.ValueType),
     wsCounter :: Natural,
-    wsFuncs :: Map Int (WasmFunction var )
+    wsFuncs :: Map Int (WasmFunction var)
   }
 
-data WasmFunction var =
-  WasmFunction {
-    wfRetType :: Type (),
+data WasmFunction var = WasmFunction
+  { wfRetType :: Type (),
     wfArgs :: [Type ()],
     wfBody :: Expr var (Type ())
-               }
+  }
 
 newtype WasmError var
   = CouldNotFindVar var
@@ -57,22 +56,26 @@ lookupEnvItem var = do
     Just a -> pure a
     Nothing -> throwError (CouldNotFindVar var)
 
-newtype WasmM var a = WasmM {getWasmM ::
-  StateT (WasmState var ) (Except (WasmError var)) a}
+newtype WasmM var a = WasmM
+  { getWasmM ::
+      StateT (WasmState var) (Except (WasmError var)) a
+  }
   deriving newtype
     ( Functor,
       Applicative,
       Monad,
-      MonadState (WasmState var ),
+      MonadState (WasmState var),
       MonadError (WasmError var)
     )
 
-runWasmM :: (Ord var) => WasmM var a ->
-    Either (WasmError var) (a, WasmState var)
+runWasmM ::
+  (Ord var) =>
+  WasmM var a ->
+  Either (WasmError var) (a, WasmState var)
 runWasmM (WasmM comp) = runExcept $ runStateT comp emptyState
 
 compileRaw ::
-  forall var .
+  forall var.
   (Ord var, Show var, Printer (Expr var (Type ()))) =>
   Expr var (Type ()) ->
   WasmModule

--- a/compiler/src/Language/Mimsa/Backend/Wasm/Compile.hs
+++ b/compiler/src/Language/Mimsa/Backend/Wasm/Compile.hs
@@ -5,39 +5,121 @@
 
 module Language.Mimsa.Backend.Wasm.Compile where
 
-import Data.Proxy
+import Data.Map (Map)
+import qualified Data.Map as M
 import qualified Data.Text as T
+import GHC.Natural
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST
-import qualified Language.Wasm.Builder as Wasm
 import qualified Language.Wasm.Structure as Wasm
 
 type WasmModule = Wasm.Module
 
-compile :: forall var ann. (Printer (Expr var ann)) => Expr var ann -> WasmModule
-compile expr =
-  Wasm.genMod (Wasm.export "test" (Wasm.fun Wasm.i32 (mainFn expr)))
+data WasmState var = WasmState
+  { wsEnv :: Map var Natural,
+    wsCounter :: Natural
+  }
+
+emptyState :: (Ord var) => WasmState var
+emptyState = WasmState mempty 0
+
+addEnvItem :: (Ord var) => var -> WasmState var -> (WasmState var, Natural)
+addEnvItem var (WasmState env count) =
+  let newCount = count + 1
+   in ( WasmState (env <> M.singleton var count) newCount,
+        count
+      )
+
+-- newtype WasmM var a = WasmM {getWasmM :: State (WasmState var) a}
+
+compileRaw ::
+  forall var ann.
+  (Ord var, Printer (Expr var ann)) =>
+  Expr var ann ->
+  WasmModule
+compileRaw expr =
+  let func = compileTestFunc expr
+      localTypes = []
+      funcType = Wasm.FuncType localTypes [Wasm.I32]
+      export =
+        Wasm.Export "test" (Wasm.ExportFunc 0)
+   in Wasm.Module
+        { Wasm.types = [funcType],
+          Wasm.functions = [func],
+          Wasm.tables = mempty,
+          Wasm.mems = mempty,
+          Wasm.globals = mempty,
+          Wasm.elems = mempty,
+          Wasm.datas = mempty,
+          Wasm.start = Nothing,
+          Wasm.imports = mempty,
+          Wasm.exports = [export]
+        }
+
+compileTestFunc ::
+  forall var ann.
+  (Ord var, Printer (Expr var ann)) =>
+  Expr var ann ->
+  Wasm.Function
+compileTestFunc expr =
+  let locals = [Wasm.I32, Wasm.I32]
+   in Wasm.Function 0 locals body
   where
-    mainFn :: Expr var ann -> Wasm.GenFun (Proxy 'Wasm.I32)
-    mainFn exp' = case exp' of
+    body = mainFn emptyState expr
+    mainFn :: WasmState var -> Expr var ann -> [Wasm.Instruction Natural]
+    mainFn ws exp' = case exp' of
       (MyLiteral _ (MyInt i)) ->
-        Wasm.i32c i
+        [Wasm.I32Const (fromIntegral i)]
       (MyLiteral _ (MyBool True)) ->
-        Wasm.i32c (1 :: Integer)
+        [Wasm.I32Const 1]
       (MyLiteral _ (MyBool False)) ->
-        Wasm.i32c (0 :: Integer)
+        [Wasm.I32Const 0]
       (MyIf _ predExpr thenExpr elseExpr) ->
-        Wasm.select (mainFn predExpr) (mainFn thenExpr) (mainFn elseExpr)
+        let block = Wasm.Inline (Just Wasm.I32) -- return type
+         in mainFn ws predExpr
+              <> [ Wasm.If
+                     block
+                     (mainFn ws thenExpr)
+                     (mainFn ws elseExpr)
+                 ]
       (MyInfix _ op a b) -> do
-        let valA = mainFn a
-            valB = mainFn b
-        case op of
-          Add -> Wasm.add valA valB
-          Subtract -> Wasm.sub valA valB
-          Equals -> Wasm.eq valA valB
-          GreaterThan -> Wasm.gt_s valA valB
-          LessThan -> Wasm.lt_s valA valB
-          GreaterThanOrEqualTo -> Wasm.ge_s valA valB
-          LessThanOrEqualTo -> Wasm.le_s valA valB
-          op' -> error (T.unpack (prettyPrint op'))
+        let valA = mainFn ws a
+            valB = mainFn ws b
+        valA <> valB <> [compileBinOp op]
+      (MyLet _ (Identifier _ ident) letExpr body') -> do
+        let (ws2, index) = addEnvItem ident ws
+        mainFn ws letExpr <> [Wasm.SetLocal index] <> mainFn ws2 body'
+      (MyVar _ _ ident) -> do
+        -- ignoring namespaces
+        -- should think about that at some point
+        case M.lookup ident (wsEnv ws) of
+          Just n -> [Wasm.GetLocal n]
+          Nothing -> error "found jack shit in env"
       other -> error (T.unpack (prettyPrint other))
+
+compileBinOp :: Operator -> Wasm.Instruction i
+compileBinOp op =
+  case op of
+    Add -> Wasm.IBinOp Wasm.BS32 Wasm.IAdd
+    Subtract -> Wasm.IBinOp Wasm.BS32 Wasm.ISub
+    Equals -> Wasm.IRelOp Wasm.BS32 Wasm.IEq
+    GreaterThan -> Wasm.IRelOp Wasm.BS32 Wasm.IGtU
+    LessThan -> Wasm.IRelOp Wasm.BS32 Wasm.ILtU
+    GreaterThanOrEqualTo -> Wasm.IRelOp Wasm.BS32 Wasm.IGeU
+    LessThanOrEqualTo -> Wasm.IRelOp Wasm.BS32 Wasm.ILeU
+    op' -> error (T.unpack (prettyPrint op'))
+
+{-
+      (MyLet _ (Identifier _ ident) letExpr body) -> do
+        loc <- Wasm.local (Proxy :: Proxy 'Wasm.I32)
+        loc .= mainFn ws letExpr
+        mainFn (addEnvItem ident loc ws) body
+      (MyVar _ _ ident) -> do
+        -- ignoring namespaces
+        -- should think about that at some point
+        case M.lookup ident (wsEnv ws) of
+          Just n -> Wasm.ret n
+          Nothing -> error "found jack shit in env"
+      (MyApp _ f a) -> do
+        Wasm.call (mainFn ws f) [mainFn ws a]
+-}

--- a/compiler/src/Language/Mimsa/Backend/Wasm/Compile.hs
+++ b/compiler/src/Language/Mimsa/Backend/Wasm/Compile.hs
@@ -16,54 +16,65 @@ import GHC.Natural
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST
 import qualified Language.Wasm.Structure as Wasm
+import Language.Mimsa.Types.Typechecker
 
 type WasmModule = Wasm.Module
 
 data WasmState var = WasmState
   { wsEnv :: Map var (Natural, Wasm.ValueType),
-    wsCounter :: Natural
+    wsCounter :: Natural,
+    wsFuncs :: Map Int (WasmFunction var )
   }
+
+data WasmFunction var =
+  WasmFunction {
+    wfRetType :: Type (),
+    wfArgs :: [Type ()],
+    wfBody :: Expr var (Type ())
+               }
 
 newtype WasmError var
   = CouldNotFindVar var
   deriving newtype (Show)
 
 emptyState :: (Ord var) => WasmState var
-emptyState = WasmState mempty 0
+emptyState = WasmState mempty 0 mempty
 
 addEnvItem :: (Ord var) => var -> Wasm.ValueType -> WasmM var Natural
 addEnvItem var wasmType =
   state
-    ( \(WasmState env count) ->
+    ( \(WasmState env count funcs) ->
         let newCount = count + 1
          in ( count,
-              WasmState (env <> M.singleton var (count, wasmType)) newCount
+              WasmState (env <> M.singleton var (count, wasmType)) newCount funcs
             )
     )
 
 lookupEnvItem :: (Ord var) => var -> WasmM var (Natural, Wasm.ValueType)
 lookupEnvItem var = do
-  maybeVal <- gets (\(WasmState env _) -> M.lookup var env)
+  maybeVal <- gets (\(WasmState env _ _) -> M.lookup var env)
   case maybeVal of
     Just a -> pure a
     Nothing -> throwError (CouldNotFindVar var)
 
-newtype WasmM var a = WasmM {getWasmM :: StateT (WasmState var) (Except (WasmError var)) a}
+newtype WasmM var a = WasmM {getWasmM ::
+  StateT (WasmState var ) (Except (WasmError var)) a}
   deriving newtype
     ( Functor,
       Applicative,
       Monad,
-      MonadState (WasmState var),
+      MonadState (WasmState var ),
       MonadError (WasmError var)
     )
 
-runWasmM :: (Ord var) => WasmM var a -> Either (WasmError var) (a, WasmState var)
+runWasmM :: (Ord var) => WasmM var a ->
+    Either (WasmError var) (a, WasmState var)
 runWasmM (WasmM comp) = runExcept $ runStateT comp emptyState
 
 compileRaw ::
-  forall var ann.
-  (Ord var, Show var, Printer (Expr var ann)) =>
-  Expr var ann ->
+  forall var .
+  (Ord var, Show var, Printer (Expr var (Type ()))) =>
+  Expr var (Type ()) ->
   WasmModule
 compileRaw expr =
   let func = compileTestFunc expr

--- a/compiler/stack.yaml
+++ b/compiler/stack.yaml
@@ -37,6 +37,7 @@ packages:
 
 extra-deps:
   - diagnose-1.8.2@sha256:d70959f2147f5a1d01c1cc14a7ad8f117d0a3cd544d626bb06a93e40b2ad5cbe,5661 
+  - wasm-1.1.1@sha256:cea1e6c43d1ee46392eabb6b0f4fc469b6d8b987bcfbdd4694f9c48be346f229,2432 
 # - acme-missiles-0.3
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a

--- a/compiler/stack.yaml.lock
+++ b/compiler/stack.yaml.lock
@@ -11,6 +11,13 @@ packages:
       size: 1200
   original:
     hackage: diagnose-1.8.2@sha256:d70959f2147f5a1d01c1cc14a7ad8f117d0a3cd544d626bb06a93e40b2ad5cbe,5661
+- completed:
+    hackage: wasm-1.1.1@sha256:cea1e6c43d1ee46392eabb6b0f4fc469b6d8b987bcfbdd4694f9c48be346f229,2432
+    pantry-tree:
+      size: 896
+      sha256: 87029a77cf92dc8ba2b3b20d61563b44b87a4f10c8a3227ff31a2ff2e534cc19
+  original:
+    hackage: wasm-1.1.1@sha256:cea1e6c43d1ee46392eabb6b0f4fc469b6d8b987bcfbdd4694f9c48be346f229,2432
 snapshots:
 - completed:
     sha256: 895204e9116cba1f32047525ec5bad7423216587706e5df044c4a7c191a5d8cb

--- a/compiler/test/Spec.hs
+++ b/compiler/test/Spec.hs
@@ -10,7 +10,6 @@ import qualified Test.Actions.Evaluate as Evaluate
 import qualified Test.Backend.ESModulesJS as ESModulesJS
 import qualified Test.Backend.RunNode as RunNode
 import qualified Test.Backend.Typescript as Typescript
-import qualified Test.Codegen as Codegen
 import qualified Test.Backend.Wasm as Wasm
 import qualified Test.Codegen as Codegen
 import Test.Hspec
@@ -91,5 +90,6 @@ main =
     ModuleTest.spec
     ModuleUses.spec
     ParseDataTypes.spec
+    Helpers.spec
     Helpers.spec
     Wasm.spec

--- a/compiler/test/Spec.hs
+++ b/compiler/test/Spec.hs
@@ -11,7 +11,6 @@ import qualified Test.Backend.ESModulesJS as ESModulesJS
 import qualified Test.Backend.RunNode as RunNode
 import qualified Test.Backend.Typescript as Typescript
 import qualified Test.Backend.Wasm as Wasm
-import qualified Test.Codegen as Codegen
 import Test.Hspec
 import qualified Test.Modules.Check as ModuleCheck
 import qualified Test.Modules.Repl as ModuleRepl
@@ -90,6 +89,4 @@ main =
     ModuleTest.spec
     ModuleUses.spec
     ParseDataTypes.spec
-    Helpers.spec
-    Helpers.spec
     Wasm.spec

--- a/compiler/test/Spec.hs
+++ b/compiler/test/Spec.hs
@@ -10,6 +10,9 @@ import qualified Test.Actions.Evaluate as Evaluate
 import qualified Test.Backend.ESModulesJS as ESModulesJS
 import qualified Test.Backend.RunNode as RunNode
 import qualified Test.Backend.Typescript as Typescript
+import qualified Test.Codegen as Codegen
+import qualified Test.Backend.Wasm as Wasm
+import qualified Test.Codegen as Codegen
 import Test.Hspec
 import qualified Test.Modules.Check as ModuleCheck
 import qualified Test.Modules.Repl as ModuleRepl
@@ -88,3 +91,5 @@ main =
     ModuleTest.spec
     ModuleUses.spec
     ParseDataTypes.spec
+    Helpers.spec
+    Wasm.spec

--- a/compiler/test/Test/Backend/Wasm.hs
+++ b/compiler/test/Test/Backend/Wasm.hs
@@ -20,60 +20,73 @@ runWasm wasmModule = do
         Right moduleInstance ->
           Wasm.invokeExport store moduleInstance "test" mempty
         Left e -> error e
-    Left e -> error $ "invalid module: " <> show e
+    Left e -> do
+      print wasmModule
+      error $ "invalid module: " <> show e
 
 spec :: Spec
 spec = do
   fdescribe "Wasm" $ do
     describe "Number literals" $ do
       it "int literal 1" $ do
-        result <- runWasm (compile (unsafeParseExpr "1"))
+        result <- runWasm (compileRaw (unsafeParseExpr "1"))
         result `shouldBe` Just [Wasm.VI32 1]
       it "int literal 42" $ do
-        result <- runWasm (compile (unsafeParseExpr "42"))
+        result <- runWasm (compileRaw (unsafeParseExpr "42"))
         result `shouldBe` Just [Wasm.VI32 42]
     describe "Boolean literals" $ do
       it "true" $ do
-        result <- runWasm (compile (unsafeParseExpr "True"))
+        result <- runWasm (compileRaw (unsafeParseExpr "True"))
         result `shouldBe` Just [Wasm.VI32 1]
       it "false" $ do
-        result <- runWasm (compile (unsafeParseExpr "False"))
+        result <- runWasm (compileRaw (unsafeParseExpr "False"))
         result `shouldBe` Just [Wasm.VI32 0]
     describe "If expression" $ do
       it "true branch" $ do
-        result <- runWasm (compile (unsafeParseExpr "if True then 42 else 5"))
+        result <- runWasm (compileRaw (unsafeParseExpr "if True then 42 else 5"))
         result `shouldBe` Just [Wasm.VI32 42]
       it "false branch" $ do
-        result <- runWasm (compile (unsafeParseExpr "if False then 42 else 5"))
+        result <- runWasm (compileRaw (unsafeParseExpr "if False then 42 else 5"))
         result `shouldBe` Just [Wasm.VI32 5]
       it "using infix op" $ do
-        result <- runWasm (compile (unsafeParseExpr "if 4 == 5 then 42 else 5"))
+        result <- runWasm (compileRaw (unsafeParseExpr "if 4 == 5 then 42 else 5"))
         result `shouldBe` Just [Wasm.VI32 5]
     describe "Infix ops" $ do
       it "1 + 1 == 2" $ do
-        result <- runWasm (compile (unsafeParseExpr "1 + 1"))
+        result <- runWasm (compileRaw (unsafeParseExpr "1 + 1"))
         result `shouldBe` Just [Wasm.VI32 2]
       it "10 - 9" $ do
-        result <- runWasm (compile (unsafeParseExpr "10 - 9"))
+        result <- runWasm (compileRaw (unsafeParseExpr "10 - 9"))
         result `shouldBe` Just [Wasm.VI32 1]
       it "1 == 1" $ do
-        result <- runWasm (compile (unsafeParseExpr "1 == 1"))
+        result <- runWasm (compileRaw (unsafeParseExpr "1 == 1"))
         result `shouldBe` Just [Wasm.VI32 1]
       it "1 == 2" $ do
-        result <- runWasm (compile (unsafeParseExpr "1 == 2"))
+        result <- runWasm (compileRaw (unsafeParseExpr "1 == 2"))
         result `shouldBe` Just [Wasm.VI32 0]
       it "1 < 2" $ do
-        result <- runWasm (compile (unsafeParseExpr "1 < 2"))
+        result <- runWasm (compileRaw (unsafeParseExpr "1 < 2"))
         result `shouldBe` Just [Wasm.VI32 1]
       it "1 > 2" $ do
-        result <- runWasm (compile (unsafeParseExpr "1 > 2"))
+        result <- runWasm (compileRaw (unsafeParseExpr "1 > 2"))
         result `shouldBe` Just [Wasm.VI32 0]
       it "1 >= 1" $ do
-        result <- runWasm (compile (unsafeParseExpr "1 >= 1"))
+        result <- runWasm (compileRaw (unsafeParseExpr "1 >= 1"))
         result `shouldBe` Just [Wasm.VI32 1]
       it "1 <= 1" $ do
-        result <- runWasm (compile (unsafeParseExpr "1 <= 1"))
+        result <- runWasm (compileRaw (unsafeParseExpr "1 <= 1"))
         result `shouldBe` Just [Wasm.VI32 1]
       it "1 + 2 + 3 + 4 + 5" $ do
-        result <- runWasm (compile (unsafeParseExpr "1 + 2 + 3 + 4 + 5"))
+        result <- runWasm (compileRaw (unsafeParseExpr "1 + 2 + 3 + 4 + 5"))
         result `shouldBe` Just [Wasm.VI32 15]
+    describe "Function" $ do
+      it "let inc = \\a -> a + 1; inc 1" $ do
+        result <- runWasm (compileRaw (unsafeParseExpr "let inc = \\a -> a + 1; inc 1"))
+        result `shouldBe` Just [Wasm.VI32 2]
+    describe "Variables" $ do
+      it "let a = 1 in a + 1" $ do
+        result <- runWasm (compileRaw (unsafeParseExpr "let a = 1 in a + 1"))
+        result `shouldBe` Just [Wasm.VI32 2]
+      it "let a = 1; let b = 2; a + b" $ do
+        result <- runWasm (compileRaw (unsafeParseExpr "let a = 1; let b = 2; a + b"))
+        result `shouldBe` Just [Wasm.VI32 3]

--- a/compiler/test/Test/Backend/Wasm.hs
+++ b/compiler/test/Test/Backend/Wasm.hs
@@ -90,3 +90,6 @@ spec = do
       it "let a = 1; let b = 2; a + b" $ do
         result <- runWasm (compileRaw (unsafeParseExpr "let a = 1; let b = 2; a + b"))
         result `shouldBe` Just [Wasm.VI32 3]
+      it "let a = 1; let b = 2; let c = 3; a + b - c" $ do
+        result <- runWasm (compileRaw (unsafeParseExpr "let a = 1; let b = 2; let c = 3; a + b - c"))
+        result `shouldBe` Just [Wasm.VI32 0]

--- a/compiler/test/Test/Backend/Wasm.hs
+++ b/compiler/test/Test/Backend/Wasm.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Backend.Wasm
+  ( spec,
+  )
+where
+
+import Control.Monad.Except
+import Data.Bifunctor
+import Data.Foldable
+import Data.Functor
+import Data.Hashable
+import qualified Data.Map as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Language.Mimsa.Actions.Shared as Actions
+import Language.Mimsa.Backend.Types
+import Language.Mimsa.Backend.Typescript.DataType
+import Language.Mimsa.Backend.Typescript.FromExpr
+import Language.Mimsa.Backend.Typescript.Monad
+import Language.Mimsa.Backend.Typescript.Patterns
+import Language.Mimsa.Backend.Typescript.Printer
+import Language.Mimsa.Backend.Typescript.Types
+import Language.Mimsa.Backend.Wasm
+import Language.Mimsa.Interpreter.UseSwaps
+import Language.Mimsa.Printer
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Error
+import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.ResolvedExpression
+import Language.Mimsa.Types.Typechecker
+import Test.Backend.RunNode hiding (spec)
+import Test.Data.Project
+import Test.Hspec
+import Test.Utils.Compilation
+import Test.Utils.Helpers
+import Test.Utils.Serialisation
+
+spec :: Spec
+spec = do
+  describe "Wasm" $ do
+    it "literals" $ do
+      printLiteral (TSBool True) `shouldBe` "true"
+      printLiteral (TSInt 100) `shouldBe` "100"
+      printLiteral (TSString "egg") `shouldBe` "\"egg\""

--- a/compiler/test/Test/Backend/Wasm.hs
+++ b/compiler/test/Test/Backend/Wasm.hs
@@ -4,19 +4,19 @@ module Test.Backend.Wasm
   ( spec,
   )
 where
-import Language.Mimsa.Typechecker.Typecheck
 
+import Data.Bifunctor
+import Data.Text (Text)
 import Language.Mimsa.Backend.Wasm.Compile
+import Language.Mimsa.Typechecker.NumberVars
+import Language.Mimsa.Typechecker.Typecheck
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Typechecker
 import qualified Language.Wasm as Wasm
 import qualified Language.Wasm.Interpreter as Wasm
 import Test.Hspec
 import Test.Utils.Helpers
-import Language.Mimsa.Types.AST
-import Language.Mimsa.Types.Identifiers
-import Language.Mimsa.Types.Typechecker
-import Data.Text (Text)
-import Data.Bifunctor
-import Language.Mimsa.Typechecker.NumberVars
 
 runWasm :: Wasm.Module -> IO (Maybe [Wasm.Value])
 runWasm wasmModule = do
@@ -31,9 +31,10 @@ runWasm wasmModule = do
       print wasmModule
       error $ "invalid module: " <> show e
 
-typecheck' :: (Monoid ann) =>
+typecheck' ::
+  (Monoid ann) =>
   Expr Name Annotation ->
-  Expr Name (Type ann) 
+  Expr Name (Type ann)
 typecheck' expr = do
   let numberedExpr = fromRight (addNumbersToStoreExpression expr mempty)
   let result =
@@ -43,9 +44,9 @@ typecheck' expr = do
   (fmap . fmap) (const mempty) (fromRight result)
 
 wasmTest :: Text -> IO (Maybe [Wasm.Value])
-wasmTest input = 
+wasmTest input =
   let expr = typecheck' $ unsafeParseExpr' input
-  in runWasm (compileRaw expr)
+   in runWasm (compileRaw expr)
 
 spec :: Spec
 spec = do
@@ -62,7 +63,7 @@ spec = do
         result <- wasmTest "True"
         result `shouldBe` Just [Wasm.VI32 1]
       it "false" $ do
-        result <- wasmTest "False" 
+        result <- wasmTest "False"
         result `shouldBe` Just [Wasm.VI32 0]
     describe "If expression" $ do
       it "true branch" $ do
@@ -88,7 +89,7 @@ spec = do
         result <- wasmTest "1 == 2"
         result `shouldBe` Just [Wasm.VI32 0]
       it "1 < 2" $ do
-        result <- wasmTest "1 < 2" 
+        result <- wasmTest "1 < 2"
         result `shouldBe` Just [Wasm.VI32 1]
       it "1 > 2" $ do
         result <- wasmTest "1 > 2"
@@ -103,7 +104,7 @@ spec = do
         result <- wasmTest "1 + 2 + 3 + 4 + 5"
         result `shouldBe` Just [Wasm.VI32 15]
     describe "Function" $ do
-      it "let inc = \\a -> a + 1; inc 1" $ do
+      xit "let inc = \\a -> a + 1; inc 1" $ do
         result <- wasmTest "let inc = \\a -> a + 1; inc 1"
         result `shouldBe` Just [Wasm.VI32 2]
     describe "Variables" $ do

--- a/compiler/test/Test/Backend/Wasm.hs
+++ b/compiler/test/Test/Backend/Wasm.hs
@@ -4,12 +4,19 @@ module Test.Backend.Wasm
   ( spec,
   )
 where
+import Language.Mimsa.Typechecker.Typecheck
 
 import Language.Mimsa.Backend.Wasm.Compile
 import qualified Language.Wasm as Wasm
 import qualified Language.Wasm.Interpreter as Wasm
 import Test.Hspec
 import Test.Utils.Helpers
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Typechecker
+import Data.Text (Text)
+import Data.Bifunctor
+import Language.Mimsa.Typechecker.NumberVars
 
 runWasm :: Wasm.Module -> IO (Maybe [Wasm.Value])
 runWasm wasmModule = do
@@ -24,72 +31,88 @@ runWasm wasmModule = do
       print wasmModule
       error $ "invalid module: " <> show e
 
+typecheck' :: (Monoid ann) =>
+  Expr Name Annotation ->
+  Expr Name (Type ann) 
+typecheck' expr = do
+  let numberedExpr = fromRight (addNumbersToStoreExpression expr mempty)
+  let result =
+        fmap (\(_, _, a, _) -> first fst a)
+          . typecheck mempty mempty
+          $ numberedExpr
+  (fmap . fmap) (const mempty) (fromRight result)
+
+wasmTest :: Text -> IO (Maybe [Wasm.Value])
+wasmTest input = 
+  let expr = typecheck' $ unsafeParseExpr' input
+  in runWasm (compileRaw expr)
+
 spec :: Spec
 spec = do
   fdescribe "Wasm" $ do
     describe "Number literals" $ do
       it "int literal 1" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "1"))
+        result <- wasmTest "1"
         result `shouldBe` Just [Wasm.VI32 1]
       it "int literal 42" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "42"))
+        result <- wasmTest "42"
         result `shouldBe` Just [Wasm.VI32 42]
     describe "Boolean literals" $ do
       it "true" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "True"))
+        result <- wasmTest "True"
         result `shouldBe` Just [Wasm.VI32 1]
       it "false" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "False"))
+        result <- wasmTest "False" 
         result `shouldBe` Just [Wasm.VI32 0]
     describe "If expression" $ do
       it "true branch" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "if True then 42 else 5"))
+        result <- wasmTest "if True then 42 else 5"
         result `shouldBe` Just [Wasm.VI32 42]
       it "false branch" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "if False then 42 else 5"))
+        result <- wasmTest "if False then 42 else 5"
         result `shouldBe` Just [Wasm.VI32 5]
       it "using infix op" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "if 4 == 5 then 42 else 5"))
+        result <- wasmTest "if 4 == 5 then 42 else 5"
         result `shouldBe` Just [Wasm.VI32 5]
     describe "Infix ops" $ do
       it "1 + 1 == 2" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "1 + 1"))
+        result <- wasmTest "1 + 1"
         result `shouldBe` Just [Wasm.VI32 2]
       it "10 - 9" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "10 - 9"))
+        result <- wasmTest "10 - 9"
         result `shouldBe` Just [Wasm.VI32 1]
       it "1 == 1" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "1 == 1"))
+        result <- wasmTest "1 == 1"
         result `shouldBe` Just [Wasm.VI32 1]
       it "1 == 2" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "1 == 2"))
+        result <- wasmTest "1 == 2"
         result `shouldBe` Just [Wasm.VI32 0]
       it "1 < 2" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "1 < 2"))
+        result <- wasmTest "1 < 2" 
         result `shouldBe` Just [Wasm.VI32 1]
       it "1 > 2" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "1 > 2"))
+        result <- wasmTest "1 > 2"
         result `shouldBe` Just [Wasm.VI32 0]
       it "1 >= 1" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "1 >= 1"))
+        result <- wasmTest "1 >= 1"
         result `shouldBe` Just [Wasm.VI32 1]
       it "1 <= 1" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "1 <= 1"))
+        result <- wasmTest "1 <= 1"
         result `shouldBe` Just [Wasm.VI32 1]
       it "1 + 2 + 3 + 4 + 5" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "1 + 2 + 3 + 4 + 5"))
+        result <- wasmTest "1 + 2 + 3 + 4 + 5"
         result `shouldBe` Just [Wasm.VI32 15]
     describe "Function" $ do
       it "let inc = \\a -> a + 1; inc 1" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "let inc = \\a -> a + 1; inc 1"))
+        result <- wasmTest "let inc = \\a -> a + 1; inc 1"
         result `shouldBe` Just [Wasm.VI32 2]
     describe "Variables" $ do
       it "let a = 1 in a + 1" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "let a = 1 in a + 1"))
+        result <- wasmTest "let a = 1 in a + 1"
         result `shouldBe` Just [Wasm.VI32 2]
       it "let a = 1; let b = 2; a + b" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "let a = 1; let b = 2; a + b"))
+        result <- wasmTest "let a = 1; let b = 2; a + b"
         result `shouldBe` Just [Wasm.VI32 3]
       it "let a = 1; let b = 2; let c = 3; a + b - c" $ do
-        result <- runWasm (compileRaw (unsafeParseExpr "let a = 1; let b = 2; let c = 3; a + b - c"))
+        result <- wasmTest "let a = 1; let b = 2; let c = 3; a + b - c"
         result `shouldBe` Just [Wasm.VI32 0]

--- a/compiler/test/Test/Backend/Wasm.hs
+++ b/compiler/test/Test/Backend/Wasm.hs
@@ -20,7 +20,7 @@ runWasm wasmModule = do
         Right moduleInstance ->
           Wasm.invokeExport store moduleInstance "test" mempty
         Left e -> error e
-    Left _ -> error "invalid module"
+    Left e -> error $ "invalid module: " <> show e
 
 spec :: Spec
 spec = do
@@ -32,6 +32,23 @@ spec = do
       it "int literal 42" $ do
         result <- runWasm (compile (unsafeParseExpr "42"))
         result `shouldBe` Just [Wasm.VI32 42]
+    describe "Boolean literals" $ do
+      it "true" $ do
+        result <- runWasm (compile (unsafeParseExpr "True"))
+        result `shouldBe` Just [Wasm.VI32 1]
+      it "false" $ do
+        result <- runWasm (compile (unsafeParseExpr "False"))
+        result `shouldBe` Just [Wasm.VI32 0]
+    describe "If expression" $ do
+      it "true branch" $ do
+        result <- runWasm (compile (unsafeParseExpr "if True then 42 else 5"))
+        result `shouldBe` Just [Wasm.VI32 42]
+      it "false branch" $ do
+        result <- runWasm (compile (unsafeParseExpr "if False then 42 else 5"))
+        result `shouldBe` Just [Wasm.VI32 5]
+      it "using infix op" $ do
+        result <- runWasm (compile (unsafeParseExpr "if 4 == 5 then 42 else 5"))
+        result `shouldBe` Just [Wasm.VI32 5]
     describe "Infix ops" $ do
       it "1 + 1 == 2" $ do
         result <- runWasm (compile (unsafeParseExpr "1 + 1"))


### PR DESCRIPTION
Very very early Wasm output experiments.

We have:

- [x] Ints
- [x] Infix ops
- [x] Booleans
- [x] If expressions

The real blocker is when we need to do strings or anything involving linear memory. Before we worry about that we can still implement:

- [ ] Pattern matching on enum-shaped datatypes (store them as num, ie `Red` == 0, `Yellow` == 1, `Green` == 2, etc)
- [ ] Functions of some kind perhaps?
