### PR TITLE
Bind expressions in repl

### DIFF
--- a/compiler/mimsa.cabal
+++ b/compiler/mimsa.cabal
@@ -282,6 +282,7 @@ executable mimsa
       Repl.ReplM
       Repl.Types
       ReplNew.Actions
+      ReplNew.Actions.Bindings
       ReplNew.Actions.Evaluate
       ReplNew.Actions.ListModules
       ReplNew.Helpers

--- a/compiler/repl/Repl/Parser.hs
+++ b/compiler/repl/Repl/Parser.hs
@@ -8,7 +8,6 @@ where
 import Data.Functor (($>))
 import Language.Mimsa.Backend.Types
 import Language.Mimsa.Parser
-import Language.Mimsa.Parser.Lexeme
 import Language.Mimsa.Parser.Literal
 import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.AST

--- a/compiler/repl/ReplNew/Actions.hs
+++ b/compiler/repl/ReplNew/Actions.hs
@@ -11,6 +11,7 @@ import Data.Text (Text)
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Project
+import ReplNew.Actions.Bindings
 import ReplNew.Actions.Evaluate
 import ReplNew.Actions.ListModules
 import ReplNew.Helpers
@@ -22,15 +23,22 @@ doReplAction ::
   Text ->
   ReplAction Annotation ->
   ReplM (Error Annotation) (Project Annotation)
-doReplAction env input action =
+doReplAction prj input action =
   case action of
     Help -> do
       doHelp
-      pure env
+      pure prj
     ListModules ->
-      catchMimsaError env (doListModules env input $> env)
+      catchMimsaError prj (doListModules prj input $> prj)
+    ListBindings ->
+      catchMimsaError prj (doListBindings $> prj)
     (Evaluate expr) ->
-      catchMimsaError env (doEvaluate env input expr $> env)
+      catchMimsaError prj (doEvaluate prj input expr $> prj)
+    (AddBinding modItem) ->
+      catchMimsaError
+        prj
+        ( doAddBinding prj modItem input $> prj
+        )
 
 ----------
 
@@ -39,6 +47,8 @@ doHelp = do
   replOutput @Text "~~~ MIMSA ~~~"
   replOutput @Text ":help - this help screen"
   replOutput @Text ":modules - show a list of modules in the project"
+  replOutput @Text ":list - show a list of bindings created in this repl session"
+  replOutput @Text ":bind <binding> - bind an expression, infix or type"
   replOutput @Text "<expr> - Evaluate <expr>, returning it's simplified form and type"
   replOutput @Text ":quit - give up and leave"
 

--- a/compiler/repl/ReplNew/Actions/Bindings.hs
+++ b/compiler/repl/ReplNew/Actions/Bindings.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ReplNew.Actions.Bindings
+  ( doAddBinding,
+    doListBindings,
+  )
+where
+
+import Data.Text (Text)
+import qualified Language.Mimsa.Actions.BindModule as Actions
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Error
+import Language.Mimsa.Types.Modules
+import Language.Mimsa.Types.Project
+import ReplNew.Helpers
+import ReplNew.ReplM
+
+-- | add a binding to the global repl module
+doAddBinding ::
+  Project Annotation ->
+  ModuleItem Annotation ->
+  Text ->
+  ReplM (Error Annotation) ()
+doAddBinding project modItem input = do
+  oldModule <- getStoredModule
+  -- add the new binding
+  (_prj, newModule) <- toReplM project (Actions.addBindingToModule oldModule modItem input)
+  -- store the new module in Repl state
+  setStoredModule newModule
+
+-- | what is in the current implicit repl module
+doListBindings :: ReplM (Error Annotation) ()
+doListBindings = do
+  oldModule <- getStoredModule
+  -- output to console
+  if oldModule == mempty
+    then replOutput ("Current module is empty" :: Text)
+    else replOutput oldModule

--- a/compiler/repl/ReplNew/Actions/Evaluate.hs
+++ b/compiler/repl/ReplNew/Actions/Evaluate.hs
@@ -9,6 +9,7 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
+import Language.Mimsa.Types.Typechecker
 import ReplNew.Helpers
 import ReplNew.ReplM
 
