### PR TITLE
Unit tests in module land

### DIFF
--- a/compiler/mimsa.cabal
+++ b/compiler/mimsa.cabal
@@ -27,7 +27,6 @@ library
   exposed-modules:
       Language.Mimsa.Actions.AddUnitTest
       Language.Mimsa.Actions.BindExpression
-      Language.Mimsa.Actions.BindModule
       Language.Mimsa.Actions.BindType
       Language.Mimsa.Actions.Compile
       Language.Mimsa.Actions.Evaluate
@@ -41,8 +40,11 @@ library
       Language.Mimsa.Actions.Helpers.Parse
       Language.Mimsa.Actions.Helpers.UpdateTests
       Language.Mimsa.Actions.Interpret
+      Language.Mimsa.Actions.Modules.Bind
       Language.Mimsa.Actions.Modules.Check
+      Language.Mimsa.Actions.Modules.Evaluate
       Language.Mimsa.Actions.Modules.RunTests
+      Language.Mimsa.Actions.Modules.Typecheck
       Language.Mimsa.Actions.Monad
       Language.Mimsa.Actions.Optimise
       Language.Mimsa.Actions.RemoveBinding

--- a/compiler/mimsa.cabal
+++ b/compiler/mimsa.cabal
@@ -127,7 +127,6 @@ library
       Language.Mimsa.Tests.Helpers
       Language.Mimsa.Tests.PropertyTest
       Language.Mimsa.Tests.Test
-      Language.Mimsa.Tests.Types
       Language.Mimsa.Tests.UnitTest
       Language.Mimsa.Transform.BetaReduce
       Language.Mimsa.Transform.EtaReduce
@@ -214,6 +213,7 @@ library
       Language.Mimsa.Types.Store.Store
       Language.Mimsa.Types.Store.StoreExpression
       Language.Mimsa.Types.Store.TypeBindings
+      Language.Mimsa.Types.Tests
       Language.Mimsa.Types.Typechecker
       Language.Mimsa.Types.Typechecker.Constraint
       Language.Mimsa.Types.Typechecker.Environment
@@ -436,7 +436,7 @@ test-suite mimsa-test
       Test.Data.Prelude
       Test.Data.Project
       Test.Interpreter.Repl
-      Test.Modules.CheckModule
+      Test.Modules.Check
       Test.Modules.Compile
       Test.Modules.Repl
       Test.Parser.MonoTypeParser

--- a/compiler/mimsa.cabal
+++ b/compiler/mimsa.cabal
@@ -44,6 +44,7 @@ library
       Language.Mimsa.Actions.Monad
       Language.Mimsa.Actions.Optimise
       Language.Mimsa.Actions.RemoveBinding
+      Language.Mimsa.Actions.RunModuleTests
       Language.Mimsa.Actions.Typecheck
       Language.Mimsa.Actions.Types
       Language.Mimsa.Actions.Upgrade
@@ -439,6 +440,7 @@ test-suite mimsa-test
       Test.Modules.Check
       Test.Modules.Compile
       Test.Modules.Repl
+      Test.Modules.Test
       Test.Parser.MonoTypeParser
       Test.Parser.Pattern
       Test.Parser.Syntax

--- a/compiler/mimsa.cabal
+++ b/compiler/mimsa.cabal
@@ -41,10 +41,11 @@ library
       Language.Mimsa.Actions.Helpers.Parse
       Language.Mimsa.Actions.Helpers.UpdateTests
       Language.Mimsa.Actions.Interpret
+      Language.Mimsa.Actions.Modules.Check
+      Language.Mimsa.Actions.Modules.RunTests
       Language.Mimsa.Actions.Monad
       Language.Mimsa.Actions.Optimise
       Language.Mimsa.Actions.RemoveBinding
-      Language.Mimsa.Actions.RunModuleTests
       Language.Mimsa.Actions.Typecheck
       Language.Mimsa.Actions.Types
       Language.Mimsa.Actions.Upgrade

--- a/compiler/repl/Check/Main.hs
+++ b/compiler/repl/Check/Main.hs
@@ -10,7 +10,8 @@ import Data.Either
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
-import Language.Mimsa.Modules.Check
+import qualified Language.Mimsa.Actions.Modules.Check as Actions
+import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Project.Stdlib
 import Language.Mimsa.Types.AST
@@ -40,8 +41,8 @@ checkFile filePath = do
   -- use project if we're in one, if not, stdlib
   let project = fromRight stdlib maybeProject
   -- check module
