### PR TITLE
Bin off LLVM for now

### DIFF
--- a/compiler/Dockerfile
+++ b/compiler/Dockerfile
@@ -3,11 +3,9 @@ FROM haskell:9.2.2-buster as dependencies
 RUN mkdir /opt/build
 WORKDIR /opt/build
 
-RUN apt-get update && apt-get install -y llvm-11
-
 # Docker build should not use cached layer if any of these is modified
 COPY stack.yaml package.yaml stack.yaml.lock /opt/build/
-RUN stack build :mimsa-server --system-ghc --dependencies-only --ghc-options="-fllvm"
+RUN stack build :mimsa-server --system-ghc --dependencies-only 
 
 # -------------------------------------------------------------------------------------------
 FROM haskell:9.2.2-buster as build
@@ -18,9 +16,7 @@ COPY . /opt/build/
 
 WORKDIR /opt/build
 
-RUN apt-get update && apt-get install -y llvm-11
-
-RUN stack build :mimsa-server --system-ghc --ghc-options="-fllvm"
+RUN stack build :mimsa-server --system-ghc 
 
 RUN mv "$(stack path --local-install-root --system-ghc)/bin" /opt/build/bin
 


### PR DESCRIPTION
LLVM was faster and we should use it for Docker builds, but we need to get those working first, so removing for now.