### PR TITLE
Use `parallel` library on builds

### DIFF
--- a/compiler/mimsa.cabal
+++ b/compiler/mimsa.cabal
@@ -228,7 +228,7 @@ library
   hs-source-dirs:
       src
   default-extensions:
-      Strict
+      StrictData
   build-depends:
       QuickCheck
     , aeson
@@ -248,6 +248,7 @@ library
     , monad-logger
     , mtl
     , openapi3
+    , parallel
     , parser-combinators
     , prettyprinter
     , servant
@@ -282,6 +283,8 @@ executable mimsa
       Paths_mimsa
   hs-source-dirs:
       repl
+  default-extensions:
+      StrictData
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       QuickCheck
@@ -305,6 +308,7 @@ executable mimsa
     , mtl
     , openapi3
     , optparse-applicative
+    , parallel
     , parser-combinators
     , prettyprinter
     , servant
@@ -348,6 +352,8 @@ executable mimsa-server
       Paths_mimsa
   hs-source-dirs:
       server
+  default-extensions:
+      StrictData
   ghc-options: -threaded -rtsopts -with-rtsopts=-T
   build-depends:
       QuickCheck
@@ -371,6 +377,7 @@ executable mimsa-server
     , mtl
     , openapi3
     , optparse-applicative
+    , parallel
     , parser-combinators
     , prettyprinter
     , prometheus-client
@@ -481,6 +488,7 @@ test-suite mimsa-test
     , monad-logger
     , mtl
     , openapi3
+    , parallel
     , parser-combinators
     , prettyprinter
     , servant
@@ -520,6 +528,7 @@ benchmark mimsa-benchmark
     , monad-logger
     , mtl
     , openapi3
+    , parallel
     , parser-combinators
     , prettyprinter
     , servant

--- a/compiler/mimsa.cabal
+++ b/compiler/mimsa.cabal
@@ -228,7 +228,7 @@ library
   hs-source-dirs:
       src
   default-extensions:
-      StrictData
+      Strict
   build-depends:
       QuickCheck
     , aeson
@@ -283,8 +283,6 @@ executable mimsa
       Paths_mimsa
   hs-source-dirs:
       repl
-  default-extensions:
-      StrictData
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       QuickCheck
@@ -352,8 +350,6 @@ executable mimsa-server
       Paths_mimsa
   hs-source-dirs:
       server
-  default-extensions:
-      StrictData
   ghc-options: -threaded -rtsopts -with-rtsopts=-T
   build-depends:
       QuickCheck

--- a/compiler/package.yaml
+++ b/compiler/package.yaml
@@ -45,16 +45,19 @@ dependencies:
 - openapi3 
 - bifunctors 
 - diagnose # nice errors
+- parallel
 
 library:
   source-dirs: src
   default-extensions:
-  - Strict 
+  - StrictData 
 
 executables:
   mimsa:
     main:                Main.hs
     source-dirs:         repl
+    default-extensions:
+      - StrictData
     ghc-options:
     - -threaded
     - -rtsopts
@@ -67,6 +70,8 @@ executables:
   mimsa-server:
     main:                Main.hs
     source-dirs:         server
+    default-extensions:
+      - StrictData
     ghc-options:
     - -threaded
     - -rtsopts

--- a/compiler/package.yaml
+++ b/compiler/package.yaml
@@ -45,19 +45,17 @@ dependencies:
 - openapi3 
 - bifunctors 
 - diagnose # nice errors
-- parallel
+- parallel # zoooooooooom
 
 library:
   source-dirs: src
   default-extensions:
-  - StrictData 
+  - Strict 
 
 executables:
   mimsa:
     main:                Main.hs
     source-dirs:         repl
-    default-extensions:
-      - StrictData
     ghc-options:
     - -threaded
     - -rtsopts
@@ -70,8 +68,6 @@ executables:
   mimsa-server:
     main:                Main.hs
     source-dirs:         server
-    default-extensions:
-      - StrictData
     ghc-options:
     - -threaded
     - -rtsopts

--- a/compiler/src/Language/Mimsa/Actions/Helpers/Build.hs
+++ b/compiler/src/Language/Mimsa/Actions/Helpers/Build.hs
@@ -62,8 +62,7 @@ runBuilder fn st = do
       (M.toList readyJobs)
 
   -- evaluate everything in parallel