-  case checkModule fileContents (prjModuleStore project) of
-    Right (mod', _) -> do
+  case Actions.run project (Actions.checkModule (prjModuleStore project) fileContents) of
+    Right (_, _, (mod', _)) -> do
       liftIO $ T.putStrLn $ prettyPrint mod'
       -- format and rewrite
       -- liftIO $ T.writeFile (T.unpack filePath) (prettyPrint mod')

--- a/compiler/repl/Check/Main.hs
+++ b/compiler/repl/Check/Main.hs
@@ -42,8 +42,9 @@ checkFile filePath = do
   let project = fromRight stdlib maybeProject
   -- check module
   case Actions.run project (Actions.checkModule (prjModuleStore project) fileContents) of
-    Right (_, _, (mod', _)) -> do
+    Right (_, _, (mod', testResults)) -> do
       liftIO $ T.putStrLn $ prettyPrint mod'
+      liftIO $ T.putStrLn $ prettyPrint testResults -- should failing tests means a non-zero exit code?
       -- format and rewrite
       -- liftIO $ T.writeFile (T.unpack filePath) (prettyPrint mod')
       pure ExitSuccess

--- a/compiler/repl/Eval/Main.hs
+++ b/compiler/repl/Eval/Main.hs
@@ -8,8 +8,8 @@ where
 import Control.Monad.Except
 import Data.Either
 import Data.Text (Text)
-import qualified Language.Mimsa.Actions.Evaluate as Actions
 import qualified Language.Mimsa.Actions.Helpers.Parse as Actions
+import qualified Language.Mimsa.Actions.Modules.Evaluate as Actions
 import Language.Mimsa.Project.Stdlib
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error

--- a/compiler/repl/Eval/Main.hs
+++ b/compiler/repl/Eval/Main.hs
@@ -37,7 +37,7 @@ evalInput input = do
   let project = fromRight stdlib maybeProject
   let action = do
         expr <- Actions.parseExpr input
-        Actions.evaluateModule input expr mempty
+        Actions.evaluateModule expr mempty
   result <-
     (Right <$> toReplM project action)
       `catchError` (pure . Left)

--- a/compiler/repl/Repl/Actions/UnitTests.hs
+++ b/compiler/repl/Repl/Actions/UnitTests.hs
@@ -11,11 +11,11 @@ import Language.Mimsa.Actions.AddUnitTest
 import Language.Mimsa.Printer
 import Language.Mimsa.Project.Helpers
 import Language.Mimsa.Tests.Test
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
+import Language.Mimsa.Types.Tests
 import Repl.Helpers
 import Repl.ReplM
 

--- a/compiler/repl/Repl/Parser.hs
+++ b/compiler/repl/Repl/Parser.hs
@@ -9,8 +9,8 @@ import Data.Functor (($>))
 import Language.Mimsa.Backend.Types
 import Language.Mimsa.Parser
 import Language.Mimsa.Parser.Literal
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Tests
 import Repl.Types
 import Text.Megaparsec
 import Text.Megaparsec.Char

--- a/compiler/repl/Repl/Types.hs
+++ b/compiler/repl/Repl/Types.hs
@@ -9,10 +9,10 @@ where
 
 import GHC.Generics
 import Language.Mimsa.Backend.Types
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Store.RootPath
+import Language.Mimsa.Types.Tests
 import Language.Mimsa.Types.Typechecker
 
 data ReplAction ann

--- a/compiler/repl/ReplNew/Actions.hs
+++ b/compiler/repl/ReplNew/Actions.hs
@@ -20,10 +20,9 @@ import ReplNew.Types
 
 doReplAction ::
   Project Annotation ->
-  Text ->
   ReplAction Annotation ->
   ReplM (Error Annotation) (Project Annotation)
-doReplAction prj input action =
+doReplAction prj action =
   case action of
     Help -> do
       doHelp
@@ -33,11 +32,11 @@ doReplAction prj input action =
     ListBindings ->
       catchMimsaError prj (doListBindings $> prj)
     (Evaluate expr) ->
-      catchMimsaError prj (doEvaluate prj input expr $> prj)
+      catchMimsaError prj (doEvaluate prj expr $> prj)
     (AddBinding modItem) ->
       catchMimsaError
         prj
-        ( doAddBinding prj modItem input $> prj
+        ( doAddBinding prj modItem $> prj
         )
 
 ----------

--- a/compiler/repl/ReplNew/Actions/Bindings.hs
+++ b/compiler/repl/ReplNew/Actions/Bindings.hs
@@ -24,7 +24,8 @@ doAddBinding ::
 doAddBinding project modItem = do
   oldModule <- getStoredModule
   -- add the new binding
-  (_prj, newModule) <- toReplM project (Actions.addBindingToModule mempty oldModule modItem)
+  (_prj, (newModule, testResults)) <- toReplM project (Actions.addBindingToModule mempty oldModule modItem)
+
   -- store the new module in Repl state
   setStoredModule newModule
 

--- a/compiler/repl/ReplNew/Actions/Bindings.hs
+++ b/compiler/repl/ReplNew/Actions/Bindings.hs
@@ -20,12 +20,11 @@ import ReplNew.ReplM
 doAddBinding ::
   Project Annotation ->
   ModuleItem Annotation ->
-  Text ->
   ReplM (Error Annotation) ()
-doAddBinding project modItem input = do
+doAddBinding project modItem = do
   oldModule <- getStoredModule
   -- add the new binding
-  (_prj, newModule) <- toReplM project (Actions.addBindingToModule oldModule modItem input)
+  (_prj, newModule) <- toReplM project (Actions.addBindingToModule mempty oldModule modItem)
   -- store the new module in Repl state
   setStoredModule newModule
 

--- a/compiler/repl/ReplNew/Actions/Bindings.hs
+++ b/compiler/repl/ReplNew/Actions/Bindings.hs
@@ -7,7 +7,7 @@ module ReplNew.Actions.Bindings
 where
 
 import Data.Text (Text)
-import qualified Language.Mimsa.Actions.BindModule as Actions
+import qualified Language.Mimsa.Actions.Modules.Bind as Actions
 import Language.Mimsa.Modules.Pretty
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
@@ -25,6 +25,9 @@ doAddBinding project modItem = do
   oldModule <- getStoredModule
   -- add the new binding
   (_prj, (newModule, testResults)) <- toReplM project (Actions.addBindingToModule mempty oldModule modItem)
+
+  -- show test results
+  replOutput testResults
 
   -- store the new module in Repl state
   setStoredModule newModule

--- a/compiler/repl/ReplNew/Actions/Evaluate.hs
+++ b/compiler/repl/ReplNew/Actions/Evaluate.hs
@@ -3,7 +3,6 @@ module ReplNew.Actions.Evaluate
   )
 where
 
-import Data.Text (Text)
 import qualified Language.Mimsa.Actions.Evaluate as Actions
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
@@ -15,13 +14,12 @@ import ReplNew.ReplM
 
 doEvaluate ::
   Project Annotation ->
-  Text ->
   Expr Name Annotation ->
   ReplM (Error Annotation) ()
-doEvaluate project input expr = do
+doEvaluate project expr = do
   oldModule <- fmap getAnnotationForType <$> getStoredModule
 
-  _ <- toReplM project (Actions.evaluateModule input expr oldModule)
+  _ <- toReplM project (Actions.evaluateModule expr oldModule)
   pure ()
 
 ---------

--- a/compiler/repl/ReplNew/Actions/Evaluate.hs
+++ b/compiler/repl/ReplNew/Actions/Evaluate.hs
@@ -1,14 +1,18 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module ReplNew.Actions.Evaluate
   ( doEvaluate,
   )
 where
 
-import qualified Language.Mimsa.Actions.Evaluate as Actions
+import qualified Language.Mimsa.Actions.Modules.Evaluate as Actions
+import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Typechecker
+import Prettyprinter
 import ReplNew.Helpers
 import ReplNew.ReplM
 
@@ -19,7 +23,20 @@ doEvaluate ::
 doEvaluate project expr = do
   oldModule <- fmap getAnnotationForType <$> getStoredModule
 
-  _ <- toReplM project (Actions.evaluateModule expr oldModule)
+  (_prj, (exprType, evaluatedExpression, _)) <-
+    toReplM project (Actions.evaluateModule expr oldModule)
+
+  -- print
+  replDocOutput
+    ( group
+        ( prettyDoc evaluatedExpression
+            <> line
+            <> "::"
+            <> line
+            <> prettyDoc exprType
+        )
+    )
+
   pure ()
 
 ---------

--- a/compiler/repl/ReplNew/Actions/ListModules.hs
+++ b/compiler/repl/ReplNew/Actions/ListModules.hs
@@ -9,8 +9,8 @@ where
 import Data.Foldable (traverse_)
 import qualified Data.Map as M
 import Data.Text (Text)
-import qualified Language.Mimsa.Actions.BindModule as Actions
 import qualified Language.Mimsa.Actions.Helpers.LookupExpression as Actions
+import qualified Language.Mimsa.Actions.Modules.Typecheck as Actions
 import Language.Mimsa.Modules.Pretty
 import Language.Mimsa.Printer
 import Language.Mimsa.Project

--- a/compiler/repl/ReplNew/Main.hs
+++ b/compiler/repl/ReplNew/Main.hs
@@ -79,6 +79,6 @@ parseCommand env input =
       outputErrorAsDiagnostic (ParseError input errBundle)
       pure env
     Right replAction -> do
-      newExprs <- doReplAction env input replAction
+      newExprs <- doReplAction env replAction
       _ <- mapError StoreErr (saveProject newExprs)
       pure newExprs

--- a/compiler/server/Server/Endpoints/Module.hs
+++ b/compiler/server/Server/Endpoints/Module.hs
@@ -14,7 +14,7 @@ where
 import qualified Data.Aeson as JSON
 import Data.OpenApi hiding (Server)
 import GHC.Generics
-import qualified Language.Mimsa.Actions.BindModule as Actions
+import qualified Language.Mimsa.Actions.Modules.Typecheck as Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.Modules
 import Servant

--- a/compiler/server/Server/Endpoints/Project/AddUnitTest.hs
+++ b/compiler/server/Server/Endpoints/Project/AddUnitTest.hs
@@ -16,8 +16,8 @@ import Data.Text (Text)
 import GHC.Generics
 import qualified Language.Mimsa.Actions.AddUnitTest as Actions
 import qualified Language.Mimsa.Actions.Helpers.Parse as Actions
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.Project
+import Language.Mimsa.Types.Tests
 import Servant
 import Server.Handlers
 import Server.Helpers.TestData

--- a/compiler/server/Server/Endpoints/Project/Evaluate.hs
+++ b/compiler/server/Server/Endpoints/Project/Evaluate.hs
@@ -21,6 +21,7 @@ import qualified Language.Mimsa.Actions.Evaluate as Actions
 import qualified Language.Mimsa.Actions.Graph as Actions
 import qualified Language.Mimsa.Actions.Helpers.CheckStoreExpression as Actions
 import qualified Language.Mimsa.Actions.Helpers.Parse as Actions
+import qualified Language.Mimsa.Actions.Modules.Evaluate as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Transform.Warnings

--- a/compiler/server/Server/Endpoints/Project/Evaluate.hs
+++ b/compiler/server/Server/Endpoints/Project/Evaluate.hs
@@ -114,7 +114,7 @@ evaluateModuleExpression mimsaEnv (EvaluateModuleRequest input hash) =
     let action = do
           expr <- Actions.parseExpr input
           (mt, exprResult, _newModule) <-
-            Actions.evaluateModule input expr mempty
+            Actions.evaluateModule expr mempty
           let se = StoreExpression exprResult mempty mempty mempty
           pure $
             EvaluateModuleResponse

--- a/compiler/server/Server/Handlers.hs
+++ b/compiler/server/Server/Handlers.hs
@@ -50,13 +50,13 @@ import Language.Mimsa.Project.Versions
 import Language.Mimsa.Store
 import Language.Mimsa.Store.Persistence
 import Language.Mimsa.Tests.Test
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.Tests
 import Servant
 import Server.Helpers
 import Server.Persistence

--- a/compiler/server/Server/Helpers/TestData.hs
+++ b/compiler/server/Server/Helpers/TestData.hs
@@ -10,6 +10,7 @@ module Server.Helpers.TestData
     TestData (..),
     makeTestData,
     mkUnitTestData,
+    makeTestDataFromModule,
   )
 where
 
@@ -17,6 +18,7 @@ import qualified Data.Aeson as JSON
 import Data.Coerce
 import Data.Either
 import Data.Map (Map)
+import qualified Data.Map as M
 import Data.OpenApi hiding (get)
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -40,7 +42,7 @@ data TestData = TestData
 data UnitTestData = UnitTestData
   { utdTestName :: Text,
     utdTestSuccess :: Bool,
-    utdBindings :: Map Name Text
+    utdBindings :: Map Name Text -- bin this off once we're doing modules
   }
   deriving stock (Eq, Ord, Show, Generic)
   deriving anyclass (JSON.ToJSON, ToSchema)
@@ -62,7 +64,7 @@ mkUnitTestData project unitTest = do
 data PropertyTestData = PropertyTestData
   { ptdTestName :: Text,
     ptdTestFailures :: [Text],
-    ptdBindings :: Map Name Text
+    ptdBindings :: Map Name Text -- bin this off once we're doing modules
   }
   deriving stock (Eq, Ord, Show, Generic)
   deriving anyclass (JSON.ToJSON, ToSchema)
@@ -124,3 +126,10 @@ makeTestData project testResults =
       propertyTests =
         uncurry (mkPropertyTestData project) <$> pts
    in TestData unitTests propertyTests
+
+makeTestDataFromModule :: ModuleTestResults -> TestData
+makeTestDataFromModule (ModuleTestResults results) =
+  let makeUnitTest (TestName testName, result) = case result of
+        ModuleTestPassed -> UnitTestData testName True mempty
+        ModuleTestFailed -> UnitTestData testName False mempty
+   in TestData (makeUnitTest <$> M.toList results) mempty

--- a/compiler/server/Server/Helpers/TestData.hs
+++ b/compiler/server/Server/Helpers/TestData.hs
@@ -24,11 +24,11 @@ import GHC.Generics
 import Language.Mimsa.Printer
 import Language.Mimsa.Project
 import Language.Mimsa.Tests.Test
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.Tests
 
 data TestData = TestData
   { tdUnitTests :: [UnitTestData],

--- a/compiler/src/Language/Mimsa/Actions/AddUnitTest.hs
+++ b/compiler/src/Language/Mimsa/Actions/AddUnitTest.hs
@@ -6,10 +6,10 @@ import qualified Language.Mimsa.Actions.Monad as Actions
 import qualified Language.Mimsa.Actions.Typecheck as Actions
 import Language.Mimsa.Project.Helpers
 import Language.Mimsa.Tests.Test
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.ResolvedExpression
+import Language.Mimsa.Types.Tests
 
 -- add a new unit test
 

--- a/compiler/src/Language/Mimsa/Actions/BindModule.hs
+++ b/compiler/src/Language/Mimsa/Actions/BindModule.hs
@@ -37,7 +37,6 @@ typecheckModules input inputModule = do
 
   liftEither $
     runCheck
-      input
       modules
       (typecheckAllModules inputModule)
 
@@ -89,7 +88,7 @@ addModuleItemToModule ::
   ModuleItem ann ->
   Actions.ActionM (Module ann)
 addModuleItemToModule input mod' modPart =
-  liftEither $ runCheck input mempty (addModulePart modPart mod')
+  liftEither $ runCheck mempty (addModulePart modPart mod')
 
 addBindingToModule ::
   Module MonoType ->

--- a/compiler/src/Language/Mimsa/Actions/Evaluate.hs
+++ b/compiler/src/Language/Mimsa/Actions/Evaluate.hs
@@ -1,9 +1,7 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Language.Mimsa.Actions.Evaluate
   ( evaluate,
-    evaluateModule,
   )
 where
 
@@ -11,31 +9,19 @@ import Control.Monad.Except
 import Data.Bifunctor
 import Data.Foldable (traverse_)
 import qualified Data.Map as M
-import Data.Maybe (fromJust)
-import Data.Set (Set)
-import qualified Data.Set as S
 import Data.Text (Text)
--- import qualified Language.Mimsa.Actions.BindModule as Actions
 import qualified Language.Mimsa.Actions.Helpers.CheckStoreExpression as Actions
 import qualified Language.Mimsa.Actions.Helpers.GetDepsForStoreExpression as Actions
 import qualified Language.Mimsa.Actions.Interpret as Actions
-import qualified Language.Mimsa.Actions.Modules.Typecheck as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import qualified Language.Mimsa.Actions.Optimise as Actions
 import qualified Language.Mimsa.Actions.Typecheck as Actions
-import Language.Mimsa.Modules.Check
-import Language.Mimsa.Modules.Compile
-import Language.Mimsa.Modules.HashModule
-import Language.Mimsa.Modules.Uses
 import Language.Mimsa.Printer
-import Language.Mimsa.Project.Helpers
 import Language.Mimsa.Store
 import Language.Mimsa.Transform.Warnings
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
-import Language.Mimsa.Types.Modules
-import Language.Mimsa.Types.Modules.Entity
 import Language.Mimsa.Types.ResolvedExpression
 import Language.Mimsa.Types.Store
 import Language.Mimsa.Types.Typechecker
@@ -100,102 +86,3 @@ evaluate input expr = do
   pure (mt, interpretedExpr, newStoreExpr, typedNameExpr, input')
 
 ---------
-
--- we need to bind our new expression to _something_
--- so we make a `Name` which is strictly broken, but it means
--- we won't have name collisions with a real expression
-evalId :: DefIdentifier
-evalId = DIName (Name "_repl")
-
--- given deps that this expression requires, attempt to resolve these into
--- imports we'll need from the Project environment
-importsFromEntities :: Set Entity -> Actions.ActionM (Module Annotation)
-importsFromEntities uses = do
-  prj <- Actions.getProject
-  let fromEntity = \case
-        ENamespacedName modName _ ->
-          case lookupModuleName prj modName of
-            Right modHash -> pure $ mempty {moNamedImports = M.singleton modName modHash}
-            Left found -> throwError (ProjectErr (CannotFindModuleByName modName found))
-        ENamespacedType modName _ ->
-          case lookupModuleName prj modName of
-            Right modHash -> pure $ mempty {moNamedImports = M.singleton modName modHash}
-            Left found -> throwError (ProjectErr (CannotFindModuleByName modName found))
-        ENamespacedConstructor modName _ ->
-          case lookupModuleName prj modName of
-            Right modHash -> pure $ mempty {moNamedImports = M.singleton modName modHash}
-            Left found -> throwError (ProjectErr (CannotFindModuleByName modName found))
-        _ -> pure mempty
-  -- check them all, combine them
-  mconcat <$> traverse fromEntity (S.toList uses)
-
--- when we evaluate an expression, really we are adding it to an open module
--- then evaluating the expression in the context of that module
--- this means we can bind successive values
--- we should probably stop users adding the same type/value twice so we don't
--- have to deal with all the confusion
---
--- 1. work out what stuff the expression uses
--- 2. turns those into a module (ie, implied imports, new defs etc)
--- 3. combine that with the local module
--- 4. typecheck it
--- 5. get the expression type from the module type
--- 6. compile into store expressions
--- 6. interpret store expressions as normal
-evaluateModule ::
-  Expr Name Annotation ->
-  Module Annotation ->
-  Actions.ActionM (MonoType, Expr Name Annotation, Module Annotation)
-evaluateModule expr localModule = do
-  -- work out implied imports
-  moduleImports <- importsFromEntities (extractUses expr)
-
-  -- make a module for it, adding our expression as _repl
-  let newModule =
-        localModule
-          <> mempty
-            { moExpressions =
-                M.singleton evalId expr,
-              moExpressionExports = S.singleton evalId
-            }
-          <> moduleImports
-
-  typecheckedModules <- Actions.typecheckModules (prettyPrint newModule) newModule
-
-  let (_, rootModuleHash) = serializeModule newModule
-
-  -- pull root module out from pile of typechecked modules
-  typecheckedModule <- case M.lookup rootModuleHash typecheckedModules of
-    Just tcMod -> pure tcMod
-    _ -> throwError (ModuleErr $ MissingModule rootModuleHash)
-
-  -- compile to store expressions
-  compiled <- compile typecheckedModules typecheckedModule
-
-  -- find the root StoreExpression by name
-  rootStoreExpr <- case M.lookup evalId (cmExprs compiled) >>= flip M.lookup (getStore $ cmStore compiled) of
-    Just se -> pure se
-    _ -> error "fuck, could not find the thing we just made"
-
-  -- unsafe, yolo
-  let exprType = fromJust (lookupModuleDefType typecheckedModule evalId)
-
-  -- need to get our new store items into the project so this works I reckon
-  traverse_ Actions.appendStoreExpression (getStore $ cmStore compiled)
-
-  -- interpret
-  evaluatedExpression <-
-    Actions.interpreter rootStoreExpr
-
-  -- print
-  Actions.appendDocMessage
-    ( group
-        ( prettyDoc evaluatedExpression
-            <> line
-            <> "::"
-            <> line
-            <> prettyDoc exprType
-        )
-    )
-
-  pure (exprType, evaluatedExpression, newModule)

--- a/compiler/src/Language/Mimsa/Actions/Evaluate.hs
+++ b/compiler/src/Language/Mimsa/Actions/Evaluate.hs
@@ -36,7 +36,6 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Modules
-import Language.Mimsa.Types.Modules.DefIdentifier
 import Language.Mimsa.Types.Modules.Entity
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.ResolvedExpression

--- a/compiler/src/Language/Mimsa/Actions/Evaluate.hs
+++ b/compiler/src/Language/Mimsa/Actions/Evaluate.hs
@@ -15,10 +15,11 @@ import Data.Maybe (fromJust)
 import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)
-import qualified Language.Mimsa.Actions.BindModule as Actions
+-- import qualified Language.Mimsa.Actions.BindModule as Actions
 import qualified Language.Mimsa.Actions.Helpers.CheckStoreExpression as Actions
 import qualified Language.Mimsa.Actions.Helpers.GetDepsForStoreExpression as Actions
 import qualified Language.Mimsa.Actions.Interpret as Actions
+import qualified Language.Mimsa.Actions.Modules.Typecheck as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import qualified Language.Mimsa.Actions.Optimise as Actions
 import qualified Language.Mimsa.Actions.Typecheck as Actions

--- a/compiler/src/Language/Mimsa/Actions/Evaluate.hs
+++ b/compiler/src/Language/Mimsa/Actions/Evaluate.hs
@@ -212,4 +212,4 @@ compileModule ::
 compileModule typecheckedModules input inputModule = do
   modules <- prjModuleStore <$> Actions.getProject
 
-  liftEither $ runCheck input modules (compile typecheckedModules inputModule)
+  liftEither $ runCheck modules (compile typecheckedModules inputModule)

--- a/compiler/src/Language/Mimsa/Actions/Helpers/Parse.hs
+++ b/compiler/src/Language/Mimsa/Actions/Helpers/Parse.hs
@@ -24,4 +24,4 @@ parseDataType input =
 
 parseModule :: Text -> ActionM (Module Annotation)
 parseModule =
-  liftEither . Module.parseModule
+  Module.parseModule mempty

--- a/compiler/src/Language/Mimsa/Actions/Modules/Bind.hs
+++ b/compiler/src/Language/Mimsa/Actions/Modules/Bind.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Language.Mimsa.Actions.BindModule
+module Language.Mimsa.Actions.Modules.Bind
   ( bindModule,
     addBindingToModule,
   )
 where
 
-import Control.Monad.Except
 import Data.Map (Map)
-import qualified Data.Map as M
 import Data.Text (Text)
 import qualified Language.Mimsa.Actions.Modules.RunTests as Actions
 import qualified Language.Mimsa.Actions.Modules.Typecheck as Actions
@@ -16,15 +14,10 @@ import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Modules.Check
 import Language.Mimsa.Modules.FromParts
 import Language.Mimsa.Modules.HashModule
-import Language.Mimsa.Modules.Typecheck
 import Language.Mimsa.Printer
 import Language.Mimsa.Project.Helpers
 import Language.Mimsa.Types.AST
-import Language.Mimsa.Types.Error
-import Language.Mimsa.Types.Modules.Module
-import Language.Mimsa.Types.Modules.ModuleHash
-import Language.Mimsa.Types.Modules.ModuleName
-import Language.Mimsa.Types.Project
+import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Tests
 import Language.Mimsa.Types.Typechecker
 

--- a/compiler/src/Language/Mimsa/Actions/Modules/Check.hs
+++ b/compiler/src/Language/Mimsa/Actions/Modules/Check.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Language.Mimsa.Actions.Modules.Check (checkModule) where
+
+import Data.Map (Map)
+import qualified Data.Map as M
+import qualified Data.Set as S
+import Data.Text (Text)
+import qualified Language.Mimsa.Actions.Monad as Actions
+import Language.Mimsa.Modules.HashModule
+import Language.Mimsa.Modules.Monad
+import Language.Mimsa.Modules.Parse
+import Language.Mimsa.Modules.Typecheck
+import Language.Mimsa.Typechecker.Elaborate
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Modules
+import Language.Mimsa.Types.Typechecker
+import Language.Mimsa.Utils
+
+-- | This is where we load a file and check that it is "OK" as such
+--  so far this entails:
+--  1. parsing it
+--  2. ordering things
+--  3. typechecking everything
+--
+--  so far the features in modules are
+--  1. definitions of values
+--  2. types of values
+--  3. definitions of datatypes
+--  4. exports
+--  5. imports
+--  6. infix
+--
+--  soon there will also need to be
+--  1. tests
+--  2. property tests
+--  3. metadata / comments etc?
+checkModule ::
+  Map ModuleHash (Module Annotation) ->
+  Text ->
+  Actions.ActionM (Module (Type Annotation), MonoType)
+checkModule modules input = do
+  properMod <- parseModule modules input
+
+  -- typecheck this module
+  tcMods <- typecheckAllModules modules input properMod
+
+  let (_, rootModuleHash) = serializeModule properMod
+
+  tcMod <- lookupModule tcMods rootModuleHash
+  pure (tcMod, getModuleType tcMod)
+
+-- return type of module as a MTRecord of dep -> monotype
+-- TODO: module should probably be it's own MTModule or something
+-- as we'll want to pass them about at some point I think
+getModuleType :: Module (Type Annotation) -> Type Annotation
+getModuleType mod' =
+  let defs =
+        M.filterWithKey
+          (\k _ -> S.member k (moExpressionExports mod'))
+          (moExpressions mod')
+   in MTRecord mempty (getTypeFromAnn <$> filterNameDefs defs)
+
+filterNameDefs :: Map DefIdentifier a -> Map Name a
+filterNameDefs =
+  filterMapKeys
+    ( \case
+        DIName name -> Just name
+        _ -> Nothing
+    )

--- a/compiler/src/Language/Mimsa/Actions/Modules/Evaluate.hs
+++ b/compiler/src/Language/Mimsa/Actions/Modules/Evaluate.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Mimsa.Actions.Modules.Evaluate
+  ( evaluateModule,
+  )
+where
+
+import Control.Monad.Except
+import Data.Foldable (traverse_)
+import qualified Data.Map as M
+import Data.Maybe (fromJust)
+import Data.Set (Set)
+import qualified Data.Set as S
+import qualified Language.Mimsa.Actions.Interpret as Actions
+import qualified Language.Mimsa.Actions.Modules.Typecheck as Actions
+import qualified Language.Mimsa.Actions.Monad as Actions
+import Language.Mimsa.Modules.Check
+import Language.Mimsa.Modules.Compile
+import Language.Mimsa.Modules.HashModule
+import Language.Mimsa.Modules.Uses
+import Language.Mimsa.Printer
+import Language.Mimsa.Project.Helpers
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Error
+import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Modules
+import Language.Mimsa.Types.Modules.Entity
+import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.Typechecker
+
+-- we need to bind our new expression to _something_
+-- so we make a `Name` which is strictly broken, but it means
+-- we won't have name collisions with a real expression
+evalId :: DefIdentifier
+evalId = DIName (Name "_repl")
+
+-- given deps that this expression requires, attempt to resolve these into
+-- imports we'll need from the Project environment
+importsFromEntities :: Set Entity -> Actions.ActionM (Module Annotation)
+importsFromEntities uses = do
+  prj <- Actions.getProject
+  let fromEntity = \case
+        ENamespacedName modName _ ->
+          case lookupModuleName prj modName of
+            Right modHash -> pure $ mempty {moNamedImports = M.singleton modName modHash}
+            Left found -> throwError (ProjectErr (CannotFindModuleByName modName found))
+        ENamespacedType modName _ ->
+          case lookupModuleName prj modName of
+            Right modHash -> pure $ mempty {moNamedImports = M.singleton modName modHash}
+            Left found -> throwError (ProjectErr (CannotFindModuleByName modName found))
+        ENamespacedConstructor modName _ ->
+          case lookupModuleName prj modName of
+            Right modHash -> pure $ mempty {moNamedImports = M.singleton modName modHash}
+            Left found -> throwError (ProjectErr (CannotFindModuleByName modName found))
+        _ -> pure mempty
+  -- check them all, combine them
+  mconcat <$> traverse fromEntity (S.toList uses)
+
+-- when we evaluate an expression, really we are adding it to an open module
+-- then evaluating the expression in the context of that module
+-- this means we can bind successive values
+-- we should probably stop users adding the same type/value twice so we don't
+-- have to deal with all the confusion
+--
+-- 1. work out what stuff the expression uses
+-- 2. turns those into a module (ie, implied imports, new defs etc)
+-- 3. combine that with the local module
+-- 4. typecheck it
+-- 5. get the expression type from the module type
+-- 6. compile into store expressions
+-- 6. interpret store expressions as normal
+evaluateModule ::
+  Expr Name Annotation ->
+  Module Annotation ->
+  Actions.ActionM (MonoType, Expr Name Annotation, Module Annotation)
+evaluateModule expr localModule = do
+  -- work out implied imports
+  moduleImports <- importsFromEntities (extractUses expr)
+
+  -- make a module for it, adding our expression as _repl
+  let newModule =
+        localModule
+          <> mempty
+            { moExpressions =
+                M.singleton evalId expr,
+              moExpressionExports = S.singleton evalId
+            }
+          <> moduleImports
+
+  typecheckedModules <- Actions.typecheckModules (prettyPrint newModule) newModule
+
+  let (_, rootModuleHash) = serializeModule newModule
+
+  -- pull root module out from pile of typechecked modules
+  typecheckedModule <- case M.lookup rootModuleHash typecheckedModules of
+    Just tcMod -> pure tcMod
+    _ -> throwError (ModuleErr $ MissingModule rootModuleHash)
+
+  -- compile to store expressions
+  compiled <- compile typecheckedModules typecheckedModule
+
+  -- find the root StoreExpression by name
+  rootStoreExpr <- case M.lookup evalId (cmExprs compiled) >>= flip M.lookup (getStore $ cmStore compiled) of
+    Just se -> pure se
+    _ -> error "fuck, could not find the thing we just made"
+
+  -- unsafe, yolo
+  let exprType = fromJust (lookupModuleDefType typecheckedModule evalId)
+
+  -- need to get our new store items into the project so this works I reckon
+  traverse_ Actions.appendStoreExpression (getStore $ cmStore compiled)
+
+  -- interpret
+  evaluatedExpression <-
+    Actions.interpreter rootStoreExpr
+
+  pure (exprType, evaluatedExpression, newModule)

--- a/compiler/src/Language/Mimsa/Actions/Modules/RunTests.hs
+++ b/compiler/src/Language/Mimsa/Actions/Modules/RunTests.hs
@@ -32,10 +32,10 @@ filterTests =
 -- we specify it to make sure we only work with non-broken modules
 runModuleTests ::
   Module (Type Annotation) ->
-  Actions.ActionM (Map TestName ModuleTestResult)
+  Actions.ActionM ModuleTestResults
 runModuleTests mod' =
   let untypedModule = getAnnotationForType <$> mod'
-   in traverse (runUnitTest untypedModule) (filterTests (moExpressions mod'))
+   in ModuleTestResults <$> traverse (runUnitTest untypedModule) (filterTests (moExpressions mod'))
 
 -- check the type of the unit test expression `Boolean`
 -- explode if not

--- a/compiler/src/Language/Mimsa/Actions/Modules/RunTests.hs
+++ b/compiler/src/Language/Mimsa/Actions/Modules/RunTests.hs
@@ -5,7 +5,7 @@ module Language.Mimsa.Actions.Modules.RunTests (runModuleTests) where
 import Control.Monad.Except
 import Data.Bifunctor
 import Data.Map (Map)
-import qualified Language.Mimsa.Actions.Evaluate as Actions
+import qualified Language.Mimsa.Actions.Modules.Evaluate as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Tests.Helpers

--- a/compiler/src/Language/Mimsa/Actions/Modules/RunTests.hs
+++ b/compiler/src/Language/Mimsa/Actions/Modules/RunTests.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 
-module Language.Mimsa.Actions.RunModuleTests (runModuleTests) where
+module Language.Mimsa.Actions.Modules.RunTests (runModuleTests) where
 
 import Control.Monad.Except
 import Data.Bifunctor
@@ -50,7 +50,7 @@ runUnitTest :: Module Annotation -> Expr Name MonoType -> Actions.ActionM Module
 runUnitTest mod' testExpr = do
   _ <- unifiesWithBoolean testExpr
   let untypedExpr = getAnnotationForType <$> testExpr
-  (_, result, _) <- Actions.evaluateModule (prettyPrint untypedExpr) untypedExpr mod'
+  (_, result, _) <- Actions.evaluateModule untypedExpr mod'
   pure $
     if testIsSuccess result
       then ModuleTestPassed

--- a/compiler/src/Language/Mimsa/Actions/Modules/Typecheck.hs
+++ b/compiler/src/Language/Mimsa/Actions/Modules/Typecheck.hs
@@ -1,0 +1,45 @@
+module Language.Mimsa.Actions.Modules.Typecheck
+  ( typecheckModules,
+    typecheckModule,
+  )
+where
+
+import Control.Monad.Except
+import Data.Map (Map)
+import qualified Data.Map as M
+import Data.Text (Text)
+import qualified Language.Mimsa.Actions.Monad as Actions
+import Language.Mimsa.Modules.Check
+import Language.Mimsa.Modules.FromParts
+import Language.Mimsa.Modules.HashModule
+import Language.Mimsa.Modules.Typecheck
+import Language.Mimsa.Printer
+import Language.Mimsa.Project.Helpers
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Error
+import Language.Mimsa.Types.Modules.Module
+import Language.Mimsa.Types.Modules.ModuleHash
+import Language.Mimsa.Types.Modules.ModuleName
+import Language.Mimsa.Types.Project
+import Language.Mimsa.Types.Tests
+import Language.Mimsa.Types.Typechecker
+
+typecheckModules ::
+  Text ->
+  Module Annotation ->
+  Actions.ActionM (Map ModuleHash (Module MonoType))
+typecheckModules input inputModule = do
+  modules <- prjModuleStore <$> Actions.getProject
+
+  typecheckAllModules modules input inputModule
+
+typecheckModule :: Text -> Module Annotation -> Actions.ActionM (Module MonoType)
+typecheckModule input inputModule = do
+  -- typecheck it to make sure it's not silly
+  typecheckedModules <-
+    typecheckModules input inputModule
+
+  let (_, rootModuleHash) = serializeModule inputModule
+  case M.lookup rootModuleHash typecheckedModules of
+    Just tcMod -> pure tcMod
+    _ -> throwError (ModuleErr $ MissingModule rootModuleHash)

--- a/compiler/src/Language/Mimsa/Actions/Modules/Typecheck.hs
+++ b/compiler/src/Language/Mimsa/Actions/Modules/Typecheck.hs
@@ -9,19 +9,12 @@ import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Text (Text)
 import qualified Language.Mimsa.Actions.Monad as Actions
-import Language.Mimsa.Modules.Check
-import Language.Mimsa.Modules.FromParts
 import Language.Mimsa.Modules.HashModule
 import Language.Mimsa.Modules.Typecheck
-import Language.Mimsa.Printer
-import Language.Mimsa.Project.Helpers
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
-import Language.Mimsa.Types.Modules.Module
-import Language.Mimsa.Types.Modules.ModuleHash
-import Language.Mimsa.Types.Modules.ModuleName
+import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Project
-import Language.Mimsa.Types.Tests
 import Language.Mimsa.Types.Typechecker
 
 typecheckModules ::

--- a/compiler/src/Language/Mimsa/Actions/Monad.hs
+++ b/compiler/src/Language/Mimsa/Actions/Monad.hs
@@ -61,7 +61,7 @@ run ::
   Either (Error Annotation) (Project Annotation, [ActionOutcome], a)
 run project action =
   let (result, ActionState newProject _ outcomes) =
-        runState (runExceptT action) (emptyState project)
+        runState (runExceptT (runActionM action)) (emptyState project)
    in (,,) newProject outcomes <$> result
 
 getProject :: ActionM (Project Annotation)

--- a/compiler/src/Language/Mimsa/Actions/RunModuleTests.hs
+++ b/compiler/src/Language/Mimsa/Actions/RunModuleTests.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Language.Mimsa.Actions.RunModuleTests (runModuleTests) where
+
+import Control.Monad.Except
+import Data.Bifunctor
+import Data.Map (Map)
+import qualified Language.Mimsa.Actions.Evaluate as Actions
+import qualified Language.Mimsa.Actions.Monad as Actions
+import Language.Mimsa.Printer
+import Language.Mimsa.Tests.Helpers
+import Language.Mimsa.Tests.UnitTest
+import Language.Mimsa.Typechecker.Elaborate
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Error
+import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Modules
+import Language.Mimsa.Types.Tests
+import Language.Mimsa.Types.Typechecker
+import Language.Mimsa.Utils
+
+filterTests :: Map DefIdentifier (Expr Name ann) -> Map TestName (Expr Name ann)
+filterTests =
+  filterMapKeys
+    ( \case
+        (DITest tn) -> Just tn
+        _ -> Nothing
+    )
+
+-- | run unit tests
+-- although we do not take advantage of the typechecked module
+-- we specify it to make sure we only work with non-broken modules
+runModuleTests ::
+  Module (Type Annotation) ->
+  Actions.ActionM (Map TestName ModuleTestResult)
+runModuleTests mod' =
+  let untypedModule = getAnnotationForType <$> mod'
+   in traverse (runUnitTest untypedModule) (filterTests (moExpressions mod'))
+
+-- check the type of the unit test expression `Boolean`
+-- explode if not
+unifiesWithBoolean :: Expr Name MonoType -> Actions.ActionM ()
+unifiesWithBoolean testExpr =
+  void $
+    liftEither $
+      first (TypeErr (prettyPrint testExpr)) $
+        resultIsBoolean (getTypeFromAnn testExpr)
+
+runUnitTest :: Module Annotation -> Expr Name MonoType -> Actions.ActionM ModuleTestResult
+runUnitTest mod' testExpr = do
+  _ <- unifiesWithBoolean testExpr
+  let untypedExpr = getAnnotationForType <$> testExpr
+  (_, result, _) <- Actions.evaluateModule (prettyPrint untypedExpr) untypedExpr mod'
+  pure $
+    if testIsSuccess result
+      then ModuleTestPassed
+      else ModuleTestFailed

--- a/compiler/src/Language/Mimsa/Actions/Types.hs
+++ b/compiler/src/Language/Mimsa/Actions/Types.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Language.Mimsa.Actions.Types
-  ( ActionM,
+  ( ActionM (..),
     SavePath (..),
     SaveContents (..),
     SaveFilename (..),
@@ -53,7 +53,17 @@ data ActionState = ActionState
   }
   deriving stock (Eq, Ord, Show)
 
-type ActionM =
-  ExceptT
-    (Error Annotation)
-    (State ActionState)
+newtype ActionM a = ActionM
+  { runActionM ::
+      ExceptT
+        (Error Annotation)
+        (State ActionState)
+        a
+  }
+  deriving newtype
+    ( Functor,
+      Applicative,
+      Monad,
+      MonadError (Error Annotation),
+      MonadState ActionState
+    )

--- a/compiler/src/Language/Mimsa/Modules/Check.hs
+++ b/compiler/src/Language/Mimsa/Modules/Check.hs
@@ -2,70 +2,14 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 
-module Language.Mimsa.Modules.Check (checkModule, getModuleItemIdentifier, lookupModuleDefType) where
+module Language.Mimsa.Modules.Check (getModuleItemIdentifier, lookupModuleDefType) where
 
-import Data.Map (Map)
 import qualified Data.Map as M
 import qualified Data.Set as S
-import Data.Text (Text)
-import Language.Mimsa.Modules.HashModule
-import Language.Mimsa.Modules.Monad
-import Language.Mimsa.Modules.Parse
-import Language.Mimsa.Modules.Typecheck
 import Language.Mimsa.Typechecker.Elaborate
 import Language.Mimsa.Types.AST
-import Language.Mimsa.Types.Error
-import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Typechecker
-import Language.Mimsa.Utils
-
-checkModule ::
-  Text ->
-  Map ModuleHash (Module Annotation) ->
-  Either (Error Annotation) (Module (Type Annotation), MonoType)
-checkModule input modules = runCheck modules (checkModule' input)
-
--- | This is where we load a file and check that it is "OK" as such
---  so far this entails:
---  1. parsing it
---  2. ordering things
---  3. typechecking everything
---
---  so far the features in modules are
---  1. definitions of values
---  2. types of values
---  3. definitions of datatypes
---  4. exports
---  5. imports
---  6. infix
---
---  soon there will also need to be
---  1. tests
---  2. property tests
---  3. metadata / comments etc?
-checkModule' :: Text -> CheckM (Module (Type Annotation), MonoType)
-checkModule' input = do
-  properMod <- parseModule' input
-
-  -- typecheck this module
-  tcMods <- typecheckAllModules properMod
-
-  let (_, rootModuleHash) = serializeModule properMod
-
-  tcMod <- lookupModule tcMods rootModuleHash
-  pure (tcMod, getModuleType tcMod)
-
--- return type of module as a MTRecord of dep -> monotype
--- TODO: module should probably be it's own MTModule or something
--- as we'll want to pass them about at some point I think
-getModuleType :: Module (Type Annotation) -> Type Annotation
-getModuleType mod' =
-  let defs =
-        M.filterWithKey
-          (\k _ -> S.member k (moExpressionExports mod'))
-          (moExpressions mod')
-   in MTRecord mempty (getTypeFromAnn <$> filterNameDefs defs)
 
 lookupModuleDefType :: Module (Type Annotation) -> DefIdentifier -> Maybe (Type Annotation)
 lookupModuleDefType mod' defId =
@@ -74,14 +18,6 @@ lookupModuleDefType mod' defId =
           (\k _ -> S.member k (moExpressionExports mod'))
           (moExpressions mod')
    in getTypeFromAnn <$> M.lookup defId defs
-
-filterNameDefs :: Map DefIdentifier a -> Map Name a
-filterNameDefs =
-  filterMapKeys
-    ( \case
-        DIName name -> Just name
-        _ -> Nothing
-    )
 
 -- used in logging etc, "what is this thing"
 getModuleItemIdentifier :: ModuleItem ann -> Maybe DefIdentifier

--- a/compiler/src/Language/Mimsa/Modules/Check.hs
+++ b/compiler/src/Language/Mimsa/Modules/Check.hs
@@ -4,7 +4,6 @@
 
 module Language.Mimsa.Modules.Check (checkModule, getModuleItemIdentifier, lookupModuleDefType) where
 
-import Control.Monad.Except
 import Data.Map (Map)
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -25,7 +24,7 @@ checkModule ::
   Text ->
   Map ModuleHash (Module Annotation) ->
   Either (Error Annotation) (Module (Type Annotation), MonoType)
-checkModule input modules = runCheck input modules (checkModule' input)
+checkModule input modules = runCheck modules (checkModule' input)
 
 -- | This is where we load a file and check that it is "OK" as such
 --  so far this entails:
@@ -54,9 +53,8 @@ checkModule' input = do
 
   let (_, rootModuleHash) = serializeModule properMod
 
-  case M.lookup rootModuleHash tcMods of
-    Nothing -> throwError (ModuleErr $ MissingModule rootModuleHash)
-    Just tcMod -> pure (tcMod, getModuleType tcMod)
+  tcMod <- lookupModule tcMods rootModuleHash
+  pure (tcMod, getModuleType tcMod)
 
 -- return type of module as a MTRecord of dep -> monotype
 -- TODO: module should probably be it's own MTModule or something

--- a/compiler/src/Language/Mimsa/Modules/Check.hs
+++ b/compiler/src/Language/Mimsa/Modules/Check.hs
@@ -93,3 +93,4 @@ getModuleItemIdentifier (ModuleExpression name _ _) = Just (DIName name)
 getModuleItemIdentifier (ModuleDataType (DataType typeName _ _)) = Just (DIType typeName)
 getModuleItemIdentifier (ModuleExport a) = getModuleItemIdentifier a
 getModuleItemIdentifier (ModuleImport _) = Nothing
+getModuleItemIdentifier (ModuleTest _ _) = error "what module item identifier should a test have?"

--- a/compiler/src/Language/Mimsa/Modules/Check.hs
+++ b/compiler/src/Language/Mimsa/Modules/Check.hs
@@ -18,7 +18,6 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Modules
-import Language.Mimsa.Types.Modules.DefIdentifier
 import Language.Mimsa.Types.Typechecker
 import Language.Mimsa.Utils
 

--- a/compiler/src/Language/Mimsa/Modules/Compile.hs
+++ b/compiler/src/Language/Mimsa/Modules/Compile.hs
@@ -19,7 +19,6 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Modules
-import Language.Mimsa.Types.Modules.DefIdentifier
 import Language.Mimsa.Types.Modules.Entity
 import Language.Mimsa.Types.Store
 import Language.Mimsa.Types.Typechecker

--- a/compiler/src/Language/Mimsa/Modules/Dependencies.hs
+++ b/compiler/src/Language/Mimsa/Modules/Dependencies.hs
@@ -19,7 +19,6 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Modules
-import Language.Mimsa.Types.Modules.DefIdentifier
 import Language.Mimsa.Types.Modules.Entity
 import Language.Mimsa.Utils
 

--- a/compiler/src/Language/Mimsa/Modules/Dependencies.hs
+++ b/compiler/src/Language/Mimsa/Modules/Dependencies.hs
@@ -68,9 +68,9 @@ filterTypes =
 -- get the vars used by each def
 -- explode if there's not available
 getValueDependencies ::
-  (Eq ann, Monoid ann) =>
+  (Eq ann, Monoid ann, MonadError (Error Annotation) m) =>
   Module ann ->
-  CheckM
+  m
     ( Map
         DefIdentifier
         ( DepType ann,
@@ -92,16 +92,21 @@ getValueDependencies mod' = do
 
 -- get all dependencies of a type
 getTypeDependencies ::
+  (MonadError (Error Annotation) m) =>
   Module ann ->
   DataType ->
-  CheckM (DepType ann, Set DefIdentifier, Set Entity)
+  m (DepType ann, Set DefIdentifier, Set Entity)
 getTypeDependencies mod' dt = do
   let allUses = extractDataTypeUses dt
   typeDefIds <- getTypeUses mod' allUses
   exprDefIds <- getExprDeps mod' allUses
   pure (DTData dt, typeDefIds <> exprDefIds, allUses)
 
-getTypeUses :: Module ann -> Set Entity -> CheckM (Set DefIdentifier)
+getTypeUses ::
+  (MonadError (Error Annotation) m) =>
+  Module ann ->
+  Set Entity ->
+  m (Set DefIdentifier)
 getTypeUses mod' uses =
   let typeDeps = filterTypes uses
       unknownTypeDeps =
@@ -136,10 +141,10 @@ localsOnly =
     )
 
 getExprDependencies ::
-  (Eq ann, Monoid ann) =>
+  (Eq ann, Monoid ann, MonadError (Error Annotation) m) =>
   Module ann ->
   Expr Name ann ->
-  CheckM (DepType ann, Set DefIdentifier, Set Entity)
+  m (DepType ann, Set DefIdentifier, Set Entity)
 getExprDependencies mod' expr = do
   let allUses = extractUses expr
   exprDefIds <- getExprDeps mod' allUses
@@ -147,9 +152,10 @@ getExprDependencies mod' expr = do
   pure (DTExpr expr, exprDefIds <> typeDefIds, allUses)
 
 getExprDeps ::
+  (MonadError (Error Annotation) m) =>
   Module ann ->
   Set Entity ->
-  CheckM (Set DefIdentifier)
+  m (Set DefIdentifier)
 getExprDeps mod' uses =
   let nameDeps = filterDefs uses
       unknownNameDeps =

--- a/compiler/src/Language/Mimsa/Modules/Monad.hs
+++ b/compiler/src/Language/Mimsa/Modules/Monad.hs
@@ -6,7 +6,6 @@ module Language.Mimsa.Modules.Monad
   ( CheckM (..),
     CheckEnv (..),
     runCheck,
-    getStoredInput,
     lookupModule,
     lookupModuleDep,
     lookupModuleType,
@@ -35,8 +34,7 @@ import Language.Mimsa.Types.Typechecker
 
 -- this is where we keep all the modules we need to do things
 data CheckEnv ann = CheckEnv
-  { ceModules :: Map ModuleHash (Module ann),
-    ceInput :: Text
+  { ceModules :: Map ModuleHash (Module ann)
   }
 
 newtype CheckM a = CheckM
@@ -55,18 +53,14 @@ newtype CheckM a = CheckM
       MonadReader (CheckEnv Annotation)
     )
 
-runCheck :: Text -> Map ModuleHash (Module Annotation) -> CheckM a -> Either (Error Annotation) a
-runCheck input modules comp =
+runCheck :: Map ModuleHash (Module Annotation) -> CheckM a -> Either (Error Annotation) a
+runCheck modules comp =
   runReader (runExceptT (runCheckM comp)) initialEnv
   where
     initialEnv =
       CheckEnv
-        { ceModules = modules,
-          ceInput = input
+        { ceModules = modules
         }
-
-getStoredInput :: CheckM Text
-getStoredInput = asks ceInput
 
 lookupModule :: (MonadError (Error Annotation) m) => Map ModuleHash (Module ann) -> ModuleHash -> m (Module ann)
 lookupModule mods modHash = do

--- a/compiler/src/Language/Mimsa/Modules/Parse.hs
+++ b/compiler/src/Language/Mimsa/Modules/Parse.hs
@@ -1,25 +1,26 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 
-module Language.Mimsa.Modules.Parse (parseModule, parseModule') where
+module Language.Mimsa.Modules.Parse (parseModule) where
 
 import Control.Monad.Except
 import Data.Bifunctor
+import Data.Map (Map)
 import Data.Text (Text)
 import Language.Mimsa.Modules.FromParts
-import Language.Mimsa.Modules.Monad
 import qualified Language.Mimsa.Parser.Module as Parser
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Modules
 
-parseModule :: Text -> Either (Error Annotation) (Module Annotation)
-parseModule input = runCheck mempty (parseModule' input)
-
-parseModule' :: Text -> CheckM (Module Annotation)
-parseModule' input = do
+parseModule ::
+  (MonadError (Error Annotation) m) =>
+  Map ModuleHash (Module Annotation) ->
+  Text ->
+  m (Module Annotation)
+parseModule modules input = do
   moduleItems <-
     liftEither $
       first (ParseError input) (Parser.parseModule input)
   -- create module from parsed items
-  moduleFromModuleParts moduleItems
+  moduleFromModuleParts modules moduleItems

--- a/compiler/src/Language/Mimsa/Modules/Parse.hs
+++ b/compiler/src/Language/Mimsa/Modules/Parse.hs
@@ -14,7 +14,7 @@ import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Modules
 
 parseModule :: Text -> Either (Error Annotation) (Module Annotation)
-parseModule input = runCheck input mempty (parseModule' input)
+parseModule input = runCheck mempty (parseModule' input)
 
 parseModule' :: Text -> CheckM (Module Annotation)
 parseModule' input = do

--- a/compiler/src/Language/Mimsa/Parser/Literal.hs
+++ b/compiler/src/Language/Mimsa/Parser/Literal.hs
@@ -2,6 +2,7 @@
 
 module Language.Mimsa.Parser.Literal
   ( literalParser,
+    testNameParser,
     stringLiteral,
     trueParser,
     falseParser,
@@ -10,11 +11,13 @@ module Language.Mimsa.Parser.Literal
 where
 
 import Data.Functor (($>))
+import Data.Text (Text)
 import qualified Data.Text as T
 import Language.Mimsa.Parser.Helpers
 import Language.Mimsa.Parser.Lexeme
 import Language.Mimsa.Parser.Types
 import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Tests
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as L
@@ -53,10 +56,12 @@ falseParser = myString "False" $> MyBool False
 
 -----
 
+textLiteral :: Parser Text
+textLiteral = T.pack <$> (char '\"' *> manyTill L.charLiteral (char '\"'))
+
 stringLiteral :: Parser Literal
-stringLiteral = do
-  chr <- char '\"' *> manyTill L.charLiteral (char '\"')
-  pure (MyString $ StringType $ T.pack chr)
+stringLiteral =
+  MyString . StringType <$> textLiteral
 
 stringParser :: Parser ParserExpr
 stringParser =
@@ -65,3 +70,6 @@ stringParser =
         MyLiteral
         stringLiteral
     )
+
+testNameParser :: Parser TestName
+testNameParser = TestName <$> myLexeme textLiteral

--- a/compiler/src/Language/Mimsa/Parser/MonoType.hs
+++ b/compiler/src/Language/Mimsa/Parser/MonoType.hs
@@ -116,6 +116,7 @@ protectedTypeNames =
       "def",
       "type",
       "infix",
+      "test",
       "import",
       "export"
     ]

--- a/compiler/src/Language/Mimsa/Parser/Types.hs
+++ b/compiler/src/Language/Mimsa/Parser/Types.hs
@@ -39,7 +39,8 @@ protectedNames =
       "False",
       "def",
       "export",
-      "import"
+      "import",
+      "test"
     ]
 
 protectedOperators :: Set Text

--- a/compiler/src/Language/Mimsa/Project/Helpers.hs
+++ b/compiler/src/Language/Mimsa/Project/Helpers.hs
@@ -48,11 +48,11 @@ import qualified Data.Set as S
 import Language.Mimsa.Modules.HashModule
 import Language.Mimsa.Store.ExtractTypes
 import Language.Mimsa.Store.Storage
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.Tests
 
 ----------
 

--- a/compiler/src/Language/Mimsa/Project/Stdlib.hs
+++ b/compiler/src/Language/Mimsa/Project/Stdlib.hs
@@ -28,12 +28,12 @@ import Language.Mimsa.Modules.HashModule
 import Language.Mimsa.Modules.Prelude
 import Language.Mimsa.Parser
 import Language.Mimsa.Printer
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Project
+import Language.Mimsa.Types.Tests
 
 buildStdlib :: Either (Error Annotation) (Project Annotation)
 buildStdlib =

--- a/compiler/src/Language/Mimsa/Project/Stdlib.hs
+++ b/compiler/src/Language/Mimsa/Project/Stdlib.hs
@@ -19,9 +19,9 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Language.Mimsa.Actions.AddUnitTest as Actions
 import qualified Language.Mimsa.Actions.BindExpression as Actions
-import qualified Language.Mimsa.Actions.BindModule as Actions
 import qualified Language.Mimsa.Actions.BindType as Actions
 import qualified Language.Mimsa.Actions.Helpers.Parse as Actions
+import qualified Language.Mimsa.Actions.Modules.Bind as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import qualified Language.Mimsa.Actions.RemoveBinding as Actions
 import Language.Mimsa.Modules.HashModule

--- a/compiler/src/Language/Mimsa/Tests/PropertyTest.hs
+++ b/compiler/src/Language/Mimsa/Tests/PropertyTest.hs
@@ -19,13 +19,13 @@ import Language.Mimsa.Store
 import Language.Mimsa.Store.ResolveDataTypes
 import Language.Mimsa.Tests.Generate
 import Language.Mimsa.Tests.Helpers
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.ResolvedExpression
 import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.Tests
 import Language.Mimsa.Types.Typechecker
 
 -- | given a StoreExpression, check it is the correct type

--- a/compiler/src/Language/Mimsa/Tests/Test.hs
+++ b/compiler/src/Language/Mimsa/Tests/Test.hs
@@ -20,12 +20,12 @@ import qualified Data.Set as S
 import Language.Mimsa.Project.Helpers
 import Language.Mimsa.Store.UpdateDeps
 import Language.Mimsa.Tests.PropertyTest
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Tests.UnitTest
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.Tests
 
 {- we have multiple types of test, this module operates on all kinds
 -}

--- a/compiler/src/Language/Mimsa/Tests/UnitTest.hs
+++ b/compiler/src/Language/Mimsa/Tests/UnitTest.hs
@@ -2,6 +2,7 @@
 
 module Language.Mimsa.Tests.UnitTest
   ( createUnitTest,
+    resultIsBoolean,
   )
 where
 
@@ -17,6 +18,7 @@ import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.ResolvedExpression
 import Language.Mimsa.Types.Store
 import Language.Mimsa.Types.Tests
+import Language.Mimsa.Types.Typechecker
 
 -- | a unit test must have type Boolean
 createUnitTest ::
@@ -39,3 +41,9 @@ createUnitTest project storeExpr testName = do
         utSuccess = UnitTestSuccess (testIsSuccess result),
         utExprHash = getStoreExpressionHash storeExpr
       }
+
+resultIsBoolean :: MonoType -> Either TypeError ()
+resultIsBoolean mt = do
+  unifies
+    mt
+    (MTPrim mempty MTBool)

--- a/compiler/src/Language/Mimsa/Tests/UnitTest.hs
+++ b/compiler/src/Language/Mimsa/Tests/UnitTest.hs
@@ -11,12 +11,12 @@ import qualified Language.Mimsa.Actions.Typecheck as Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Store
 import Language.Mimsa.Tests.Helpers
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.ResolvedExpression
 import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.Tests
 
 -- | a unit test must have type Boolean
 createUnitTest ::

--- a/compiler/src/Language/Mimsa/Types/Error/ModuleError.hs
+++ b/compiler/src/Language/Mimsa/Types/Error/ModuleError.hs
@@ -7,6 +7,7 @@ import Data.Set (Set)
 import Data.Text (Text)
 import Error.Diagnose
 import Language.Mimsa.Printer
+import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error.TypeError
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Modules
@@ -26,6 +27,7 @@ data ModuleError
   | MissingModuleTypeDep TypeName ModuleHash
   | DefMissingReturnType DefIdentifier
   | DefMissingTypeAnnotation DefIdentifier Name
+  | EmptyTestName (Expr Name ())
   deriving stock (Eq, Ord, Show)
 
 instance Printer ModuleError where
@@ -55,6 +57,8 @@ instance Printer ModuleError where
     "Definition " <> prettyPrint defName <> " was expected to have a return type but it is missing"
   prettyPrint (DefMissingTypeAnnotation defName name) =
     "Argument " <> prettyPrint name <> " in " <> prettyPrint defName <> " was expected to have a type annotation but it does not."
+  prettyPrint (EmptyTestName expr) =
+    "Test name must be non-empty for expression " <> prettyPrint expr
 
 moduleErrorDiagnostic :: ModuleError -> Diagnostic Text
 moduleErrorDiagnostic (DefDoesNotTypeCheck input _ typeErr) = typeErrorDiagnostic input typeErr

--- a/compiler/src/Language/Mimsa/Types/Error/ModuleError.hs
+++ b/compiler/src/Language/Mimsa/Types/Error/ModuleError.hs
@@ -11,7 +11,6 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error.TypeError
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Modules
-import Language.Mimsa.Types.Modules.DefIdentifier
 
 data ModuleError
   = DuplicateDefinition DefIdentifier

--- a/compiler/src/Language/Mimsa/Types/Modules.hs
+++ b/compiler/src/Language/Mimsa/Types/Modules.hs
@@ -2,9 +2,11 @@ module Language.Mimsa.Types.Modules
   ( module Language.Mimsa.Types.Modules.Module,
     module Language.Mimsa.Types.Modules.ModuleName,
     module Language.Mimsa.Types.Modules.ModuleHash,
+    module Language.Mimsa.Types.Modules.DefIdentifier,
   )
 where
 
+import Language.Mimsa.Types.Modules.DefIdentifier
 import Language.Mimsa.Types.Modules.Module
 import Language.Mimsa.Types.Modules.ModuleHash
 import Language.Mimsa.Types.Modules.ModuleName

--- a/compiler/src/Language/Mimsa/Types/Modules/DefIdentifier.hs
+++ b/compiler/src/Language/Mimsa/Types/Modules/DefIdentifier.hs
@@ -12,9 +12,14 @@ import GHC.Generics
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST.InfixOp
 import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Tests
 
 -- | different kinds of top-level definitions
-data DefIdentifier = DIName Name | DIInfix InfixOp | DIType TypeName
+data DefIdentifier
+  = DIName Name
+  | DIInfix InfixOp
+  | DIType TypeName
+  | DITest TestName
   deriving stock (Eq, Ord, Show, Generic)
   deriving anyclass
     ( JSON.ToJSON,
@@ -27,3 +32,4 @@ instance Printer DefIdentifier where
   prettyPrint (DIName name) = prettyPrint name
   prettyPrint (DIInfix infixOp) = prettyPrint infixOp
   prettyPrint (DIType typeName) = prettyPrint typeName
+  prettyPrint (DITest testName) = prettyPrint testName

--- a/compiler/src/Language/Mimsa/Types/Modules/DefIdentifier.hs
+++ b/compiler/src/Language/Mimsa/Types/Modules/DefIdentifier.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Language.Mimsa.Types.Modules.DefIdentifier
   ( DefIdentifier (..),
@@ -32,4 +33,4 @@ instance Printer DefIdentifier where
   prettyPrint (DIName name) = prettyPrint name
   prettyPrint (DIInfix infixOp) = prettyPrint infixOp
   prettyPrint (DIType typeName) = prettyPrint typeName
-  prettyPrint (DITest testName) = prettyPrint testName
+  prettyPrint (DITest testName) = "\"" <> prettyPrint testName <> "\""

--- a/compiler/src/Language/Mimsa/Types/Modules/Module.hs
+++ b/compiler/src/Language/Mimsa/Types/Modules/Module.hs
@@ -153,7 +153,8 @@ printDefinition mod' def expr =
         DIInfix infixOp ->
           "infix" <+> prettyDoc infixOp <+> "=" <+> prettyDoc expr
         DIType _ -> error "printDefinition is printing type oh no"
-        DITest _ -> error "printDefinition is printing test oh no"
+        DITest testName ->
+          "test" <+> "\"" <> prettyDoc testName <> "\"" <+> "=" <+> prettyDoc expr
 
 instance Semigroup (Module ann) where
   (Module a b c d e f g) <> (Module a' b' c' d' e' f' g') =

--- a/compiler/src/Language/Mimsa/Types/Modules/Module.hs
+++ b/compiler/src/Language/Mimsa/Types/Modules/Module.hs
@@ -27,6 +27,7 @@ import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Modules.DefIdentifier
 import Language.Mimsa.Types.Modules.ModuleHash
 import Language.Mimsa.Types.Modules.ModuleName
+import Language.Mimsa.Types.Tests
 import Language.Mimsa.Types.Typechecker.MonoType
 import Prettyprinter
 
@@ -54,6 +55,7 @@ data ModuleItem ann
   | ModuleExport (ModuleItem ann)
   | ModuleImport Import
   | ModuleInfix InfixOp (Expr Name ann)
+  | ModuleTest TestName (Expr Name ann)
   deriving stock (Functor)
 
 -- going to want way more granularity here in future but _shrug_
@@ -150,7 +152,8 @@ printDefinition mod' def expr =
                 <> indentMulti 2 (prettyDoc other)
         DIInfix infixOp ->
           "infix" <+> prettyDoc infixOp <+> "=" <+> prettyDoc expr
-        DIType _ -> error "printing type oh no"
+        DIType _ -> error "printDefinition is printing type oh no"
+        DITest _ -> error "printDefinition is printing test oh no"
 
 instance Semigroup (Module ann) where
   (Module a b c d e f g) <> (Module a' b' c' d' e' f' g') =

--- a/compiler/src/Language/Mimsa/Types/Project/Project.hs
+++ b/compiler/src/Language/Mimsa/Types/Project/Project.hs
@@ -6,10 +6,10 @@ module Language.Mimsa.Types.Project.Project where
 
 import Data.Map (Map)
 import GHC.Generics (Generic)
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Project.Versioned
 import Language.Mimsa.Types.Store (ExprHash, Store)
+import Language.Mimsa.Types.Tests
 
 -- our environment contains whichever hash/expr pairs we have flapping about
 -- and a list of mappings of names to those pieces

--- a/compiler/src/Language/Mimsa/Types/Project/SaveProject.hs
+++ b/compiler/src/Language/Mimsa/Types/Project/SaveProject.hs
@@ -12,9 +12,9 @@ import Data.Aeson
 import qualified Data.Aeson as JSON
 import Data.Map (Map)
 import GHC.Generics (Generic)
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.Project.Versioned
 import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.Tests
 
 data SaveProject = SaveProject
   { projectVersion :: Int,

--- a/compiler/src/Language/Mimsa/Types/Tests.hs
+++ b/compiler/src/Language/Mimsa/Types/Tests.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Language.Mimsa.Tests.Types
+module Language.Mimsa.Types.Tests
   ( Test (..),
     UnitTest (..),
     TestName (..),

--- a/compiler/src/Language/Mimsa/Types/Tests.hs
+++ b/compiler/src/Language/Mimsa/Types/Tests.hs
@@ -13,6 +13,7 @@ module Language.Mimsa.Types.Tests
     PropertyTest (..),
     PropertyTestResult (..),
     TestResult (..),
+    ModuleTestResult (..),
   )
 where
 
@@ -117,3 +118,8 @@ instance Printer (TestResult ann) where
           PropertyTestFailures es ->
             "\nFailing inputs:\n" <> T.intercalate "\n" ((<>) " - " . prettyPrint <$> S.toList es)
      in tickOrCross <> " " <> prettyPrint pt <> failures
+
+data ModuleTestResult
+  = ModuleTestPassed
+  | ModuleTestFailed
+  deriving stock (Eq, Ord, Show)

--- a/compiler/static/modules/Prelude.mimsa
+++ b/compiler/static/modules/Prelude.mimsa
@@ -15,3 +15,26 @@ export def snd pair = let (_,b) = pair in b
 export def const a b = a
 
 export type Unit = Unit
+
+test "id does nothing" = id True == True
+
+test "fst and snd work as expected" =
+  let pair = (1,2);
+  let newPair = (fst pair, snd pair);
+  newPair == pair
+
+test "const True 1 equals True" = const True 1
+
+test "and True True equals True" =
+  and True True
+
+test "or False True equals True"
+  = or False True
+
+test "not False equals True"
+  = not False
+
+test "composing increment twice adds two"
+  = let increment a = a + 1;
+    let incrementTwice = compose increment increment;
+    incrementTwice 40 == 42

--- a/compiler/test/Spec.hs
+++ b/compiler/test/Spec.hs
@@ -23,6 +23,7 @@ import qualified Test.Interpreter.Repl as Repl
 import qualified Test.Modules.Check as ModuleCheck
 import qualified Test.Modules.Compile as ModuleCompile
 import qualified Test.Modules.Repl as ModuleRepl
+import qualified Test.Modules.Test as ModuleTest
 import qualified Test.Parser.MonoTypeParser as MonoTypeParser
 import qualified Test.Parser.Pattern as Pattern
 import qualified Test.Parser.Syntax as Syntax
@@ -116,3 +117,4 @@ main =
     RenderErrors.spec
     ModuleRepl.spec
     ModuleCompile.spec
+    ModuleTest.spec

--- a/compiler/test/Spec.hs
+++ b/compiler/test/Spec.hs
@@ -20,7 +20,7 @@ import qualified Test.Backend.Typescript as Typescript
 import qualified Test.Codegen as Codegen
 import Test.Hspec
 import qualified Test.Interpreter.Repl as Repl
-import qualified Test.Modules.CheckModule as CheckModule
+import qualified Test.Modules.Check as ModuleCheck
 import qualified Test.Modules.Compile as ModuleCompile
 import qualified Test.Modules.Repl as ModuleRepl
 import qualified Test.Parser.MonoTypeParser as MonoTypeParser
@@ -112,7 +112,7 @@ main =
     TypecheckAction.spec
     SimplifyPatterns.spec
     NumberVars.spec
-    CheckModule.spec
+    ModuleCheck.spec
     RenderErrors.spec
     ModuleRepl.spec
     ModuleCompile.spec

--- a/compiler/test/Test/Actions/AddUnitTest.hs
+++ b/compiler/test/Test/Actions/AddUnitTest.hs
@@ -15,10 +15,10 @@ import qualified Language.Mimsa.Actions.BindExpression as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Tests.Test
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.Tests
 import Test.Data.Project
 import Test.Hspec
 import Test.Utils.Helpers

--- a/compiler/test/Test/Actions/BindExpression.hs
+++ b/compiler/test/Test/Actions/BindExpression.hs
@@ -17,11 +17,11 @@ import qualified Language.Mimsa.Actions.Monad as Actions
 import qualified Language.Mimsa.Actions.RemoveBinding as Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Project.Helpers
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.Tests
 import Test.Data.Project
 import Test.Hspec
 import Test.Utils.Helpers

--- a/compiler/test/Test/Actions/BindModule.hs
+++ b/compiler/test/Test/Actions/BindModule.hs
@@ -8,7 +8,7 @@ where
 
 import Data.Either (isLeft, isRight)
 import qualified Data.Set as S
-import qualified Language.Mimsa.Actions.BindModule as Actions
+import qualified Language.Mimsa.Actions.Modules.Bind as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Project.Helpers

--- a/compiler/test/Test/Actions/BindModule.hs
+++ b/compiler/test/Test/Actions/BindModule.hs
@@ -41,7 +41,7 @@ spec = do
               (_hash, mod') <- Actions.bindModule prelude "Prelude" (prettyPrint prelude)
               let input = "def useId = fst (True, 1)"
                   modItem = unsafeParseModuleItem input
-              newModule <- Actions.addBindingToModule mempty mod' modItem
+              (newModule, _) <- Actions.addBindingToModule mempty mod' modItem
               Actions.bindModule (getAnnotationForType <$> newModule) "Repl" (prettyPrint newModule)
         let (newProject, _outcomes, _) = fromRight $ Actions.run testStdlib action
         newModules testStdlib newProject
@@ -53,10 +53,10 @@ spec = do
               (preludeHash', _mod') <- Actions.bindModule prelude "Prelude" (prettyPrint prelude)
               -- import Prelude
               let importExpr = unsafeParseModuleItem $ "import MyPrelude from " <> prettyPrint preludeHash'
-              mod2 <- Actions.addBindingToModule mempty mempty importExpr
+              (mod2, _) <- Actions.addBindingToModule mempty mempty importExpr
               -- use Prelude
               let expr = unsafeParseModuleItem "def useFst = MyPrelude.fst (1,2)"
-              mod3 <- Actions.addBindingToModule mempty mod2 expr
+              (mod3, _) <- Actions.addBindingToModule mempty mod2 expr
               -- store the updated thing
               Actions.bindModule (getAnnotationForType <$> mod3) "Repl" (prettyPrint mod3)
         let (newProject, _outcomes, _) = fromRight $ Actions.run testStdlib action

--- a/compiler/test/Test/Actions/BindModule.hs
+++ b/compiler/test/Test/Actions/BindModule.hs
@@ -33,7 +33,7 @@ spec = do
               (_hash, mod') <- Actions.bindModule prelude "Prelude" (prettyPrint prelude)
               let input = "def idTrue = fst True"
                   modItem = unsafeParseModuleItem input
-              Actions.addBindingToModule mod' modItem input
+              Actions.addBindingToModule mempty mod' modItem
         Actions.run testStdlib action `shouldSatisfy` isLeft
 
       it "Adds a new function to Prelude that is good typecheck" $ do
@@ -41,7 +41,7 @@ spec = do
               (_hash, mod') <- Actions.bindModule prelude "Prelude" (prettyPrint prelude)
               let input = "def useId = fst (True, 1)"
                   modItem = unsafeParseModuleItem input
-              newModule <- Actions.addBindingToModule mod' modItem input
+              newModule <- Actions.addBindingToModule mempty mod' modItem
               Actions.bindModule (getAnnotationForType <$> newModule) "Repl" (prettyPrint newModule)
         let (newProject, _outcomes, _) = fromRight $ Actions.run testStdlib action
         newModules testStdlib newProject
@@ -53,10 +53,10 @@ spec = do
               (preludeHash', _mod') <- Actions.bindModule prelude "Prelude" (prettyPrint prelude)
               -- import Prelude
               let importExpr = unsafeParseModuleItem $ "import MyPrelude from " <> prettyPrint preludeHash'
-              mod2 <- Actions.addBindingToModule mempty importExpr ""
+              mod2 <- Actions.addBindingToModule mempty mempty importExpr
               -- use Prelude
               let expr = unsafeParseModuleItem "def useFst = MyPrelude.fst (1,2)"
-              mod3 <- Actions.addBindingToModule mod2 expr ""
+              mod3 <- Actions.addBindingToModule mempty mod2 expr
               -- store the updated thing
               Actions.bindModule (getAnnotationForType <$> mod3) "Repl" (prettyPrint mod3)
         let (newProject, _outcomes, _) = fromRight $ Actions.run testStdlib action

--- a/compiler/test/Test/Actions/Evaluate.hs
+++ b/compiler/test/Test/Actions/Evaluate.hs
@@ -8,8 +8,9 @@ where
 
 import Data.Either (isLeft, isRight)
 import Data.Functor
-import qualified Language.Mimsa.Actions.BindModule as Actions
 import qualified Language.Mimsa.Actions.Evaluate as Actions
+import qualified Language.Mimsa.Actions.Modules.Bind as Actions
+import qualified Language.Mimsa.Actions.Modules.Evaluate as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST

--- a/compiler/test/Test/Actions/Evaluate.hs
+++ b/compiler/test/Test/Actions/Evaluate.hs
@@ -52,7 +52,7 @@ spec = do
         let action = do
               -- add a definition to an empty module
               let expr = unsafeParseModuleItem "def dog = True"
-              newMod <- Actions.addBindingToModule mempty expr ""
+              newMod <- Actions.addBindingToModule mempty mempty expr
               -- evaluate using that module
-              Actions.evaluateModule "dog" (unsafeParseExpr' "dog") (getAnnotationForType <$> newMod)
+              Actions.evaluateModule (unsafeParseExpr' "dog") (getAnnotationForType <$> newMod)
         Actions.run testStdlib action `shouldSatisfy` isRight

--- a/compiler/test/Test/Actions/Evaluate.hs
+++ b/compiler/test/Test/Actions/Evaluate.hs
@@ -52,7 +52,7 @@ spec = do
         let action = do
               -- add a definition to an empty module
               let expr = unsafeParseModuleItem "def dog = True"
-              newMod <- Actions.addBindingToModule mempty mempty expr
+              (newMod, _) <- Actions.addBindingToModule mempty mempty expr
               -- evaluate using that module
               Actions.evaluateModule (unsafeParseExpr' "dog") (getAnnotationForType <$> newMod)
         Actions.run testStdlib action `shouldSatisfy` isRight

--- a/compiler/test/Test/Actions/Upgrade.hs
+++ b/compiler/test/Test/Actions/Upgrade.hs
@@ -14,10 +14,10 @@ import qualified Language.Mimsa.Actions.BindExpression as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import qualified Language.Mimsa.Actions.Upgrade as Actions
 import Language.Mimsa.Printer
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
+import Language.Mimsa.Types.Tests
 import Test.Data.Project
 import Test.Hspec
 import Test.Utils.Helpers

--- a/compiler/test/Test/Modules/Check.hs
+++ b/compiler/test/Test/Modules/Check.hs
@@ -23,7 +23,6 @@ import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Modules
-import Language.Mimsa.Types.Modules.DefIdentifier
 import Language.Mimsa.Types.Typechecker
 import Test.Data.Prelude
 import Test.Hspec

--- a/compiler/test/Test/Modules/Check.hs
+++ b/compiler/test/Test/Modules/Check.hs
@@ -40,7 +40,7 @@ exprAndTypeFromParts' ::
   Expr Name ann ->
   Either (Error Annotation) (Expr Name ann)
 exprAndTypeFromParts' parts expr =
-  runCheck "" testModules (exprAndTypeFromParts (DIName "test") parts expr)
+  runCheck testModules (exprAndTypeFromParts (DIName "test") parts expr)
 
 testModules :: Map ModuleHash (Module Annotation)
 testModules = M.singleton preludeHash prelude

--- a/compiler/test/Test/Modules/Compile.hs
+++ b/compiler/test/Test/Modules/Compile.hs
@@ -9,7 +9,6 @@ import Data.Functor
 import qualified Data.Map as M
 import Language.Mimsa.Modules.Compile
 import Language.Mimsa.Modules.HashModule
-import Language.Mimsa.Modules.Monad
 import Language.Mimsa.Modules.Typecheck
 import Language.Mimsa.Printer
 import Language.Mimsa.Store
@@ -23,11 +22,11 @@ import Test.Utils.Helpers
 compile' :: Module Annotation -> CompiledModule Annotation
 compile' mod' =
   let action = do
-        tcMods <- typecheckAllModules mod'
+        tcMods <- typecheckAllModules mempty (prettyPrint mod') mod'
         case M.lookup (snd $ serializeModule mod') tcMods of
           Just tcMod -> compile tcMods tcMod
           Nothing -> error "Could not find the module we just typechecked"
-   in fromRight $ runCheck mempty action
+   in fromRight action
 
 spec :: Spec
 spec = do

--- a/compiler/test/Test/Modules/Compile.hs
+++ b/compiler/test/Test/Modules/Compile.hs
@@ -27,7 +27,7 @@ compile' mod' =
         case M.lookup (snd $ serializeModule mod') tcMods of
           Just tcMod -> compile tcMods tcMod
           Nothing -> error "Could not find the module we just typechecked"
-   in fromRight $ runCheck (prettyPrint mod') mempty action
+   in fromRight $ runCheck mempty action
 
 spec :: Spec
 spec = do

--- a/compiler/test/Test/Modules/Repl.hs
+++ b/compiler/test/Test/Modules/Repl.hs
@@ -38,7 +38,7 @@ eval input = do
   let action = do
         expr <- Actions.parseExpr input
         (mt, interpretedExpr, _) <-
-          Actions.evaluateModule input expr mempty
+          Actions.evaluateModule expr mempty
         pure (mt, interpretedExpr)
   case Actions.run stdlib action of
     Right (_, _, (mt, endExpr)) -> do

--- a/compiler/test/Test/Modules/Repl.hs
+++ b/compiler/test/Test/Modules/Repl.hs
@@ -13,8 +13,8 @@ import Data.Either (isLeft, isRight)
 import Data.Functor (($>))
 import Data.Text (Text)
 import qualified Data.Text as T
-import qualified Language.Mimsa.Actions.Evaluate as Actions
 import qualified Language.Mimsa.Actions.Helpers.Parse as Actions
+import qualified Language.Mimsa.Actions.Modules.Evaluate as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.ExprUtils
 import Language.Mimsa.Printer

--- a/compiler/test/Test/Modules/Test.hs
+++ b/compiler/test/Test/Modules/Test.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Modules.Test
+  ( spec,
+  )
+where
+
+import Data.Either (isLeft)
+import Data.Map (Map)
+import qualified Data.Map as M
+import Data.Maybe
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Language.Mimsa.Actions.Monad as Actions
+import qualified Language.Mimsa.Actions.RunModuleTests as Actions
+import Language.Mimsa.Modules.Check
+import Language.Mimsa.Printer
+import Language.Mimsa.Project.Helpers
+import Language.Mimsa.Project.Stdlib
+import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Error
+import Language.Mimsa.Types.Project
+import Language.Mimsa.Types.Tests
+import Test.Hspec
+
+joinLines :: [Text] -> Text
+joinLines = T.intercalate "\n"
+
+runTests :: Text -> Either (Error Annotation) (Map TestName ModuleTestResult)
+runTests t = do
+  (modA, _tyA) <- checkModule t (prjModuleStore stdlib)
+  let action = Actions.runModuleTests modA
+  (_, _, a) <- Actions.run stdlib action
+  pure a
+
+spec :: Spec
+spec = do
+  describe "Modules tests" $ do
+    it "Trivial passing unit test" $
+      runTests
+        (joinLines ["test \"2 equals 2\" = 2 == 2"])
+        `shouldBe` Right (M.singleton (TestName "2 equals 2") ModuleTestPassed)
+
+    it "Trivial failing unit test" $
+      runTests
+        (joinLines ["test \"2 equals 3\" = 2 == 3"])
+        `shouldBe` Right (M.singleton (TestName "2 equals 3") ModuleTestFailed)
+
+    it "A test that does not typecheck with Boolean fails" $
+      runTests
+        (joinLines ["test \"2 equals 2\" = 2"])
+        `shouldSatisfy` isLeft
+
+    it "Passing unit test using module functions" $
+      runTests
+        ( joinLines
+            [ "test \"identity 2 equals 2\" = id 2 == 2",
+              "def id a = a"
+            ]
+        )
+        `shouldBe` Right (M.singleton (TestName "identity 2 equals 2") ModuleTestPassed)
+
+    it "Runs a trivial test that refers to a Prelude expression" $ do
+      let preludeHash = fromJust (M.lookup "Prelude" (getCurrentModules $ prjModules stdlib))
+       in runTests
+            ( joinLines
+                [ "test \"Prelude.id 2 equals 2\" = Prelude.id 2 == 2",
+                  "import Prelude from " <> prettyPrint preludeHash
+                ]
+            )
+            `shouldBe` Right (M.singleton (TestName "Prelude.id 2 equals 2") ModuleTestPassed)

--- a/compiler/test/Test/Modules/Test.hs
+++ b/compiler/test/Test/Modules/Test.hs
@@ -11,9 +11,9 @@ import qualified Data.Map as M
 import Data.Maybe
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Language.Mimsa.Actions.Modules.Check as Actions
+import qualified Language.Mimsa.Actions.Modules.RunTests as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
-import qualified Language.Mimsa.Actions.RunModuleTests as Actions
-import Language.Mimsa.Modules.Check
 import Language.Mimsa.Printer
 import Language.Mimsa.Project.Helpers
 import Language.Mimsa.Project.Stdlib
@@ -28,8 +28,9 @@ joinLines = T.intercalate "\n"
 
 runTests :: Text -> Either (Error Annotation) (Map TestName ModuleTestResult)
 runTests t = do
-  (modA, _tyA) <- checkModule t (prjModuleStore stdlib)
-  let action = Actions.runModuleTests modA
+  let action = do
+        (modA, _tyA) <- Actions.checkModule (prjModuleStore stdlib) t
+        Actions.runModuleTests modA
   (_, _, a) <- Actions.run stdlib action
   pure a
 

--- a/compiler/test/Test/Modules/Test.hs
+++ b/compiler/test/Test/Modules/Test.hs
@@ -6,7 +6,6 @@ module Test.Modules.Test
 where
 
 import Data.Either (isLeft)
-import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Maybe
 import Data.Text (Text)
@@ -26,7 +25,7 @@ import Test.Hspec
 joinLines :: [Text] -> Text
 joinLines = T.intercalate "\n"
 
-runTests :: Text -> Either (Error Annotation) (Map TestName ModuleTestResult)
+runTests :: Text -> Either (Error Annotation) ModuleTestResults
 runTests t = do
   let action = do
         (modA, _tyA) <- Actions.checkModule (prjModuleStore stdlib) t
@@ -40,12 +39,12 @@ spec = do
     it "Trivial passing unit test" $
       runTests
         (joinLines ["test \"2 equals 2\" = 2 == 2"])
-        `shouldBe` Right (M.singleton (TestName "2 equals 2") ModuleTestPassed)
+        `shouldBe` Right (ModuleTestResults (M.singleton (TestName "2 equals 2") ModuleTestPassed))
 
     it "Trivial failing unit test" $
       runTests
         (joinLines ["test \"2 equals 3\" = 2 == 3"])
-        `shouldBe` Right (M.singleton (TestName "2 equals 3") ModuleTestFailed)
+        `shouldBe` Right (ModuleTestResults (M.singleton (TestName "2 equals 3") ModuleTestFailed))
 
     it "A test that does not typecheck with Boolean fails" $
       runTests
@@ -59,7 +58,7 @@ spec = do
               "def id a = a"
             ]
         )
-        `shouldBe` Right (M.singleton (TestName "identity 2 equals 2") ModuleTestPassed)
+        `shouldBe` Right (ModuleTestResults (M.singleton (TestName "identity 2 equals 2") ModuleTestPassed))
 
     it "Runs a trivial test that refers to a Prelude expression" $ do
       let preludeHash = fromJust (M.lookup "Prelude" (getCurrentModules $ prjModules stdlib))
@@ -69,4 +68,4 @@ spec = do
                   "import Prelude from " <> prettyPrint preludeHash
                 ]
             )
-            `shouldBe` Right (M.singleton (TestName "Prelude.id 2 equals 2") ModuleTestPassed)
+            `shouldBe` Right (ModuleTestResults (M.singleton (TestName "Prelude.id 2 equals 2") ModuleTestPassed))

--- a/compiler/test/Test/Tests/PropertyTest.hs
+++ b/compiler/test/Test/Tests/PropertyTest.hs
@@ -12,11 +12,11 @@ import qualified Data.Text as T
 import Language.Mimsa.Printer
 import Language.Mimsa.Project.Helpers
 import Language.Mimsa.Tests.PropertyTest
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.Tests
 import Test.Data.Project
 import Test.Hspec
 import Test.Utils.Helpers

--- a/compiler/test/Test/Tests/UnitTest.hs
+++ b/compiler/test/Test/Tests/UnitTest.hs
@@ -10,12 +10,12 @@ import qualified Data.Map as M
 import Language.Mimsa.Project.Helpers
 import Language.Mimsa.Store
 import Language.Mimsa.Tests.Test
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Tests.UnitTest
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.Tests
 import Test.Data.Project
 import Test.Hspec
 import Test.Utils.Helpers

--- a/compiler/test/Test/Utils/Helpers.hs
+++ b/compiler/test/Test/Utils/Helpers.hs
@@ -12,7 +12,6 @@ import qualified Language.Mimsa.Actions.Typecheck as Actions
 import Language.Mimsa.Parser
 import Language.Mimsa.Printer
 import Language.Mimsa.Project
-import Language.Mimsa.Tests.Types
 import Language.Mimsa.Tests.UnitTest
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
@@ -21,6 +20,7 @@ import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.ResolvedExpression
 import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.Tests
 import Language.Mimsa.Types.Typechecker
 
 fromRight :: (Printer e) => Either e a -> a

--- a/ui/src/components/Editor/EditModule.tsx
+++ b/ui/src/components/Editor/EditModule.tsx
@@ -6,10 +6,7 @@ import { Feedback } from './Feedback'
 import * as O from 'fp-ts/Option'
 import { Panel } from '../View/Panel'
 import { Button } from '../View/Button'
-import {
-  GetModuleResponse,
-  ModuleHash,
-} from '../../types'
+import { GetModuleResponse, ModuleHash } from '../../types'
 import {
   updateCode,
   bindExpression,

--- a/ui/src/components/Editor/EditModule.tsx
+++ b/ui/src/components/Editor/EditModule.tsx
@@ -6,7 +6,10 @@ import { Feedback } from './Feedback'
 import * as O from 'fp-ts/Option'
 import { Panel } from '../View/Panel'
 import { Button } from '../View/Button'
-import { ModuleData, ModuleHash } from '../../types'
+import {
+  GetModuleResponse,
+  ModuleHash,
+} from '../../types'
 import {
   updateCode,
   bindExpression,
@@ -44,15 +47,16 @@ export const EditModule: React.FC<Props> = ({
     maybeMod,
     O.fold(
       () => editor.code,
-      (a) => a.mdModulePretty
+      ({ geModuleData }) => geModuleData.mdModulePretty
     )
   )
 
   const feedback = pipe(
     maybeMod,
-    O.fold<ModuleData, FeedbackType>(
+    O.fold<GetModuleResponse, FeedbackType>(
       () => editorNew(),
-      showModule
+      ({ geModuleData, geTestData }) =>
+        showModule(geModuleData, geTestData)
     )
   )
 

--- a/ui/src/components/Editor/Feedback.tsx
+++ b/ui/src/components/Editor/Feedback.tsx
@@ -7,6 +7,7 @@ import { UnitTest } from '../UnitTest'
 import { Code } from '../View/Code'
 import { Paragraph } from '../View/Paragraph'
 import { FlexColumnSpaced } from '../View/FlexColumnSpaced'
+import { ListTests } from '../ListTests'
 import {
   BindingVersion,
   ProjectHash,
@@ -179,6 +180,12 @@ export const Feedback: React.FC<Props> = ({
           <Code codeType="type">
             {feedback.moduleData.mdModuleType}
           </Code>
+          <ListTests
+            propertyTests={
+              feedback.testData.tdPropertyTests
+            }
+            unitTests={feedback.testData.tdUnitTests}
+          />
           <ListBindings
             modules={{}}
             onModuleSelect={() => {}}

--- a/ui/src/components/ListBindings.tsx
+++ b/ui/src/components/ListBindings.tsx
@@ -24,6 +24,8 @@ export const ListBindings: React.FC<ListBindingsProps> = ({
   values,
   types,
   onBindingSelect,
+  //  modules,
+  //onModuleSelect,
 }) => {
   // try and re-use it this where possible
   const items = { ...values, ...types }
@@ -54,7 +56,7 @@ export const ListBindings: React.FC<ListBindingsProps> = ({
           {name}
         </Link>
       ))}
-  */}
+        */}
       {Object.entries(values).map(([name, exprHash]) => (
         <Link
           depType="expression"

--- a/ui/src/generated/models/GetModuleResponse.ts
+++ b/ui/src/generated/models/GetModuleResponse.ts
@@ -3,7 +3,9 @@
 /* eslint-disable */
 
 import type { ModuleData } from './ModuleData'
+import type { TestData } from './TestData'
 
 export type GetModuleResponse = {
   geModuleData: ModuleData
+  geTestData: TestData
 }

--- a/ui/src/hooks/useModule.ts
+++ b/ui/src/hooks/useModule.ts
@@ -4,7 +4,6 @@ import { getModule } from '../service/module'
 import {
   GetModuleResponse,
   UserErrorResponse,
-  ModuleData,
 } from '../generated'
 import { ModuleHash } from '../types'
 import { pipe } from 'fp-ts/function'
@@ -13,7 +12,7 @@ import * as E from 'fp-ts/Either'
 // fetch module from API and/or store
 export const useModule = (moduleHash: ModuleHash) => {
   const [result, setResult] = React.useState<
-    O.Option<ModuleData>
+    O.Option<GetModuleResponse>
   >(O.none)
 
   React.useEffect(() => {
@@ -23,11 +22,8 @@ export const useModule = (moduleHash: ModuleHash) => {
         E.fold<
           UserErrorResponse,
           GetModuleResponse,
-          O.Option<ModuleData>
-        >(
-          () => O.none,
-          ({ geModuleData }) => O.some(geModuleData)
-        ),
+          O.Option<GetModuleResponse>
+        >(() => O.none, O.some),
         setResult
       )
     )

--- a/ui/src/reducer/editor/feedback.ts
+++ b/ui/src/reducer/editor/feedback.ts
@@ -59,9 +59,13 @@ export const showPreviewSuccess = (
   expression,
 })
 
-export const showModule = (moduleData: ModuleData) => ({
+export const showModule = (
+  moduleData: ModuleData,
+  testData: TestData
+) => ({
   type: 'ShowModuleData' as const,
   moduleData,
+  testData,
 })
 
 export type Feedback =


### PR DESCRIPTION
That's right.

Adds the `test "2 + 2 == 5" = 2 + 2 == 5` item to modules.

When checking a module, we run the tests. In the repl we output them. When running the `mimsa check` command we output them.

It's working in repl:

<img width="406" alt="Screenshot 2022-07-14 at 18 12 25" src="https://user-images.githubusercontent.com/4729125/179043219-659fa2fe-8b89-4175-8f24-d70b4a100385.png">

And now it's working in UI:

<img width="383" alt="Screenshot 2022-07-15 at 09 27 41" src="https://user-images.githubusercontent.com/4729125/179312992-23125193-635a-4c85-8252-77821c2ba5f3.png">

Only done unit tests for now, property tests are a bit more complicated as we need to do the IO outside of `Action` (or just unsafe it because YOLO?). Might return `IO TestResult` from the `Action` so it's ready for the outside world to give it a quick kick into life and evaluate it.