### PR TITLE
Show modules types in Repl/UI

### DIFF
--- a/compiler/mimsa.cabal
+++ b/compiler/mimsa.cabal
@@ -87,6 +87,7 @@ library
       Language.Mimsa.Modules.Monad
       Language.Mimsa.Modules.Parse
       Language.Mimsa.Modules.Prelude
+      Language.Mimsa.Modules.Pretty
       Language.Mimsa.Modules.Typecheck
       Language.Mimsa.Modules.Uses
       Language.Mimsa.Parser

--- a/compiler/repl/ReplNew/Actions.hs
+++ b/compiler/repl/ReplNew/Actions.hs
@@ -28,8 +28,8 @@ doReplAction prj input action =
     Help -> do
       doHelp
       pure prj
-    ListModules ->
-      catchMimsaError prj (doListModules prj input $> prj)
+    ListModules modName ->
+      catchMimsaError prj (doListModules prj modName $> prj)
     ListBindings ->
       catchMimsaError prj (doListBindings $> prj)
     (Evaluate expr) ->
@@ -46,7 +46,7 @@ doHelp :: ReplM e ()
 doHelp = do
   replOutput @Text "~~~ MIMSA ~~~"
   replOutput @Text ":help - this help screen"
-  replOutput @Text ":modules - show a list of modules in the project"
+  replOutput @Text ":modules <moduleName> - show a list of modules in the project or details of a module"
   replOutput @Text ":list - show a list of bindings created in this repl session"
   replOutput @Text ":bind <binding> - bind an expression, infix or type"
   replOutput @Text "<expr> - Evaluate <expr>, returning it's simplified form and type"

--- a/compiler/repl/ReplNew/Actions/Bindings.hs
+++ b/compiler/repl/ReplNew/Actions/Bindings.hs
@@ -8,6 +8,7 @@ where
 
 import Data.Text (Text)
 import qualified Language.Mimsa.Actions.BindModule as Actions
+import Language.Mimsa.Modules.Pretty
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Modules
@@ -35,4 +36,4 @@ doListBindings = do
   -- output to console
   if oldModule == mempty
     then replOutput ("Current module is empty" :: Text)
-    else replOutput oldModule
+    else replDocOutput (modulePretty oldModule)

--- a/compiler/repl/ReplNew/Actions/ListModules.hs
+++ b/compiler/repl/ReplNew/Actions/ListModules.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
 module ReplNew.Actions.ListModules
   ( doListModules,
   )
@@ -6,17 +9,34 @@ where
 import Data.Foldable (traverse_)
 import qualified Data.Map as M
 import Data.Text (Text)
+import qualified Language.Mimsa.Actions.BindModule as Actions
+import qualified Language.Mimsa.Actions.Helpers.LookupExpression as Actions
+import Language.Mimsa.Modules.Pretty
+import Language.Mimsa.Printer
 import Language.Mimsa.Project
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Project
+import ReplNew.Helpers
 import ReplNew.ReplM
 
-showModule :: ModuleName -> ReplM e ()
-showModule = replOutput
+-- | get module from project
+-- | typecheck it
+-- | pretty display it
+showModule :: Project Annotation -> ModuleHash -> ReplM (Error Annotation) ()
+showModule prj modHash = do
+  let action = do
+        mod' <- Actions.lookupModule modHash
+        Actions.typecheckModule (prettyPrint mod') mod'
+  (_, typedMod) <- toReplM prj action
+  replDocOutput (modulePretty typedMod)
 
-doListModules :: Project Annotation -> Text -> ReplM (Error Annotation) ()
-doListModules project _input = do
+doListModules :: Project Annotation -> Maybe ModuleName -> ReplM (Error Annotation) ()
+doListModules project Nothing = do
   let moduleNames = M.keys (getCurrentModules $ prjModules project)
-  traverse_ showModule moduleNames
+  traverse_ replOutput moduleNames
+doListModules project (Just modName) = do
+  case M.lookup modName (getCurrentModules $ prjModules project) of
+    Just moduleHash -> showModule project moduleHash
+    Nothing -> replOutput @Text $ "Could not find module " <> prettyPrint modName

--- a/compiler/repl/ReplNew/Parser.hs
+++ b/compiler/repl/ReplNew/Parser.hs
@@ -8,6 +8,7 @@ where
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as S
 import Language.Mimsa.Parser
+import Language.Mimsa.Parser.Identifiers
 import Language.Mimsa.Types.AST
 import ReplNew.Types
 import Text.Megaparsec
@@ -31,7 +32,10 @@ evalParser =
     <$> expressionParser
 
 listModulesParser :: Parser ReplActionAnn
-listModulesParser = ListModules <$ myString ":modules"
+listModulesParser = do
+  myString ":modules"
+  modName <- optional moduleNameParser
+  pure (ListModules modName)
 
 listBindingsParser :: Parser ReplActionAnn
 listBindingsParser = ListBindings <$ myString ":list"

--- a/compiler/repl/ReplNew/ReplM.hs
+++ b/compiler/repl/ReplNew/ReplM.hs
@@ -10,6 +10,7 @@ module ReplNew.ReplM
     getStoredModule,
     replMFromEither,
     replOutput,
+    replDocOutput,
   )
 where
 