-  let reallyDone =
-        done `using` parTraversable rseq
+  let reallyDone = done `using` parTraversable rseq
 
   -- remove them from inputs
   let newInputs =

--- a/compiler/src/Language/Mimsa/Actions/Helpers/Build.hs
+++ b/compiler/src/Language/Mimsa/Actions/Helpers/Build.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 
 module Language.Mimsa.Actions.Helpers.Build (doJobs, getMissing, Plan (..), State (..), Job, Inputs) where
 
@@ -31,7 +30,6 @@ data State k input output = State
 -- | one run of the builder builds everything that is currently ready, then
 -- updates the state
 runBuilder ::
-  forall k m input output.
   (Ord k, Monad m) =>
   Job m k input output ->
   State k input output ->


### PR DESCRIPTION
Makes the `Build` abstraction do any steps it can in parallel. Doesn't make much difference on most things, makes the big evaluation job (JSON parsing) waaaaay faster so let's do it.

before:

```
benchmarking build stdlib/allFns
time                 123.3 ms   (122.4 ms .. 124.2 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 123.6 ms   (123.1 ms .. 124.2 ms)
std dev              846.6 μs   (534.2 μs .. 1.099 ms)
variance introduced by outliers: 11% (moderately inflated)

benchmarking compilation/compile either fmap test
time                 12.55 ms   (12.48 ms .. 12.64 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 12.65 ms   (12.61 ms .. 12.70 ms)
std dev              107.3 μs   (86.90 μs .. 137.0 μs)

benchmarking evaluate/evaluate big looping thing
time                 106.1 ms   (101.2 ms .. 113.5 ms)
                     0.996 R²   (0.991 R² .. 1.000 R²)
mean                 101.4 ms   (99.56 ms .. 103.9 ms)
std dev              3.480 ms   (1.733 ms .. 5.091 ms)

benchmarking evaluate/evaluate parsing
time                 68.18 ms   (67.53 ms .. 69.32 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 69.04 ms   (68.58 ms .. 70.01 ms)
std dev              1.142 ms   (424.5 μs .. 1.905 ms)

benchmarking evaluate/evaluate parsing 2
time                 365.3 ms   (268.8 ms .. 466.4 ms)
                     0.978 R²   (0.968 R² .. 1.000 R²)
mean                 293.5 ms   (269.1 ms .. 325.2 ms)
std dev              35.76 ms   (22.53 ms .. 44.64 ms)
variance introduced by outliers: 37% (moderately inflated)
```

after:

```

benchmarking build stdlib/allFns
time                 121.0 ms   (107.5 ms .. 131.4 ms)
                     0.990 R²   (0.972 R² .. 1.000 R²)
mean                 142.7 ms   (135.1 ms .. 152.4 ms)
std dev              13.36 ms   (10.35 ms .. 16.78 ms)
variance introduced by outliers: 24% (moderately inflated)

benchmarking compilation/compile either fmap test
time                 13.49 ms   (13.33 ms .. 13.69 ms)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 13.57 ms   (13.48 ms .. 13.69 ms)
std dev              257.8 μs   (165.4 μs .. 380.4 μs)

benchmarking evaluate/evaluate big looping thing
time                 97.95 ms   (97.61 ms .. 98.59 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 99.10 ms   (98.51 ms .. 100.7 ms)
std dev              1.569 ms   (265.3 μs .. 2.502 ms)

benchmarking evaluate/evaluate parsing
time                 69.48 ms   (67.25 ms .. 72.51 ms)
                     0.997 R²   (0.991 R² .. 1.000 R²)
mean                 71.48 ms   (70.49 ms .. 73.18 ms)
std dev              2.154 ms   (1.570 ms .. 2.845 ms)

benchmarking evaluate/evaluate parsing 2
time                 266.9 ms   (263.5 ms .. 269.9 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 269.7 ms   (268.3 ms .. 270.5 ms)
std dev              1.415 ms   (475.7 μs .. 2.071 ms)
variance introduced by outliers: 16% (moderately inflated)
```