### PR TITLE
Compile modules to ts

### DIFF
--- a/compiler/src/Language/Mimsa/Modules/Dependencies.hs
+++ b/compiler/src/Language/Mimsa/Modules/Dependencies.hs
@@ -10,6 +10,7 @@ import Control.Monad.Except
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Maybe
+import Data.Monoid
 import Data.Set (Set)
 import qualified Data.Set as S
 import Language.Mimsa.Modules.HashModule
@@ -54,16 +55,23 @@ filterDefs =
       )
     . S.toList
 
-filterTypes :: Set Entity -> Set (Maybe ModuleName, TypeName)
-filterTypes =
+filterTypes :: Module ann -> Set Entity -> Set TypeName
+filterTypes mod' =
   S.fromList
     . mapMaybe
       ( \case
-          EType typeName -> Just (Nothing, typeName)
-          ENamespacedType modName typeName -> Just (Just modName, typeName)
+          EType typeName -> Just typeName
+          EConstructor tyCon ->
+            findTypenameInModule mod' tyCon >>= \typeName -> Just typeName
           _ -> Nothing
       )
     . S.toList
+
+findTypenameInModule :: Module ann -> TyCon -> Maybe TypeName
+findTypenameInModule mod' tyCon =
+  let lookupInDataType (DataType typeName _ constructors) =
+        if M.member tyCon constructors then First (Just typeName) else First Nothing
+   in getFirst $ foldMap lookupInDataType (M.elems (moDataTypes mod'))
 
 -- get the vars used by each def
 -- explode if there's not available
@@ -99,8 +107,7 @@ getTypeDependencies ::
 getTypeDependencies mod' dt = do
   let allUses = extractDataTypeUses dt
   typeDefIds <- getTypeUses mod' allUses
-  exprDefIds <- getExprDeps mod' allUses
-  pure (DTData dt, typeDefIds <> exprDefIds, allUses)
+  pure (DTData dt, typeDefIds, allUses)
 
 getTypeUses ::
   (MonadError (Error Annotation) m) =>
@@ -108,37 +115,24 @@ getTypeUses ::
   Set Entity ->
   m (Set DefIdentifier)
 getTypeUses mod' uses =
-  let typeDeps = filterTypes uses
+  let typeDeps = filterTypes mod' uses
       unknownTypeDeps =
         S.filter
-          ( \(modName, typeName) ->
-              case modName of
-                Just _externalMod -> False
-                Nothing ->
-                  S.notMember typeName (M.keysSet (moDataTypes mod'))
-                    && S.notMember typeName (M.keysSet (moDataTypeImports mod'))
+          ( \typeName ->
+              S.notMember typeName (M.keysSet (moDataTypes mod'))
+                && S.notMember typeName (M.keysSet (moDataTypeImports mod'))
           )
           typeDeps
    in if S.null unknownTypeDeps
         then
           let localTypeDeps =
                 S.filter
-                  ( \(modName, typeName) -> case modName of
-                      Just _externalMod -> False
-                      Nothing -> typeName `S.member` M.keysSet (moDataTypes mod')
+                  ( \typeName ->
+                      typeName `S.member` M.keysSet (moDataTypes mod')
                   )
                   typeDeps
-              withoutExternal = localsOnly localTypeDeps
-           in pure (S.map DIType withoutExternal)
+           in pure (S.map DIType localTypeDeps)
         else throwError (ModuleErr (CannotFindTypes unknownTypeDeps))
-
-localsOnly :: (Ord b) => Set (Maybe a, b) -> Set b
-localsOnly =
-  setMapMaybe
-    ( \case
-        (Just _, _) -> Nothing
-        (Nothing, b) -> Just b
-    )
 
 getExprDependencies ::
   (Eq ann, MonadError (Error Annotation) m) =>
@@ -151,6 +145,7 @@ getExprDependencies mod' expr = do
   typeDefIds <- getTypeUses mod' allUses
   pure (DTExpr expr, exprDefIds <> typeDefIds, allUses)
 
+-- | this gets dependencies that are functions / values
 getExprDeps ::
   (MonadError (Error Annotation) m) =>
   Module ann ->
@@ -169,8 +164,8 @@ getExprDeps mod' uses =
         then
           let localNameDeps =
                 S.filter
-                  ( `S.member`
-                      M.keysSet (moExpressions mod')
+                  ( \dep ->
+                      dep `S.member` M.keysSet (moExpressions mod')
                   )
                   nameDeps
            in pure localNameDeps

--- a/compiler/src/Language/Mimsa/Modules/ToStoreExprs.hs
+++ b/compiler/src/Language/Mimsa/Modules/ToStoreExprs.hs
@@ -2,18 +2,22 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TupleSections #-}
 
 module Language.Mimsa.Modules.ToStoreExprs (toStoreExpressions, CompiledModule (..)) where
 
 import Control.Monad.Except
+import Data.Functor
 import Data.Map (Map)
 import qualified Data.Map as M
+import Data.Maybe
 import Data.Set (Set)
 import qualified Data.Set as S
 import qualified Language.Mimsa.Actions.Helpers.Build as Build
 import Language.Mimsa.Modules.Dependencies
 import Language.Mimsa.Modules.HashModule
 import Language.Mimsa.Store
+import Language.Mimsa.Store.ExtractTypes
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
@@ -73,9 +77,11 @@ exprToStoreExpression ::
   m (StoreExpression (Type ann))
 exprToStoreExpression compiledModules inputModule inputs (expr, uses) = do
   bindings <- bindingsFromEntities compiledModules inputModule inputs uses
+  typeBindings <- typesFromEntities compiledModules inputModule inputs uses
   infixes <- infixesFromEntities inputs uses
-  pure $ StoreExpression expr bindings mempty infixes
+  pure $ StoreExpression expr bindings typeBindings infixes
 
+-- | where can I find this function?
 resolveNamespacedName ::
   Map ModuleHash (CompiledModule (Type ann)) ->
   Module (Type ann) ->
@@ -91,6 +97,75 @@ resolveNamespacedName compiledModules inputModule modName name = do
 
   -- lookup the name in the module
   M.lookup (DIName name) (cmExprs compiledMod)
+
+-- | where can I find this Constructor?
+resolveNamespacedTyCon ::
+  Map ModuleHash (CompiledModule (Type ann)) ->
+  Module (Type ann) ->
+  ModuleName ->
+  TyCon ->
+  Maybe ExprHash
+resolveNamespacedTyCon compiledModules inputModule modName tyCon = do
+  -- find out which module the modName refers to
+  modHash <- M.lookup modName (moNamedImports inputModule)
+
+  -- find the module in our pile of already compiled modules
+  compiledMod <- M.lookup modHash compiledModules
+
+  -- lookup the name in the module
+  getStoreExpressionHash <$> M.lookup tyCon (dataTypesByTyCon (flattenCompiled compiledMod))
+
+-- filter data types out, and put in a map keyed by TyCon
+dataTypesByTyCon ::
+  Map DefIdentifier (StoreExpression (Type ann)) ->
+  Map
+    TyCon
+    ( StoreExpression (Type ann)
+    )
+dataTypesByTyCon items =
+  let withSe se =
+        fmap (se,) . listToMaybe . S.toList . extractDataTypes
+          . storeExpression
+          $ se
+
+      dataTypes = mapMaybe withSe (M.elems items)
+   in mconcat $
+        ( \(se, DataType _ _ constructors) ->
+            constructors $> se
+        )
+          <$> dataTypes
+
+flattenCompiled ::
+  CompiledModule (Type ann) ->
+  Map DefIdentifier (StoreExpression (Type ann))
+flattenCompiled cm =
+  let lookupHash exprHash =
+        M.lookup exprHash (getStore $ cmStore cm)
+   in M.mapMaybe lookupHash (cmExprs cm)
+
+-- | given our dependencies and the entities used by the expressions, create
+-- the type bindings
+typesFromEntities ::
+  (MonadError (Error Annotation) m) =>
+  Map ModuleHash (CompiledModule (Type ann)) ->
+  Module (Type ann) ->
+  Map DefIdentifier (StoreExpression (Type ann)) ->
+  Set Entity ->
+  m (Map (Maybe ModuleName, TyCon) ExprHash)
+typesFromEntities compiledModules inputModule inputs uses = do
+  let fromUse = \case
+        EConstructor tyCon ->
+          case getStoreExpressionHash <$> M.lookup tyCon (dataTypesByTyCon inputs) of
+            Just exprHash -> pure $ M.singleton (Nothing, tyCon) exprHash
+            _ -> throwError (ModuleErr $ CannotFindConstructor tyCon)
+        ENamespacedConstructor modName tyCon ->
+          case resolveNamespacedTyCon compiledModules inputModule modName tyCon of
+            Just hash -> pure $ M.singleton (Just modName, tyCon) hash
+            _ -> error $ "could not resolve namespaced type " <> show modName <> "." <> show tyCon
+        _ -> pure mempty
+
+  -- combine results
+  mconcat <$> traverse fromUse (S.toList uses)
 
 -- given our dependencies and the entities used by the expression, create the
 -- bindings
@@ -109,7 +184,7 @@ bindingsFromEntities compiledModules inputModule inputs uses = do
         ENamespacedName modName name ->
           case resolveNamespacedName compiledModules inputModule modName name of
             Just hash -> pure $ M.singleton (Just modName, name) hash
-            _ -> pure mempty -- should this be an error?
+            _ -> error "could not resolve namespaced name"
         _ -> pure mempty
 
   -- combine results
@@ -154,7 +229,10 @@ toStoreExpressions typecheckedModules inputModule = do
 
 --- compile a module into StoreExpressions
 compileModuleDefinitions ::
-  (MonadError (Error Annotation) m, Eq ann, Monoid ann) =>
+  ( MonadError (Error Annotation) m,
+    Eq ann,
+    Monoid ann
+  ) =>
   Map ModuleHash (CompiledModule (Type ann)) ->
   Module (Type ann) ->
   m (CompiledModule (Type ann))
@@ -192,7 +270,11 @@ compileModuleDefinitions compiledModules inputModule = do
 
 --- compile many modules
 compileAllModules ::
-  (MonadError (Error Annotation) m, Eq ann, Monoid ann, Show ann) =>
+  ( MonadError (Error Annotation) m,
+    Eq ann,
+    Monoid ann,
+    Show ann
+  ) =>
   Map ModuleHash (Module (Type ann)) ->
   Module (Type ann) ->
   m (Map ModuleHash (CompiledModule (Type ann)))

--- a/compiler/src/Language/Mimsa/Modules/Uses.hs
+++ b/compiler/src/Language/Mimsa/Modules/Uses.hs
@@ -52,7 +52,10 @@ extractUses_ (MyPair _ a b) = extractUses_ a <> extractUses_ b
 extractUses_ (MyRecord _ map') = foldMap extractUses_ map'
 extractUses_ (MyRecordAccess _ a _) = extractUses_ a
 extractUses_ (MyArray _ map') = foldMap extractUses_ map'
-extractUses_ (MyData _ _ a) = extractUses_ a
+extractUses_ (MyData _ dt a) =
+  filterConstructorsIntroducedInDataType
+    dt
+    (extractUses_ a)
 extractUses_ (MyConstructor _ (Just modName) tyCon) =
   S.singleton (ENamespacedConstructor modName tyCon)
 extractUses_ (MyConstructor _ Nothing tyCon) =
@@ -73,6 +76,16 @@ extractUses_ (MyPatternMatch _ match patterns) =
             (extractUses expr)
       )
         <$> patterns
+
+-- | if we've just introduced a datatype, no need to tell anybody else about
+-- the constructors we used
+filterConstructorsIntroducedInDataType :: DataType -> Set Entity -> Set Entity
+filterConstructorsIntroducedInDataType (DataType _tn _ constructors) =
+  S.filter
+    ( \case
+        EConstructor tyCon -> S.notMember tyCon (M.keysSet constructors)
+        _ -> False
+    )
 
 -- for vars, remove any vars introduced in patterns in the expressions
 -- for everything else, keep both

--- a/compiler/src/Language/Mimsa/Types/Error/ModuleError.hs
+++ b/compiler/src/Language/Mimsa/Types/Error/ModuleError.hs
@@ -19,7 +19,8 @@ data ModuleError
   | DefinitionConflictsWithImport DefIdentifier ModuleHash
   | TypeConflictsWithImport TypeName ModuleHash
   | CannotFindValues (Set DefIdentifier)
-  | CannotFindTypes (Set (Maybe ModuleName, TypeName))
+  | CannotFindConstructor TyCon
+  | CannotFindTypes (Set TypeName)
   | DefDoesNotTypeCheck Text DefIdentifier TypeError
   | MissingModule ModuleHash
   | MissingModuleDep DefIdentifier ModuleHash
@@ -40,6 +41,8 @@ instance Printer ModuleError where
     "Cannot find values: " <> prettyPrint names
   prettyPrint (CannotFindTypes names) =
     "Cannot find types: " <> prettyPrint names
+  prettyPrint (CannotFindConstructor tyCon) =
+    "Cannot find constructor: " <> prettyPrint tyCon
   prettyPrint (DefDoesNotTypeCheck _ name typeErr) =
     prettyPrint name <> " had a typechecking error: " <> prettyPrint typeErr
   prettyPrint (MissingModule mHash) =


### PR DESCRIPTION
Resolves #729 

Contributes to #722.

Output modules as TS. They're still StoreExpressions but the module exports a load of them for sensible use in TS projects.

Need to:

- [x] Do same with JS and add tests
- [x] Make project output also export all the modules in the project
- [x] Make infixes work in TS (they should probably just be imports with invented names like "_infix1")
- [x] Make available in repl-new
- [ ] Make available in server