@@ -27,6 +28,7 @@ import qualified Data.Text.IO as T
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Typechecker
+import Prettyprinter
 import ReplNew.Types
 
 -- | to allow us to do 'bindings' in the repl,
@@ -92,6 +94,10 @@ replMFromEither = ReplM . liftEither
 -- | Output stuff for use in repl
 replOutput :: (Printer a) => a -> ReplM e ()
 replOutput = liftIO . T.putStrLn . prettyPrint
+
+-- | Output a Doc from prettyprinter
+replDocOutput :: Doc a -> ReplM e ()
+replDocOutput = liftIO . T.putStrLn . renderWithWidth 40
 
 -- | we maintain a module in state, this allows us to update it
 setStoredModule :: Module MonoType -> ReplM e ()

--- a/compiler/repl/ReplNew/Types.hs
+++ b/compiler/repl/ReplNew/Types.hs
@@ -17,7 +17,7 @@ data ReplAction ann
   = Help
   | Evaluate (Expr Name ann)
   | AddBinding (ModuleItem ann)
-  | ListModules
+  | ListModules (Maybe ModuleName)
   | ListBindings
 
 data ReplConfig = ReplConfig

--- a/compiler/server/Server/Helpers/ModuleData.hs
+++ b/compiler/server/Server/Helpers/ModuleData.hs
@@ -14,6 +14,7 @@ import qualified Data.Aeson as JSON
 import Data.OpenApi hiding (get)
 import Data.Text (Text)
 import GHC.Generics
+import Language.Mimsa.Modules.Pretty
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Typechecker
@@ -21,6 +22,7 @@ import Language.Mimsa.Types.Typechecker
 data ModuleData = ModuleData
   { mdModuleHash :: Text,
     mdModulePretty :: Text,
+    mdModuleType :: Text,
     mdInput :: Text
   }
   deriving stock (Eq, Ord, Show, Generic)
@@ -35,5 +37,6 @@ makeModuleData typedModule input =
    in ModuleData
         { mdModuleHash = prettyPrint moduleHash,
           mdModulePretty = prettyPrint typedModule,
+          mdModuleType = renderWithWidth 40 (modulePretty typedModule),
           mdInput = input
         }

--- a/compiler/src/Language/Mimsa/Actions/Helpers/LookupExpression.hs
+++ b/compiler/src/Language/Mimsa/Actions/Helpers/LookupExpression.hs
@@ -1,6 +1,7 @@
 module Language.Mimsa.Actions.Helpers.LookupExpression
   ( lookupExpressionInStore,
     lookupExpression,
+    lookupModule,
   )
 where
 
@@ -10,8 +11,18 @@ import qualified Data.Map as M
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
+import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Store
+
+lookupModule ::
+  ModuleHash ->
+  Actions.ActionM (Module Annotation)
+lookupModule modHash = do
+  project <- Actions.getProject
+  case M.lookup modHash (prjModuleStore project) of
+    Just mod' -> pure mod'
+    Nothing -> throwError (StoreErr (CouldNotFindModule modHash))
 
 lookupExpression ::
   ExprHash ->

