### PR TITLE
TS compilation refactor

### DIFF
--- a/compiler/benchmark/Spec.hs
+++ b/compiler/benchmark/Spec.hs
@@ -45,7 +45,7 @@ compileThing input =
   let action = do
         let expr = unsafeParseExpr input $> mempty
         (_, _, storeExpr, _, _) <- Actions.evaluate (prettyPrint expr) expr
-        Actions.compile Typescript storeExpr
+        Actions.compileStoreExpression Typescript storeExpr
    in case Actions.run stdlib action of
         Right (proj, _, _) -> proj
         Left e -> error (show e)

--- a/compiler/repl/Repl/Actions/Compile.hs
+++ b/compiler/repl/Repl/Actions/Compile.hs
@@ -35,7 +35,7 @@ doOutputJS project input maybeBackend expr = do
         project
         (Actions.typecheckExpression project input expr)
   (_, (_, _)) <-
-    toReplM project (Actions.compile be (reStoreExpression resolvedExpr))
+    toReplM project (Actions.compileStoreExpression be (reStoreExpression resolvedExpr))
   replOutput @Text "Compilation complete!"
 
 doCompileProject ::

--- a/compiler/server/Server/Endpoints/Compile.hs
+++ b/compiler/server/Server/Endpoints/Compile.hs
@@ -73,7 +73,7 @@ compileHashEndpoint
   (CompileHashRequest exprHash backend) = do
     (storeExpr, pd, _) <- projectFromExpressionHandler mimsaEnv exprHash
     (_, outcomes, (rootExprHash, _)) <-
-      fromActionM mimsaEnv (pdHash pd) (Actions.compile backend storeExpr)
+      fromActionM mimsaEnv (pdHash pd) (Actions.compileStoreExpression backend storeExpr)
     let makeZip = encodeZipFile . zipFromSavedFiles . Actions.writeFilesFromOutcomes
     let filename = "mimsa-" <> show rootExprHash <> ".zip"
         contentDisposition = "attachment; filename=\"" <> filename <> "\""

--- a/compiler/src/Language/Mimsa/Actions/Modules/Evaluate.hs
+++ b/compiler/src/Language/Mimsa/Actions/Modules/Evaluate.hs
@@ -109,10 +109,12 @@ evaluateModule expr localModule = do
   let exprType = fromJust (lookupModuleDefType typecheckedModule evalId)
 
   -- need to get our new store items into the project so this works I reckon
-  traverse_ Actions.appendStoreExpression (getStore $ cmStore compiled)
+  traverse_
+    (Actions.appendStoreExpression . fmap getAnnotationForType)
+    (getStore $ cmStore compiled)
 
   -- interpret
   evaluatedExpression <-
-    Actions.interpreter rootStoreExpr
+    Actions.interpreter (getAnnotationForType <$> rootStoreExpr)
 
   pure (exprType, evaluatedExpression, newModule)

--- a/compiler/src/Language/Mimsa/Modules/Dependencies.hs
+++ b/compiler/src/Language/Mimsa/Modules/Dependencies.hs
@@ -68,7 +68,7 @@ filterTypes =
 -- get the vars used by each def
 -- explode if there's not available
 getValueDependencies ::
-  (Eq ann, Monoid ann, MonadError (Error Annotation) m) =>
+  (Eq ann, MonadError (Error Annotation) m) =>
   Module ann ->
   m
     ( Map
@@ -141,7 +141,7 @@ localsOnly =
     )
 
 getExprDependencies ::
-  (Eq ann, Monoid ann, MonadError (Error Annotation) m) =>
+  (Eq ann, MonadError (Error Annotation) m) =>
   Module ann ->
   Expr Name ann ->
   m (DepType ann, Set DefIdentifier, Set Entity)

--- a/compiler/src/Language/Mimsa/Modules/Uses.hs
+++ b/compiler/src/Language/Mimsa/Modules/Uses.hs
@@ -20,10 +20,10 @@ import Language.Mimsa.Types.Typechecker
 -- important - we must not count variables brought in via lambdas or let
 -- bindings as those aren't external deps
 
-extractUses :: (Eq ann, Monoid ann) => Expr Name ann -> Set Entity
+extractUses :: (Eq ann) => Expr Name ann -> Set Entity
 extractUses = extractUses_
 
-extractUses_ :: (Eq ann, Monoid ann) => Expr Name ann -> Set Entity
+extractUses_ :: (Eq ann) => Expr Name ann -> Set Entity
 extractUses_ (MyVar _ (Just modName) a) = S.singleton (ENamespacedName modName a)
 extractUses_ (MyVar _ _ a) = S.singleton (EName a)
 extractUses_ (MyAnnotation _ mt expr) =