@@ -18,7 +19,9 @@ doEvaluate ::
   Expr Name Annotation ->
   ReplM (Error Annotation) ()
 doEvaluate project input expr = do
-  _ <- toReplM project (Actions.evaluateModule input expr mempty)
+  oldModule <- fmap getAnnotationForType <$> getStoredModule
+
+  _ <- toReplM project (Actions.evaluateModule input expr oldModule)
   pure ()
 
 ---------

--- a/compiler/repl/ReplNew/Types.hs
+++ b/compiler/repl/ReplNew/Types.hs
@@ -10,12 +10,15 @@ where
 import GHC.Generics
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Store.RootPath
 
 data ReplAction ann
   = Help
   | Evaluate (Expr Name ann)
+  | AddBinding (ModuleItem ann)
   | ListModules
+  | ListBindings
 
 data ReplConfig = ReplConfig
   { rcRootPath :: RootPath,

--- a/compiler/src/Language/Mimsa/Actions/BindModule.hs
+++ b/compiler/src/Language/Mimsa/Actions/BindModule.hs
@@ -12,6 +12,7 @@ import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Text (Text)
 import qualified Language.Mimsa.Actions.Monad as Actions
+import Language.Mimsa.Modules.Check
 import Language.Mimsa.Modules.FromParts
 import Language.Mimsa.Modules.HashModule
 import Language.Mimsa.Modules.Monad
@@ -98,4 +99,12 @@ addBindingToModule mod' modItem input = do
   -- add our new definition
   newModule <- addModuleItemToModule input (getAnnotationForType <$> mod') modItem
   -- check everything still makes sense
-  typecheckModule (prettyPrint newModule) newModule
+  typecheckedModule <- typecheckModule (prettyPrint newModule) newModule
+  -- output what's happened
+  case getModuleItemIdentifier modItem of
+    Just di ->
+      Actions.appendMessage
+        ("Added definition " <> prettyPrint di <> " to module")
+    Nothing -> Actions.appendMessage "Module updated"
+
+  pure typecheckedModule

--- a/compiler/src/Language/Mimsa/Actions/BindModule.hs
+++ b/compiler/src/Language/Mimsa/Actions/BindModule.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Language.Mimsa.Actions.BindModule (bindModule, typecheckModules) where
+module Language.Mimsa.Actions.BindModule
+  ( bindModule,
+    typecheckModules,
+    addBindingToModule,
+  )
+where
 
 import Control.Monad.Except
 import Data.Map (Map)
@@ -14,6 +19,7 @@ import Language.Mimsa.Printer
 import Language.Mimsa.Project.Helpers
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
+import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Modules.Module
 import Language.Mimsa.Types.Modules.ModuleHash
 import Language.Mimsa.Types.Modules.ModuleName
@@ -64,5 +70,14 @@ bindModule inputModule moduleName input = do
       Actions.appendMessage
         ( "Bound " <> prettyPrint moduleName <> "."
         )
+
   -- return stuff
   pure (snd (serializeModule typecheckedModule), typecheckedModule)
+
+addBindingToModule ::
+  Module MonoType ->
+  ModuleItem Annotation ->
+  Text ->
+  Actions.ActionM (Module MonoType)
+addBindingToModule _mod' _modItem _input = do
+  error "fuck"

--- a/compiler/src/Language/Mimsa/Actions/Evaluate.hs
+++ b/compiler/src/Language/Mimsa/Actions/Evaluate.hs
@@ -157,10 +157,11 @@ evaluateModule input expr localModule = do
   -- make a module for it, adding our expression as _repl
   let newModule =
         localModule
-          { moExpressions =
-              M.singleton evalId expr,
-            moExpressionExports = S.singleton evalId
-          }
+          <> mempty
+            { moExpressions =
+                M.singleton evalId expr,
+              moExpressionExports = S.singleton evalId
+            }
           <> moduleImports
 
   typecheckedModules <- Actions.typecheckModules (prettyPrint newModule) newModule

--- a/compiler/src/Language/Mimsa/Modules/Check.hs
+++ b/compiler/src/Language/Mimsa/Modules/Check.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 
-module Language.Mimsa.Modules.Check (checkModule, lookupModuleDefType) where
+module Language.Mimsa.Modules.Check (checkModule, getModuleItemIdentifier, lookupModuleDefType) where
 
 import Control.Monad.Except
 import Data.Map (Map)
@@ -85,3 +85,11 @@ filterNameDefs =
         DIName name -> Just name
         _ -> Nothing
     )
+
+-- used in logging etc, "what is this thing"
+getModuleItemIdentifier :: ModuleItem ann -> Maybe DefIdentifier
+getModuleItemIdentifier (ModuleInfix infixOp _) = Just (DIInfix infixOp)
+getModuleItemIdentifier (ModuleExpression name _ _) = Just (DIName name)
+getModuleItemIdentifier (ModuleDataType (DataType typeName _ _)) = Just (DIType typeName)
+getModuleItemIdentifier (ModuleExport a) = getModuleItemIdentifier a
+getModuleItemIdentifier (ModuleImport _) = Nothing

--- a/compiler/src/Language/Mimsa/Modules/FromParts.hs
+++ b/compiler/src/Language/Mimsa/Modules/FromParts.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TupleSections #-}
 
-module Language.Mimsa.Modules.FromParts (moduleFromModuleParts, exprAndTypeFromParts) where
+module Language.Mimsa.Modules.FromParts (addModulePart, moduleFromModuleParts, exprAndTypeFromParts) where
 
 import Control.Monad.Except
 import Control.Monad.Reader
@@ -26,91 +26,95 @@ moduleFromModuleParts ::
 moduleFromModuleParts parts =
   let addPart part output = do
         mod' <- output
-        case part of
-          ModuleExport modItem -> do
-            -- get whatever is inside
-            innerModule <- addPart modItem output
-            -- get the keys, add them to exports
-            let defExports = case modItem of
-                  ModuleExpression name _ _ -> S.singleton (DIName name)
-                  ModuleInfix infixOp _ -> S.singleton (DIInfix infixOp)
-                  _ -> mempty
-            let typeExports = case modItem of
-                  ModuleDataType (DataType tn _ _) -> S.singleton (coerce tn)
-                  _ -> mempty
-            pure $
-              innerModule
-                { moExpressionExports =
-                    defExports <> moExpressionExports innerModule,
-                  moDataTypeExports =
-                    typeExports <> moDataTypeExports innerModule
-                }
-          ModuleExpression name bits expr -> do
-            errorIfExpressionAlreadyDefined mod' (DIName name)
-            exp' <- exprAndTypeFromParts (DIName name) bits expr
-            pure $
-              mod'
-                { moExpressions =
-                    M.singleton (DIName name) exp' <> moExpressions mod'
-                }
-          ModuleDataType dt@(DataType tyCon _ _) -> do
-            let typeName = coerce tyCon
-            checkDataType mod' dt
-            pure $
-              mod'
-                { moDataTypes =
-                    M.singleton typeName dt
-                      <> moDataTypes mod'
-                }
-          ModuleInfix infixOp expr -> do
-            errorIfExpressionAlreadyDefined mod' (DIInfix infixOp)
-            pure $
-              mod'
-                { moExpressions =
-                    M.singleton (DIInfix infixOp) expr
-                      <> moExpressions mod'
-                }
-          ModuleImport (ImportNamedFromHash mHash mName) ->
-            pure $ mod' {moNamedImports = M.singleton mName mHash <> moNamedImports mod'}
-          ModuleImport (ImportAllFromHash mHash) -> do
-            modules <- asks ceModules
-            importMod <- lookupModule modules mHash
-            let defImports =
-                  M.fromList
-                    . fmap (,mHash)
-                    . S.toList
-                    . moExpressionExports
-                    $ importMod
-
-            -- explode if these are defined already
-            _ <-
-              M.traverseWithKey
-                (errorIfImportAlreadyDefined mod')
-                defImports
-
-            let typeImports =
-                  M.fromList
-                    . fmap (,mHash)
-                    . S.toList
-                    . moDataTypeExports
-                    $ importMod
-
-            -- explode if these types are defined already
-            _ <-
-              M.traverseWithKey
-                (errorIfTypeImportAlreadyDefined mod')
-                typeImports
-
-            pure $
-              mod'
-                { moExpressionImports =
-                    defImports
-                      <> moExpressionImports mod',
-                  moDataTypeImports =
-                    typeImports
-                      <> moDataTypeImports mod'
-                }
+        addModulePart part mod'
    in foldr addPart (pure mempty) parts
+
+addModulePart :: Monoid ann => ModuleItem ann -> Module ann -> CheckM (Module ann)
+addModulePart part mod' =
+  case part of
+    ModuleExport modItem -> do
+      -- get whatever is inside
+      innerModule <- addModulePart modItem mod'
+      -- get the keys, add them to exports
+      let defExports = case modItem of
+            ModuleExpression name _ _ -> S.singleton (DIName name)
+            ModuleInfix infixOp _ -> S.singleton (DIInfix infixOp)
+            _ -> mempty
+      let typeExports = case modItem of
+            ModuleDataType (DataType tn _ _) -> S.singleton (coerce tn)
+            _ -> mempty
+      pure $
+        innerModule
+          { moExpressionExports =
+              defExports <> moExpressionExports innerModule,
+            moDataTypeExports =
+              typeExports <> moDataTypeExports innerModule
+          }
+    ModuleExpression name bits expr -> do
+      errorIfExpressionAlreadyDefined mod' (DIName name)
+      exp' <- exprAndTypeFromParts (DIName name) bits expr
+      pure $
+        mod'
+          { moExpressions =
+              M.singleton (DIName name) exp' <> moExpressions mod'
+          }
+    ModuleDataType dt@(DataType tyCon _ _) -> do
+      let typeName = coerce tyCon
+      checkDataType mod' dt
+      pure $
+        mod'
+          { moDataTypes =
+              M.singleton typeName dt
+                <> moDataTypes mod'
+          }
+    ModuleInfix infixOp expr -> do
+      errorIfExpressionAlreadyDefined mod' (DIInfix infixOp)
+      pure $
+        mod'
+          { moExpressions =
+              M.singleton (DIInfix infixOp) expr
+                <> moExpressions mod'
+          }
+    ModuleImport (ImportNamedFromHash mHash mName) ->
+      pure $ mod' {moNamedImports = M.singleton mName mHash <> moNamedImports mod'}
+    ModuleImport (ImportAllFromHash mHash) -> do
+      modules <- asks ceModules
+      importMod <- lookupModule modules mHash
+      let defImports =
+            M.fromList
+              . fmap (,mHash)
+              . S.toList
+              . moExpressionExports
+              $ importMod
+
+      -- explode if these are defined already
+      _ <-
+        M.traverseWithKey
+          (errorIfImportAlreadyDefined mod')
+          defImports
+
+      let typeImports =
+            M.fromList
+              . fmap (,mHash)
+              . S.toList
+              . moDataTypeExports
+              $ importMod
+
+      -- explode if these types are defined already
+      _ <-
+        M.traverseWithKey
+          (errorIfTypeImportAlreadyDefined mod')
+          typeImports
+
+      pure $
+        mod'
+          { moExpressionImports =
+              defImports
+                <> moExpressionImports mod',
+            moDataTypeImports =
+              typeImports
+                <> moDataTypeImports mod'
+          }
 
 addAnnotation :: Maybe (Type ann) -> Expr Name ann -> Expr Name ann
 addAnnotation mt expr =

--- a/compiler/src/Language/Mimsa/Parser.hs
+++ b/compiler/src/Language/Mimsa/Parser.hs
@@ -2,9 +2,13 @@ module Language.Mimsa.Parser
   ( module Language.Mimsa.Parser.Language,
     module Language.Mimsa.Parser.MonoType,
     module Language.Mimsa.Parser.TypeDecl,
+    module Language.Mimsa.Parser.Module,
+    module Language.Mimsa.Parser.Lexeme,
   )
 where
 
 import Language.Mimsa.Parser.Language
+import Language.Mimsa.Parser.Lexeme
+import Language.Mimsa.Parser.Module
 import Language.Mimsa.Parser.MonoType
 import Language.Mimsa.Parser.TypeDecl

--- a/compiler/src/Language/Mimsa/Parser/Module.hs
+++ b/compiler/src/Language/Mimsa/Parser/Module.hs
@@ -3,7 +3,6 @@
 
 module Language.Mimsa.Parser.Module
   ( parseModule,
-    parseModuleItem,
     moduleParser,
     DefPart (..),
   )
@@ -41,15 +40,15 @@ moduleParser =
 
 -- we've excluded Export here
 parseModuleItem :: Parser [ModuleItem Annotation]
-parseModuleItem = parseDef <|> parseType <|> parseImport <|> parseInfix
+parseModuleItem = parseDef <|> typeParser <|> parseImport <|> parseInfix
 
 -------
 
 -- type definitions
 -- type Maybe a = Just a | Nothing
 -- type Tree a = Branch (Tree a) a (Tree a) | Leaf a
-parseType :: Parser [ModuleItem Annotation]
-parseType = do
+typeParser :: Parser [ModuleItem Annotation]
+typeParser = do
   td <- typeDeclParser
   pure [ModuleDataType td]
 

--- a/compiler/src/Language/Mimsa/Parser/Module.hs
+++ b/compiler/src/Language/Mimsa/Parser/Module.hs
@@ -3,6 +3,7 @@
 
 module Language.Mimsa.Parser.Module
   ( parseModule,
+    parseModuleItem,
     moduleParser,
     DefPart (..),
   )

--- a/compiler/src/Language/Mimsa/Types/Modules/Module.hs
+++ b/compiler/src/Language/Mimsa/Types/Modules/Module.hs
@@ -41,7 +41,7 @@ data DefPart ann
     DefTypedArg (Identifier Name ann) (Type ann)
   | -- | type with no binding `String`
     DefType (Type ann)
-  deriving stock (Eq, Ord, Show)
+  deriving stock (Eq, Ord, Show, Functor)
 
 -- item parsed from file, kept like this so we can order them and have
 -- duplicates
@@ -54,6 +54,7 @@ data ModuleItem ann
   | ModuleExport (ModuleItem ann)
   | ModuleImport Import
   | ModuleInfix InfixOp (Expr Name ann)
+  deriving stock (Functor)
 
 -- going to want way more granularity here in future but _shrug_
 data Import

--- a/compiler/test/Test/Actions/BindModule.hs
+++ b/compiler/test/Test/Actions/BindModule.hs
@@ -6,14 +6,14 @@ module Test.Actions.BindModule
   )
 where
 
-import Data.Either (isLeft)
+import Data.Either (isLeft, isRight)
 import qualified Data.Set as S
 import qualified Language.Mimsa.Actions.BindModule as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Project.Helpers
-import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Project
+import Language.Mimsa.Types.Typechecker
 import Test.Data.Prelude
 import Test.Data.Project
 import Test.Hspec
@@ -31,20 +31,38 @@ spec = do
       it "Adds a new function to Prelude that does not typecheck" $ do
         let action = do
               (_hash, mod') <- Actions.bindModule prelude "Prelude" (prettyPrint prelude)
-              let input = "id True False"
-                  modItem = ModuleExpression "idTrue" [] (unsafeParseExpr' input)
+              let input = "def idTrue = fst True"
+                  modItem = unsafeParseModuleItem input
               Actions.addBindingToModule mod' modItem input
         Actions.run testStdlib action `shouldSatisfy` isLeft
 
       it "Adds a new function to Prelude that is good typecheck" $ do
         let action = do
               (_hash, mod') <- Actions.bindModule prelude "Prelude" (prettyPrint prelude)
-              let input = "id True False"
-                  expr = unsafeParseExpr' input
-              Actions.addBindingToModule mod' "useId" expr input
+              let input = "def useId = fst (True, 1)"
+                  modItem = unsafeParseModuleItem input
+              newModule <- Actions.addBindingToModule mod' modItem input
+              Actions.bindModule (getAnnotationForType <$> newModule) "Repl" (prettyPrint newModule)
         let (newProject, _outcomes, _) = fromRight $ Actions.run testStdlib action
         newModules testStdlib newProject
-          `shouldBe` 1
+          `shouldBe` 2
+
+      it "Adds a new function to a new module that uses the Prelude" $ do
+        let action = do
+              -- add the Prelude
+              (preludeHash', _mod') <- Actions.bindModule prelude "Prelude" (prettyPrint prelude)
+              -- import Prelude
+              let importExpr = unsafeParseModuleItem $ "import MyPrelude from " <> prettyPrint preludeHash'
+              mod2 <- Actions.addBindingToModule mempty importExpr ""
+              -- use Prelude
+              let expr = unsafeParseModuleItem "def useFst = MyPrelude.fst (1,2)"
+              mod3 <- Actions.addBindingToModule mod2 expr ""
+              -- store the updated thing
+              Actions.bindModule (getAnnotationForType <$> mod3) "Repl" (prettyPrint mod3)
+        let (newProject, _outcomes, _) = fromRight $ Actions.run testStdlib action
+        -- we've added two modules here
+        newModules testStdlib newProject
+          `shouldBe` 2
 
     describe "bindModule" $ do
       it "Adds a fresh new module to prjModules and to Store" $ do

--- a/compiler/test/Test/Actions/BindModule.hs
+++ b/compiler/test/Test/Actions/BindModule.hs
@@ -6,16 +6,18 @@ module Test.Actions.BindModule
   )
 where
 
-import Data.Either
+import Data.Either (isLeft)
 import qualified Data.Set as S
 import qualified Language.Mimsa.Actions.BindModule as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Project.Helpers
+import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Project
 import Test.Data.Prelude
 import Test.Data.Project
 import Test.Hspec
+import Test.Utils.Helpers
 
 newModules :: Project ann -> Project ann -> Int
 newModules old new =
@@ -25,18 +27,38 @@ newModules old new =
 spec :: Spec
 spec = do
   describe "BindModule" $ do
-    it "Adds a fresh new module to prjModules and to Store" $ do
-      case Actions.run testStdlib (Actions.bindModule prelude "Prelude" (prettyPrint prelude)) of
-        Left _ -> error "Should not have failed"
-        Right (newProject, outcomes, _) -> do
-          -- one more item in module store
-          newModules testStdlib newProject
-            `shouldBe` 1
-          -- one more binding
-          lookupModuleName
-            newProject
-            "Prelude"
-            `shouldSatisfy` isRight
-          -- one new store expression
-          S.size (Actions.modulesFromOutcomes outcomes)
-            `shouldBe` 1
+    describe "addBindingToModule" $ do
+      it "Adds a new function to Prelude that does not typecheck" $ do
+        let action = do
+              (_hash, mod') <- Actions.bindModule prelude "Prelude" (prettyPrint prelude)
+              let input = "id True False"
+                  modItem = ModuleExpression "idTrue" [] (unsafeParseExpr' input)
+              Actions.addBindingToModule mod' modItem input
+        Actions.run testStdlib action `shouldSatisfy` isLeft
+
+      it "Adds a new function to Prelude that is good typecheck" $ do
+        let action = do
+              (_hash, mod') <- Actions.bindModule prelude "Prelude" (prettyPrint prelude)
+              let input = "id True False"
+                  expr = unsafeParseExpr' input
+              Actions.addBindingToModule mod' "useId" expr input
+        let (newProject, _outcomes, _) = fromRight $ Actions.run testStdlib action
+        newModules testStdlib newProject
+          `shouldBe` 1
+
+    describe "bindModule" $ do
+      it "Adds a fresh new module to prjModules and to Store" $ do
+        case Actions.run testStdlib (Actions.bindModule prelude "Prelude" (prettyPrint prelude)) of
+          Left _ -> expectationFailure "Should not have failed"
+          Right (newProject, outcomes, _) -> do
+            -- one more item in module store
+            newModules testStdlib newProject
+              `shouldBe` 1
+            -- one more binding
+            lookupModuleName
+              newProject
+              "Prelude"
+              `shouldSatisfy` isRight
+            -- one new store expression
+            S.size (Actions.modulesFromOutcomes outcomes)
+              `shouldBe` 1

--- a/compiler/test/Test/Actions/Evaluate.hs
+++ b/compiler/test/Test/Actions/Evaluate.hs
@@ -6,8 +6,9 @@ module Test.Actions.Evaluate
   )
 where
 
-import Data.Either (isLeft)
+import Data.Either (isLeft, isRight)
 import Data.Functor
+import qualified Language.Mimsa.Actions.BindModule as Actions
 import qualified Language.Mimsa.Actions.Evaluate as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Printer
@@ -27,18 +28,31 @@ onePlusOneExpr = MyInfix mempty Add (int 1) (int 1)
 spec :: Spec
 spec = do
   describe "Evaluate" $ do
-    it "Should return an error for a broken expr" $ do
-      Actions.run testStdlib (Actions.evaluate (prettyPrint brokenExpr) brokenExpr) `shouldSatisfy` isLeft
-    it "Should evaluate an expression" $ do
-      let action = Actions.evaluate (prettyPrint onePlusOneExpr) onePlusOneExpr
-      let (newProject, _, (mt, expr, _, _, _)) = fromRight (Actions.run testStdlib action)
-      mt $> () `shouldBe` MTPrim mempty MTInt
-      expr $> () `shouldBe` int 2
-      -- optimised version in store
-      additionalStoreItems testStdlib newProject `shouldBe` 1
-    it "Should evaluate an expression with a nested dependency" $ do
-      let expr = unsafeParseExpr "incrementInt 1 + id 10" $> mempty
-      let action = Actions.evaluate (prettyPrint expr) expr
-      let (_, _, (mt, newExpr, _, _, _)) = fromRight (Actions.run testStdlib action)
-      mt $> () `shouldBe` MTPrim mempty MTInt
-      newExpr $> () `shouldBe` int 12
+    describe "StoreExpression-based" $ do
+      it "Should return an error for a broken expr" $ do
+        Actions.run testStdlib (Actions.evaluate (prettyPrint brokenExpr) brokenExpr) `shouldSatisfy` isLeft
+
+      it "Should evaluate an expression" $ do
+        let action = Actions.evaluate (prettyPrint onePlusOneExpr) onePlusOneExpr
+        let (newProject, _, (mt, expr, _, _, _)) = fromRight (Actions.run testStdlib action)
+        mt $> () `shouldBe` MTPrim mempty MTInt
+        expr $> () `shouldBe` int 2
+        -- optimised version in store
+        additionalStoreItems testStdlib newProject `shouldBe` 1
+
+      it "Should evaluate an expression with a nested dependency" $ do
+        let expr = unsafeParseExpr "incrementInt 1 + id 10" $> mempty
+        let action = Actions.evaluate (prettyPrint expr) expr
+        let (_, _, (mt, newExpr, _, _, _)) = fromRight (Actions.run testStdlib action)
+        mt $> () `shouldBe` MTPrim mempty MTInt
+        newExpr $> () `shouldBe` int 12
+
+    describe "Module-based" $ do
+      it "Should use the passed in module as context" $ do
+        let action = do
+              -- add a definition to an empty module
+              let expr = unsafeParseModuleItem "def dog = True"
+              newMod <- Actions.addBindingToModule mempty expr ""
+              -- evaluate using that module
+              Actions.evaluateModule "dog" (unsafeParseExpr' "dog") (getAnnotationForType <$> newMod)
+        Actions.run testStdlib action `shouldSatisfy` isRight

--- a/compiler/test/Test/Utils/Helpers.hs
+++ b/compiler/test/Test/Utils/Helpers.hs
@@ -45,11 +45,11 @@ unsafeParseExpr' t = case parseExpr t of
 unsafeParseExpr :: Text -> Expr Name ()
 unsafeParseExpr = unsafeParseExpr'
 
-unsafeParseModuleItem :: Text -> ModuleItem ann
-unsafeParseModuleItem t = case parseModuleItem t of
+unsafeParseModuleItem :: (Monoid ann) => Text -> ModuleItem ann
+unsafeParseModuleItem t = case parseAndFormat moduleParser t of
   Right [item] -> item $> mempty
-  Right many -> error "ModuleItem parser succeeded but did not have 1 item"
-  Left e -> error $ "Error parsing ModuleItem for tests: " <> T.pack (prettyPrint e)
+  Right _many -> error "ModuleItem parser succeeded but did not have 1 item"
+  Left e -> error $ "Error parsing ModuleItem for tests: " <> T.unpack (prettyPrint e)
 
 unsafeParseMonoType :: Text -> Type ()
 unsafeParseMonoType t = case parseMonoType t of

--- a/compiler/test/Test/Utils/Helpers.hs
+++ b/compiler/test/Test/Utils/Helpers.hs
@@ -10,6 +10,7 @@ import qualified Data.Text as T
 import qualified Language.Mimsa.Actions.Monad as Actions
 import qualified Language.Mimsa.Actions.Typecheck as Actions
 import Language.Mimsa.Parser
+import Language.Mimsa.Parser.Module
 import Language.Mimsa.Printer
 import Language.Mimsa.Project
 import Language.Mimsa.Tests.Types
@@ -17,6 +18,7 @@ import Language.Mimsa.Tests.UnitTest
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.ResolvedExpression
 import Language.Mimsa.Types.Store
@@ -32,13 +34,22 @@ fromLeft either' = case either' of
   Left e -> e
   Right _ -> error "Expected a Left!"
 
-unsafeParseExpr :: Text -> Expr Name ()
-unsafeParseExpr t = case parseExpr t of
-  Right a -> a $> ()
+unsafeParseExpr' :: Monoid ann => Text -> Expr Name ann
+unsafeParseExpr' t = case parseExpr t of
+  Right a -> a $> mempty
   Left _ ->
     error $
       "Error parsing expr for Prettier tests:"
         <> T.unpack t
+
+unsafeParseExpr :: Text -> Expr Name ()
+unsafeParseExpr = unsafeParseExpr'
+
+unsafeParseModuleItem :: Text -> ModuleItem ann
+unsafeParseModuleItem t = case parseModuleItem t of
+  Right [item] -> item $> mempty
+  Right many -> error "ModuleItem parser succeeded but did not have 1 item"
+  Left e -> error $ "Error parsing ModuleItem for tests: " <> T.pack (prettyPrint e)
 
 unsafeParseMonoType :: Text -> Type ()
 unsafeParseMonoType t = case parseMonoType t of

--- a/compiler/test/Test/Utils/Helpers.hs
+++ b/compiler/test/Test/Utils/Helpers.hs
@@ -10,7 +10,6 @@ import qualified Data.Text as T
 import qualified Language.Mimsa.Actions.Monad as Actions
 import qualified Language.Mimsa.Actions.Typecheck as Actions
 import Language.Mimsa.Parser
-import Language.Mimsa.Parser.Module
 import Language.Mimsa.Printer
 import Language.Mimsa.Project
 import Language.Mimsa.Tests.Types


### PR DESCRIPTION
This change makes the repl keep a `Module MonoType` in state, and then allow the user to add bindings to it.

The effect is a workflow like:

```haskell
$ mimsa repl-new                                                            

Successfully loaded project.
12 modules found

:> :bind def id a = a
Added definition id to module

:> id 1
1 :: Int

:> :bind def const a b = id a
Added definition const to module

:> :list

def const =
  \a -> \b -> id a

def id =
  \a -> a
```