--- a/compiler/src/Language/Mimsa/Modules/Pretty.hs
+++ b/compiler/src/Language/Mimsa/Modules/Pretty.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Modules.Pretty (modulePretty) where
+
+import Data.Map (Map)
+import qualified Data.Map as M
+import qualified Data.Set as S
+import Language.Mimsa.Printer
+import Language.Mimsa.Typechecker.Elaborate
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Modules
+import Language.Mimsa.Types.Typechecker
+import Prettyprinter
+
+-- | display types for module in a nice way
+modulePretty :: Module (Type Annotation) -> Doc a
+modulePretty mod' =
+  let useful = filterExported mod'
+      prettyExp (k, a) = indentMulti 2 (prettyDoc k <> ":" <+> prettyDoc (getTypeFromAnn a))
+      prettyType (k, a) = indentMulti 2 (prettyDoc k <> ":" <+> prettyDoc a)
+   in align
+        ( encloseSep
+            lbrace
+            rbrace
+            comma
+            ( ( prettyExp
+                  <$> M.toList (moExpressions useful)
+              )
+                <> ( prettyType
+                       <$> M.toList (moDataTypes useful)
+                   )
+            )
+        )
+
+filterByKey :: (k -> Bool) -> Map k a -> Map k a
+filterByKey f = M.filterWithKey (\k _ -> f k)
+
+filterExported :: Module ann -> Module ann
+filterExported mod' =
+  mod'
+    { moDataTypes =
+        filterByKey
+          (\k -> S.member k (moDataTypeExports mod'))
+          (moDataTypes mod'),
+      moExpressions =
+        filterByKey
+          (\k -> S.member k (moExpressionExports mod'))
+          (moExpressions mod')
+    }

--- a/compiler/src/Language/Mimsa/Printer.hs
+++ b/compiler/src/Language/Mimsa/Printer.hs
@@ -34,8 +34,6 @@ class Printer a where
   default prettyDoc :: a -> Doc ann
   prettyDoc = pretty . T.unpack . prettyPrint
 
-instance Printer (Doc ann)
-
 instance (Printer e, Printer a) => Printer (Either e a) where
   prettyDoc (Left e) = prettyDoc e
   prettyDoc (Right a) = prettyDoc a
@@ -62,7 +60,7 @@ instance (Printer a) => Printer [a] where
 
 instance (Printer k, Printer v) => Printer (Map k v) where
   prettyDoc map' =
-    let printRow (k, v) = prettyDoc k <> ":" <+> prettyDoc v
+    let printRow (k, v) = "  " <> prettyDoc k <> ":" <+> prettyDoc v
      in encloseSep lbrace rbrace comma (printRow <$> M.toList map')
 
 instance (Printer a, Printer b) => Printer (a, b) where

--- a/compiler/src/Language/Mimsa/Types/Error/StoreError.hs
+++ b/compiler/src/Language/Mimsa/Types/Error/StoreError.hs
@@ -7,7 +7,7 @@ import qualified Data.Text as T
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST.InfixOp
 import Language.Mimsa.Types.Identifiers
-import Language.Mimsa.Types.Modules.ModuleName
+import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Store
 
 data FileType = ProjectFile | StoreExprFile
@@ -29,6 +29,7 @@ data StoreError
   | CouldNotFindExprHashForTypeBindings [TyCon]
   | CouldNotFindBinding Name
   | CouldNotFindStoreExpression ExprHash
+  | CouldNotFindModule ModuleHash
   | UnknownStoreError
   deriving stock (Eq, Ord, Show)
 
@@ -61,6 +62,8 @@ instance Printer StoreError where
     "Could not find binding " <> prettyPrint name
   prettyPrint (CouldNotFindStoreExpression exprHash) =
     "Could not find store expression for hash " <> prettyPrint exprHash
+  prettyPrint (CouldNotFindModule modHash) =
+    "Could not find module for hash " <> prettyPrint modHash
   prettyPrint UnknownStoreError =
     "Unknown store error"
 

--- a/ui/src/components/Editor/EditModule.tsx
+++ b/ui/src/components/Editor/EditModule.tsx
@@ -6,11 +6,16 @@ import { Feedback } from './Feedback'
 import * as O from 'fp-ts/Option'
 import { Panel } from '../View/Panel'
 import { Button } from '../View/Button'
-import { ModuleHash } from '../../types'
+import { ModuleData, ModuleHash } from '../../types'
 import {
   updateCode,
   bindExpression,
 } from '../../reducer/editor/actions'
+import {
+  editorNew,
+  showModule,
+  Feedback as FeedbackType,
+} from '../../reducer/editor/feedback'
 import {
   getErrorLocations,
   getSourceItems,
@@ -43,7 +48,13 @@ export const EditModule: React.FC<Props> = ({
     )
   )
 
-  console.log(maybeMod)
+  const feedback = pipe(
+    maybeMod,
+    O.fold<ModuleData, FeedbackType>(
+      () => editorNew(),
+      showModule
+    )
+  )
 
   const onCodeChange = (a: string) =>
     dispatch(updateCode(a))
@@ -59,7 +70,7 @@ export const EditModule: React.FC<Props> = ({
     sourceItems: getSourceItems,
     projectHash: getProjectHash,
   })
-  const { feedback, stale } = editor
+  const { stale } = editor
 
   const bindingName = O.toNullable(editor.bindingName)
 

--- a/ui/src/components/Editor/Feedback.tsx
+++ b/ui/src/components/Editor/Feedback.tsx
@@ -173,6 +173,26 @@ export const Feedback: React.FC<Props> = ({
         </FlexColumnSpaced>
       )
 
+    case 'ShowModuleData':
+      return (
+        <FlexColumnSpaced>
+          <Code codeType="type">
+            {feedback.moduleData.mdModuleType}
+          </Code>
+          <ListBindings
+            modules={{}}
+            onModuleSelect={() => {}}
+            values={{}}
+            types={{}}
+            onBindingSelect={onBindingSelect}
+          />
+          <ListUsages
+            usages={[]}
+            onBindingSelect={onBindingSelect}
+          />
+        </FlexColumnSpaced>
+      )
+
     case 'ShowBinding':
       return (
         <FlexColumnSpaced>

--- a/ui/src/generated/models/ModuleData.ts
+++ b/ui/src/generated/models/ModuleData.ts
@@ -6,4 +6,5 @@ export type ModuleData = {
   mdInput: string
   mdModuleHash: string
   mdModulePretty: string
+  mdModuleType: string
 }

--- a/ui/src/hooks/useModule.ts
+++ b/ui/src/hooks/useModule.ts
@@ -26,7 +26,7 @@ export const useModule = (moduleHash: ModuleHash) => {
           O.Option<ModuleData>
         >(
           () => O.none,
-          (a) => O.some(a.geModuleData)
+          ({ geModuleData }) => O.some(geModuleData)
         ),
         setResult
       )

--- a/ui/src/reducer/editor/feedback.ts
+++ b/ui/src/reducer/editor/feedback.ts
@@ -4,6 +4,7 @@ import type {
   TestData,
   UnitTestData,
   UserErrorResponse,
+  ModuleData,
 } from '../../types'
 
 export const editorNew = () => ({
@@ -58,6 +59,11 @@ export const showPreviewSuccess = (
   expression,
 })
 
+export const showModule = (moduleData: ModuleData) => ({
+  type: 'ShowModuleData' as const,
+  moduleData,
+})
+
 export type Feedback =
   | ReturnType<typeof editorNew>
   | ReturnType<typeof showBinding>
@@ -66,3 +72,4 @@ export type Feedback =
   | ReturnType<typeof showEvaluate>
   | ReturnType<typeof showUpdatedBinding>
   | ReturnType<typeof showPreviewSuccess>
+  | ReturnType<typeof showModule>


### PR DESCRIPTION
Now we can see the externally available items inside a module nicely.

<img width="365" alt="Screenshot 2022-07-05 at 09 50 53" src="https://user-images.githubusercontent.com/4729125/177476615-05d70e47-e693-4664-b913-a8dd4a322e9a.png">
