### PR TITLE
Try building with LLVM

### DIFF
--- a/compiler/stack.yaml
+++ b/compiler/stack.yaml
@@ -53,7 +53,7 @@ ghc-options:
     # All packages
     "$locals": -Wall -Wno-unticked-promoted-constructors -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -Wmissing-deriving-strategies 
     "$targets": -Werror
-    "$everything": -O2 
+    "$everything": -O2 -fllvm 
 
 # Extra package databases containing global packages
 # extra-package-dbs: []


### PR DESCRIPTION
Switch on LLVM codegen to see if it runs faster.

**Before:**

benchmarking build stdlib/allFns
time                 156.9 ms   (152.2 ms .. 162.0 ms)
                     0.998 R²   (0.995 R² .. 1.000 R²)
mean                 163.9 ms   (160.0 ms .. 167.6 ms)
std dev              5.527 ms   (4.076 ms .. 6.714 ms)
variance introduced by outliers: 12% (moderately inflated)

benchmarking compilation/compile either fmap test
time                 15.73 ms   (15.25 ms .. 16.37 ms)
                     0.994 R²   (0.988 R² .. 0.997 R²)
mean                 15.97 ms   (15.71 ms .. 16.24 ms)
std dev              652.4 μs   (562.8 μs .. 845.5 μs)
variance introduced by outliers: 16% (moderately inflated)

benchmarking evaluate/evaluate big looping thing
time                 126.3 ms   (121.7 ms .. 131.1 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 122.1 ms   (120.6 ms .. 123.7 ms)
std dev              2.312 ms   (1.509 ms .. 3.306 ms)
variance introduced by outliers: 11% (moderately inflated)

benchmarking evaluate/evaluate parsing
time                 92.43 ms   (89.65 ms .. 96.10 ms)
                     0.999 R²   (0.996 R² .. 1.000 R²)
mean                 91.70 ms   (89.66 ms .. 93.55 ms)
std dev              2.857 ms   (1.862 ms .. 4.590 ms)

benchmarking evaluate/evaluate parsing 2
time                 343.9 ms   (340.2 ms .. 350.2 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 347.8 ms   (345.8 ms .. 349.4 ms)
std dev              1.992 ms   (856.9 μs .. 2.486 ms)
variance introduced by outliers: 19% (moderately inflated)


**After:**

benchmarking build stdlib/allFns
time                 133.1 ms   (130.7 ms .. 135.8 ms)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 139.1 ms   (135.5 ms .. 149.6 ms)
std dev              9.772 ms   (477.5 μs .. 14.93 ms)
variance introduced by outliers: 23% (moderately inflated)

benchmarking compilation/compile either fmap test
time                 12.97 ms   (12.83 ms .. 13.07 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 13.05 ms   (12.97 ms .. 13.15 ms)
std dev              249.3 μs   (169.5 μs .. 404.6 μs)

benchmarking evaluate/evaluate big looping thing
time                 106.3 ms   (105.7 ms .. 106.8 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 106.7 ms   (106.4 ms .. 107.7 ms)
std dev              890.2 μs   (231.4 μs .. 1.446 ms)

benchmarking evaluate/evaluate parsing
time                 75.85 ms   (75.08 ms .. 76.31 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 76.32 ms   (76.01 ms .. 77.24 ms)
std dev              894.2 μs   (157.2 μs .. 1.495 ms)

benchmarking evaluate/evaluate parsing 2
time                 327.4 ms   (325.4 ms .. 330.3 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 325.2 ms   (323.4 ms .. 326.5 ms)
std dev              1.929 ms   (1.017 ms .. 2.920 ms)
variance introduced by outliers: 16% (moderately inflated)