@@ -91,7 +91,7 @@ filterVarsIntroducedInPatterns patUses exprUses =
 extractIdentUses :: Identifier Name ann -> Set Entity
 extractIdentUses (Identifier _ name) = S.singleton (EName name)
 
-extractPatternUses :: (Eq ann, Monoid ann) => Pattern Name ann -> Set Entity
+extractPatternUses :: (Eq ann) => Pattern Name ann -> Set Entity
 extractPatternUses (PWildcard _) = mempty
 extractPatternUses (PLit _ _) = mempty
 extractPatternUses (PVar _ a) = S.singleton (EName a)

--- a/compiler/test/Test/Actions/Compile.hs
+++ b/compiler/test/Test/Actions/Compile.hs
@@ -28,7 +28,7 @@ spec = do
       let expr = MyVar mempty Nothing "id"
       let action = do
             (_, _, storeExpr, _, _) <- Actions.evaluate (prettyPrint expr) expr
-            Actions.compile Typescript storeExpr
+            Actions.compileStoreExpression Typescript storeExpr
       let (newProject, outcomes, (_, hashes)) =
             fromRight (Actions.run testStdlib action)
       -- creates four files
@@ -43,7 +43,7 @@ spec = do
       let expr = MyVar mempty Nothing "evalState"
       let action = do
             (_, _, storeExpr, _, _) <- Actions.evaluate (prettyPrint expr) expr
-            Actions.compile Typescript storeExpr
+            Actions.compileStoreExpression Typescript storeExpr
       let (newProject, outcomes, _) = fromRight (Actions.run testStdlib action)
       -- creates 9 files
       length (Actions.writeFilesFromOutcomes outcomes) `shouldBe` 9
@@ -56,14 +56,14 @@ spec = do
       let bindings = M.singleton (Nothing, "id2") exprHashForId
       let storeExpr = StoreExpression expr bindings mempty mempty
       let action = do
-            Actions.compile Typescript storeExpr
+            Actions.compileStoreExpression Typescript storeExpr
       Actions.run testStdlib action `shouldSatisfy` isRight
 
     it "Compiles with deep deps" $ do
       let expr = unsafeParseExpr "either.fmap (\\a -> a + 1) (Right 100)" $> mempty
           action = do
             (_, _, storeExpr, _, _) <- Actions.evaluate (prettyPrint expr) expr
-            Actions.compile Typescript storeExpr
+            Actions.compileStoreExpression Typescript storeExpr
       let (_, outcomes, _) = fromRight (Actions.run testStdlib action)
       -- creates 9 files (7 expressions, stdlib, index)
       -- this will reduce once we inline across expressions as

--- a/compiler/test/Test/Modules/Compile.hs
+++ b/compiler/test/Test/Modules/Compile.hs
@@ -13,18 +13,21 @@ import Language.Mimsa.Modules.Typecheck
 import Language.Mimsa.Printer
 import Language.Mimsa.Store
 import Language.Mimsa.Types.AST
+import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Modules.DefIdentifier
 import Language.Mimsa.Types.Modules.Module
 import Language.Mimsa.Types.Store
+import Language.Mimsa.Types.Typechecker
 import Test.Hspec
 import Test.Utils.Helpers
 
 compile' :: Module Annotation -> CompiledModule Annotation
 compile' mod' =
-  let action = do
+  let action :: Either (Error Annotation) (CompiledModule Annotation)
+      action = do
         tcMods <- typecheckAllModules mempty (prettyPrint mod') mod'
         case M.lookup (snd $ serializeModule mod') tcMods of
-          Just tcMod -> compile tcMods tcMod
+          Just tcMod -> (fmap . fmap) getAnnotationForType (compile tcMods tcMod)
           Nothing -> error "Could not find the module we just typechecked"
    in fromRight action
 

--- a/compiler/test/Test/Utils/Compilation.hs
+++ b/compiler/test/Test/Utils/Compilation.hs
@@ -31,7 +31,7 @@ testProjectCompile ::
 testProjectCompile folderPrefix be expr = do
   let action = do
         (_, _, storeExpr, _, _) <- Actions.evaluate (prettyPrint expr) expr
-        (seHash, _) <- Actions.compile be storeExpr
+        (seHash, _) <- Actions.compileStoreExpression be storeExpr
         pure seHash
   let (_newProject_, outcomes, seHash) =
         fromRight (Actions.run testStdlib action)


### PR DESCRIPTION
Fixing TS compilation for modules is hard, this extracts another thing that will be helpful - allowing already typed StoreExpressions to be used in compilation.