### PR TITLE
Use Data.Map.Strict

### DIFF
--- a/compiler/repl/Repl/Actions/ListBindings.hs
+++ b/compiler/repl/Repl/Actions/ListBindings.hs
@@ -7,7 +7,7 @@ where
 
 import Control.Monad (join)
 import Data.Foldable (traverse_)
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)

--- a/compiler/repl/Repl/Actions/TypeSearch.hs
+++ b/compiler/repl/Repl/Actions/TypeSearch.hs
@@ -6,7 +6,7 @@ module Repl.Actions.TypeSearch
 where
 
 import Data.Foldable
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import qualified Language.Mimsa.Actions.Monad as Actions
 import qualified Language.Mimsa.Actions.Typecheck as Actions

--- a/compiler/repl/Repl/Actions/UnitTests.hs
+++ b/compiler/repl/Repl/Actions/UnitTests.hs
@@ -5,7 +5,7 @@ module Repl.Actions.UnitTests
 where
 
 import Data.Foldable
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import Language.Mimsa.Actions.AddUnitTest
 import Language.Mimsa.Printer

--- a/compiler/repl/Repl/Persistence.hs
+++ b/compiler/repl/Repl/Persistence.hs
@@ -17,7 +17,7 @@ import Control.Monad.Reader
 import qualified Data.Aeson as JSON
 import qualified Data.ByteString.Lazy as LBS
 import Data.Functor
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import qualified Data.Text as T

--- a/compiler/repl/ReplNew/Actions/ListModules.hs
+++ b/compiler/repl/ReplNew/Actions/ListModules.hs
@@ -7,7 +7,7 @@ module ReplNew.Actions.ListModules
 where
 
 import Data.Foldable (traverse_)
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Language.Mimsa.Actions.Helpers.LookupExpression as Actions
 import qualified Language.Mimsa.Actions.Modules.Typecheck as Actions

--- a/compiler/server/Server/Endpoints/Expression.hs
+++ b/compiler/server/Server/Endpoints/Expression.hs
@@ -15,8 +15,8 @@ where
 
 import qualified Data.Aeson as JSON
 import Data.Bifunctor
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.OpenApi hiding (Server)
 import qualified Data.Text as T
 import GHC.Generics

--- a/compiler/server/Server/Endpoints/Project/BindExpression.hs
+++ b/compiler/server/Server/Endpoints/Project/BindExpression.hs
@@ -13,7 +13,7 @@ where
 import Control.Monad.Trans.Class
 import qualified Data.Aeson as JSON
 import Data.Bifunctor
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.OpenApi
 import Data.Text (Text)
 import GHC.Generics

--- a/compiler/server/Server/Endpoints/Project/ListTests.hs
+++ b/compiler/server/Server/Endpoints/Project/ListTests.hs
@@ -13,7 +13,7 @@ module Server.Endpoints.Project.ListTests
 where
 
 import qualified Data.Aeson as JSON
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.OpenApi
 import GHC.Generics
 import Language.Mimsa.Tests.Test

--- a/compiler/server/Server/Endpoints/Project/Optimise.hs
+++ b/compiler/server/Server/Endpoints/Project/Optimise.hs
@@ -15,7 +15,7 @@ where
 import Control.Monad.Except
 import qualified Data.Aeson as JSON
 import Data.Bifunctor
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.OpenApi hiding (get)
 import GHC.Generics
 import qualified Language.Mimsa.Actions.Graph as Actions

--- a/compiler/server/Server/Endpoints/Project/Upgrade.hs
+++ b/compiler/server/Server/Endpoints/Project/Upgrade.hs
@@ -15,8 +15,8 @@ where
 import Control.Monad.Except
 import qualified Data.Aeson as JSON
 import Data.Bifunctor
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.OpenApi hiding (get)
 import Data.Text (Text)
 import GHC.Generics

--- a/compiler/server/Server/Endpoints/Search.hs
+++ b/compiler/server/Server/Endpoints/Search.hs
@@ -7,7 +7,7 @@
 module Server.Endpoints.Search (SearchAPI, searchEndpoints) where
 
 import qualified Data.Aeson as JSON
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.OpenApi hiding (Server)
 import Data.Text (Text)
 import GHC.Generics

--- a/compiler/server/Server/Errors/UserErrorResponse.hs
+++ b/compiler/server/Server/Errors/UserErrorResponse.hs
@@ -11,7 +11,7 @@ where
 
 import qualified Data.Aeson as JSON
 import Data.Coerce (coerce)
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Maybe (mapMaybe)
 import Data.OpenApi hiding (name)
 import Data.Set (Set)

--- a/compiler/server/Server/Handlers.hs
+++ b/compiler/server/Server/Handlers.hs
@@ -33,8 +33,8 @@ import Data.Coerce
 import Data.Foldable (traverse_)
 import Data.Functor
 import qualified Data.List.NonEmpty as NE
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.OpenApi (ToSchema)
 import Data.Set (Set)
 import qualified Data.Set as S

--- a/compiler/server/Server/Helpers/ExpressionData.hs
+++ b/compiler/server/Server/Helpers/ExpressionData.hs
@@ -16,8 +16,8 @@ where
 import qualified Data.Aeson as JSON
 import Data.Bifunctor
 import Data.Coerce
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.OpenApi hiding (get)
 import Data.Text (Text)
 import GHC.Generics

--- a/compiler/server/Server/Helpers/TestData.hs
+++ b/compiler/server/Server/Helpers/TestData.hs
@@ -17,8 +17,8 @@ where
 import qualified Data.Aeson as JSON
 import Data.Coerce
 import Data.Either
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.OpenApi hiding (get)
 import qualified Data.Set as S
 import Data.Text (Text)

--- a/compiler/server/Server/Persistence.hs
+++ b/compiler/server/Server/Persistence.hs
@@ -17,7 +17,7 @@ import Control.Monad.Reader
 import qualified Data.Aeson as JSON
 import qualified Data.ByteString.Lazy as LBS
 import Data.Functor
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import Language.Mimsa.Printer
 import Language.Mimsa.Project.Helpers
 import Language.Mimsa.Store.Hashing

--- a/compiler/server/Server/Types.hs
+++ b/compiler/server/Server/Types.hs
@@ -1,7 +1,7 @@
 module Server.Types where
 
 import qualified Control.Concurrent.STM as STM
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Store

--- a/compiler/src/Language/Mimsa/Actions/BindType.hs
+++ b/compiler/src/Language/Mimsa/Actions/BindType.hs
@@ -5,7 +5,7 @@ module Language.Mimsa.Actions.BindType
   )
 where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Language.Mimsa.Actions.Monad as Actions
 import qualified Language.Mimsa.Actions.Typecheck as Actions

--- a/compiler/src/Language/Mimsa/Actions/Compile.hs
+++ b/compiler/src/Language/Mimsa/Actions/Compile.hs
@@ -13,8 +13,8 @@ import Control.Monad.Except
 import Data.Bifunctor (first)
 import Data.Coerce
 import Data.Foldable (traverse_)
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import qualified Data.Text as T

--- a/compiler/src/Language/Mimsa/Actions/Evaluate.hs
+++ b/compiler/src/Language/Mimsa/Actions/Evaluate.hs
@@ -8,7 +8,7 @@ where
 import Control.Monad.Except
 import Data.Bifunctor
 import Data.Foldable (traverse_)
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Language.Mimsa.Actions.Helpers.CheckStoreExpression as Actions
 import qualified Language.Mimsa.Actions.Helpers.GetDepsForStoreExpression as Actions

--- a/compiler/src/Language/Mimsa/Actions/Graph.hs
+++ b/compiler/src/Language/Mimsa/Actions/Graph.hs
@@ -5,8 +5,8 @@ module Language.Mimsa.Actions.Graph (graphExpression, graphProject) where
 
 import Control.Monad.Except
 import Data.Bifunctor (first)
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Project
 import Language.Mimsa.Store.DepGraph

--- a/compiler/src/Language/Mimsa/Actions/Helpers/Build.hs
+++ b/compiler/src/Language/Mimsa/Actions/Helpers/Build.hs
@@ -4,8 +4,8 @@
 module Language.Mimsa.Actions.Helpers.Build (doJobs, getMissing, Plan (..), State (..), Job, Inputs) where
 
 import Control.Parallel.Strategies
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Language.Mimsa.Printer

--- a/compiler/src/Language/Mimsa/Actions/Helpers/FindExistingBinding.hs
+++ b/compiler/src/Language/Mimsa/Actions/Helpers/FindExistingBinding.hs
@@ -1,6 +1,6 @@
 module Language.Mimsa.Actions.Helpers.FindExistingBinding (findExistingBinding) where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Project.Helpers
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers

--- a/compiler/src/Language/Mimsa/Actions/Helpers/GetDepsForStoreExpression.hs
+++ b/compiler/src/Language/Mimsa/Actions/Helpers/GetDepsForStoreExpression.hs
@@ -7,8 +7,8 @@ where
 
 import Control.Monad.Except
 import Data.Bifunctor (first)
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Printer

--- a/compiler/src/Language/Mimsa/Actions/Helpers/LookupExpression.hs
+++ b/compiler/src/Language/Mimsa/Actions/Helpers/LookupExpression.hs
@@ -7,7 +7,7 @@ where
 
 import Control.Monad.Except
 import Data.Functor
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error

--- a/compiler/src/Language/Mimsa/Actions/Interpret.hs
+++ b/compiler/src/Language/Mimsa/Actions/Interpret.hs
@@ -4,8 +4,8 @@ module Language.Mimsa.Actions.Interpret (interpreter) where
 
 import Control.Monad.Except
 import Data.Bifunctor
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Language.Mimsa.Actions.Helpers.Build as Build
 import qualified Language.Mimsa.Actions.Helpers.GetDepsForStoreExpression as Actions

--- a/compiler/src/Language/Mimsa/Actions/Modules/Bind.hs
+++ b/compiler/src/Language/Mimsa/Actions/Modules/Bind.hs
@@ -6,7 +6,7 @@ module Language.Mimsa.Actions.Modules.Bind
   )
 where
 
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import Data.Text (Text)
 import qualified Language.Mimsa.Actions.Modules.RunTests as Actions
 import qualified Language.Mimsa.Actions.Modules.Typecheck as Actions

--- a/compiler/src/Language/Mimsa/Actions/Modules/Check.hs
+++ b/compiler/src/Language/Mimsa/Actions/Modules/Check.hs
@@ -3,7 +3,7 @@
 
 module Language.Mimsa.Actions.Modules.Check (checkModule) where
 
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import Data.Text (Text)
 import qualified Language.Mimsa.Actions.Modules.RunTests as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions

--- a/compiler/src/Language/Mimsa/Actions/Modules/Evaluate.hs
+++ b/compiler/src/Language/Mimsa/Actions/Modules/Evaluate.hs
@@ -8,7 +8,7 @@ where
 
 import Control.Monad.Except
 import Data.Foldable
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Maybe (fromJust)
 import Data.Set (Set)
 import qualified Data.Set as S

--- a/compiler/src/Language/Mimsa/Actions/Modules/RunTests.hs
+++ b/compiler/src/Language/Mimsa/Actions/Modules/RunTests.hs
@@ -4,7 +4,7 @@ module Language.Mimsa.Actions.Modules.RunTests (runModuleTests) where
 
 import Control.Monad.Except
 import Data.Bifunctor
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import qualified Language.Mimsa.Actions.Modules.Evaluate as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Printer

--- a/compiler/src/Language/Mimsa/Actions/Modules/ToStoreExpressions.hs
+++ b/compiler/src/Language/Mimsa/Actions/Modules/ToStoreExpressions.hs
@@ -6,7 +6,7 @@ where
 
 import Control.Monad.Except
 import Data.Foldable
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Language.Mimsa.Actions.Modules.Typecheck as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Modules.HashModule

--- a/compiler/src/Language/Mimsa/Actions/Modules/Typecheck.hs
+++ b/compiler/src/Language/Mimsa/Actions/Modules/Typecheck.hs
@@ -5,8 +5,8 @@ module Language.Mimsa.Actions.Modules.Typecheck
 where
 
 import Control.Monad.Except
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Language.Mimsa.Actions.Monad as Actions
 import Language.Mimsa.Modules.HashModule

--- a/compiler/src/Language/Mimsa/Actions/Monad.hs
+++ b/compiler/src/Language/Mimsa/Actions/Monad.hs
@@ -28,8 +28,8 @@ where
 
 import Control.Monad.Except
 import Control.Monad.State
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)

--- a/compiler/src/Language/Mimsa/Actions/Optimise.hs
+++ b/compiler/src/Language/Mimsa/Actions/Optimise.hs
@@ -10,8 +10,8 @@ where
 
 import Control.Monad.Except
 import Data.Bifunctor
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Language.Mimsa.Actions.Helpers.Build as Build
 import qualified Language.Mimsa.Actions.Helpers.CheckStoreExpression as Actions

--- a/compiler/src/Language/Mimsa/Actions/Typecheck.hs
+++ b/compiler/src/Language/Mimsa/Actions/Typecheck.hs
@@ -12,8 +12,8 @@ where
 import Control.Monad.Except
 import Data.Bifunctor (first)
 import Data.Foldable (traverse_)
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Language.Mimsa.Actions.Helpers.Build as Build

--- a/compiler/src/Language/Mimsa/Actions/Types.hs
+++ b/compiler/src/Language/Mimsa/Actions/Types.hs
@@ -14,7 +14,7 @@ where
 import Control.Monad.Except
 import Control.Monad.State
 import Data.Hashable
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Language.Mimsa.Types.AST

--- a/compiler/src/Language/Mimsa/Actions/Upgrade.hs
+++ b/compiler/src/Language/Mimsa/Actions/Upgrade.hs
@@ -6,8 +6,8 @@ module Language.Mimsa.Actions.Upgrade (upgradeByName) where
 import Control.Applicative
 import Control.Monad.Except
 import Data.Bifunctor (first)
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Maybe
 import Data.Set (Set)
 import qualified Data.Set as S

--- a/compiler/src/Language/Mimsa/Backend/Javascript/Printer.hs
+++ b/compiler/src/Language/Mimsa/Backend/Javascript/Printer.hs
@@ -10,7 +10,7 @@ module Language.Mimsa.Backend.Javascript.Printer
   )
 where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)

--- a/compiler/src/Language/Mimsa/Backend/Output.hs
+++ b/compiler/src/Language/Mimsa/Backend/Output.hs
@@ -18,8 +18,8 @@ import Data.Bifunctor
 import Data.Coerce
 import Data.Functor
 import Data.List (intersperse)
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/compiler/src/Language/Mimsa/Backend/Typescript/DataType.hs
+++ b/compiler/src/Language/Mimsa/Backend/Typescript/DataType.hs
@@ -3,7 +3,7 @@
 module Language.Mimsa.Backend.Typescript.DataType (createConstructorFunctions) where
 
 import Data.Coerce (coerce)
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)

--- a/compiler/src/Language/Mimsa/Backend/Typescript/FromExpr.hs
+++ b/compiler/src/Language/Mimsa/Backend/Typescript/FromExpr.hs
@@ -6,8 +6,8 @@ module Language.Mimsa.Backend.Typescript.FromExpr (fromExpr) where
 import Control.Monad.Except
 import Data.Bifunctor
 import Data.Coerce (coerce)
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import qualified Data.Text as T

--- a/compiler/src/Language/Mimsa/Backend/Typescript/Monad.hs
+++ b/compiler/src/Language/Mimsa/Backend/Typescript/Monad.hs
@@ -26,8 +26,8 @@ import Control.Monad.Writer
 import Data.Either
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NE
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Language.Mimsa.Backend.Typescript.Types

--- a/compiler/src/Language/Mimsa/Backend/Typescript/Patterns.hs
+++ b/compiler/src/Language/Mimsa/Backend/Typescript/Patterns.hs
@@ -10,7 +10,7 @@ module Language.Mimsa.Backend.Typescript.Patterns
 where
 
 import Data.Foldable (foldl')
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Backend.Typescript.Types
 import Language.Mimsa.Printer
 import Language.Mimsa.Utils (mapWithIndex)

--- a/compiler/src/Language/Mimsa/Backend/Typescript/Printer.hs
+++ b/compiler/src/Language/Mimsa/Backend/Typescript/Printer.hs
@@ -12,7 +12,7 @@ module Language.Mimsa.Backend.Typescript.Printer
   )
 where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)

--- a/compiler/src/Language/Mimsa/Backend/Typescript/Types.hs
+++ b/compiler/src/Language/Mimsa/Backend/Typescript/Types.hs
@@ -23,7 +23,7 @@ module Language.Mimsa.Backend.Typescript.Types
   )
 where
 
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import Data.Set (Set)
 import Data.String
 import Data.Text (Text)

--- a/compiler/src/Language/Mimsa/Codegen.hs
+++ b/compiler/src/Language/Mimsa/Codegen.hs
@@ -19,8 +19,8 @@ where
 import qualified Data.Aeson as JSON
 import Data.Either (isRight)
 import Data.Functor
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.OpenApi (ToSchema)
 import GHC.Generics
 import Language.Mimsa.Codegen.ApplicativeApply

--- a/compiler/src/Language/Mimsa/Codegen/ApplicativeApply.hs
+++ b/compiler/src/Language/Mimsa/Codegen/ApplicativeApply.hs
@@ -13,7 +13,7 @@ import Data.Coerce
 import Data.Foldable (foldl')
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import qualified Data.Set as S
 import qualified Data.Text as T
 import Language.Mimsa.Codegen.Utils

--- a/compiler/src/Language/Mimsa/Codegen/ApplicativePure.hs
+++ b/compiler/src/Language/Mimsa/Codegen/ApplicativePure.hs
@@ -11,8 +11,8 @@ import Data.Coerce
 import Data.Foldable (foldl')
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Maybe (mapMaybe)
 import Language.Mimsa.Codegen.Utils
 import Language.Mimsa.Types.AST

--- a/compiler/src/Language/Mimsa/Codegen/Enum.hs
+++ b/compiler/src/Language/Mimsa/Codegen/Enum.hs
@@ -8,7 +8,7 @@ where
 
 import Data.Coerce
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error.CodegenError
 import Language.Mimsa.Types.Identifiers

--- a/compiler/src/Language/Mimsa/Codegen/Newtype.hs
+++ b/compiler/src/Language/Mimsa/Codegen/Newtype.hs
@@ -7,8 +7,8 @@ module Language.Mimsa.Codegen.Newtype
 where
 
 import Control.Monad.Except
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error.CodegenError
 import Language.Mimsa.Types.Identifiers

--- a/compiler/src/Language/Mimsa/Codegen/Utils.hs
+++ b/compiler/src/Language/Mimsa/Codegen/Utils.hs
@@ -14,8 +14,8 @@ where
 import Control.Monad.Except
 import Control.Monad.State
 import qualified Data.List.NonEmpty as NE
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Semigroup
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.Error

--- a/compiler/src/Language/Mimsa/ExprUtils.hs
+++ b/compiler/src/Language/Mimsa/ExprUtils.hs
@@ -13,7 +13,7 @@ module Language.Mimsa.ExprUtils
 where
 
 import Data.Bifunctor (second)
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Types.AST.Expr (Expr (..))
 import Language.Mimsa.Types.AST.Identifier
 import Language.Mimsa.Types.AST.Pattern

--- a/compiler/src/Language/Mimsa/Interpreter/Interpret.hs
+++ b/compiler/src/Language/Mimsa/Interpreter/Interpret.hs
@@ -2,7 +2,7 @@ module Language.Mimsa.Interpreter.Interpret (interpret, addEmptyStackFrames) whe
 
 import Control.Monad.Reader
 import Data.Functor
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import Language.Mimsa.Interpreter.App
 import Language.Mimsa.Interpreter.If
 import Language.Mimsa.Interpreter.Infix

--- a/compiler/src/Language/Mimsa/Interpreter/Monad.hs
+++ b/compiler/src/Language/Mimsa/Interpreter/Monad.hs
@@ -11,7 +11,7 @@ where
 
 import Control.Monad.Except
 import Control.Monad.Reader
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Interpreter.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error.InterpreterError

--- a/compiler/src/Language/Mimsa/Interpreter/PatternMatch.hs
+++ b/compiler/src/Language/Mimsa/Interpreter/PatternMatch.hs
@@ -7,7 +7,7 @@ module Language.Mimsa.Interpreter.PatternMatch
 where
 
 import Control.Monad.Except
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
 import Data.Monoid
 import qualified Data.Set as S

--- a/compiler/src/Language/Mimsa/Interpreter/RecordAccess.hs
+++ b/compiler/src/Language/Mimsa/Interpreter/RecordAccess.hs
@@ -1,7 +1,7 @@
 module Language.Mimsa.Interpreter.RecordAccess (interpretRecordAccess) where
 
 import Control.Monad.Except
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Interpreter.Types
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error.InterpreterError

--- a/compiler/src/Language/Mimsa/Interpreter/Types.hs
+++ b/compiler/src/Language/Mimsa/Interpreter/Types.hs
@@ -10,7 +10,7 @@ module Language.Mimsa.Interpreter.Types
 where
 
 import Control.Monad.Reader
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error.InterpreterError
 import Language.Mimsa.Types.Interpreter.Stack

--- a/compiler/src/Language/Mimsa/Modules/Check.hs
+++ b/compiler/src/Language/Mimsa/Modules/Check.hs
@@ -10,8 +10,8 @@ module Language.Mimsa.Modules.Check
   )
 where
 
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Language.Mimsa.Typechecker.Elaborate
 import Language.Mimsa.Types.AST

--- a/compiler/src/Language/Mimsa/Modules/Dependencies.hs
+++ b/compiler/src/Language/Mimsa/Modules/Dependencies.hs
@@ -14,8 +14,8 @@ where
 -- work out the dependencies between definitions inside a module
 
 import Control.Monad.Except
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Maybe
 import Data.Monoid (First (..))
 import Data.Set (Set)

--- a/compiler/src/Language/Mimsa/Modules/FromParts.hs
+++ b/compiler/src/Language/Mimsa/Modules/FromParts.hs
@@ -8,8 +8,8 @@ module Language.Mimsa.Modules.FromParts (addModulePart, moduleFromModuleParts, e
 
 import Control.Monad.Except
 import Data.Coerce
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Language.Mimsa.Modules.Monad
 import Language.Mimsa.Parser.Module

--- a/compiler/src/Language/Mimsa/Modules/Monad.hs
+++ b/compiler/src/Language/Mimsa/Modules/Monad.hs
@@ -15,8 +15,8 @@ where
 import Control.Monad.Except
 import Data.Coerce
 import Data.Foldable
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error

--- a/compiler/src/Language/Mimsa/Modules/Parse.hs
+++ b/compiler/src/Language/Mimsa/Modules/Parse.hs
@@ -5,7 +5,7 @@ module Language.Mimsa.Modules.Parse (parseModule) where
 
 import Control.Monad.Except
 import Data.Bifunctor
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import Data.Text (Text)
 import Language.Mimsa.Modules.FromParts
 import qualified Language.Mimsa.Parser.Module as Parser

--- a/compiler/src/Language/Mimsa/Modules/Pretty.hs
+++ b/compiler/src/Language/Mimsa/Modules/Pretty.hs
@@ -2,8 +2,8 @@
 
 module Language.Mimsa.Modules.Pretty (modulePretty) where
 
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Language.Mimsa.Printer
 import Language.Mimsa.Typechecker.Elaborate

--- a/compiler/src/Language/Mimsa/Modules/ToStoreExprs.hs
+++ b/compiler/src/Language/Mimsa/Modules/ToStoreExprs.hs
@@ -11,8 +11,8 @@ import Control.Monad.Except
 import Control.Monad.Identity
 import Data.Bifunctor
 import Data.Functor (($>))
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Maybe
 import Data.Set (Set)
 import qualified Data.Set as S

--- a/compiler/src/Language/Mimsa/Modules/Typecheck.hs
+++ b/compiler/src/Language/Mimsa/Modules/Typecheck.hs
@@ -10,8 +10,8 @@ import Control.Monad.Except
 import Data.Bifunctor
 import Data.Coerce
 import Data.Foldable
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Maybe
 import Data.Set (Set)
 import qualified Data.Set as S

--- a/compiler/src/Language/Mimsa/Modules/Uses.hs
+++ b/compiler/src/Language/Mimsa/Modules/Uses.hs
@@ -7,7 +7,7 @@ module Language.Mimsa.Modules.Uses
   )
 where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import qualified Language.Mimsa.TypeUtils as MT

--- a/compiler/src/Language/Mimsa/Parser/Language.hs
+++ b/compiler/src/Language/Mimsa/Parser/Language.hs
@@ -19,7 +19,7 @@ module Language.Mimsa.Parser.Language
 where
 
 import Data.Functor (($>))
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import Language.Mimsa.Parser.Helpers (addLocation, chainl1, inBrackets, orInBrackets, parseAndFormat, withLocation)
 import Language.Mimsa.Parser.Identifier

--- a/compiler/src/Language/Mimsa/Parser/MonoType.hs
+++ b/compiler/src/Language/Mimsa/Parser/MonoType.hs
@@ -11,8 +11,8 @@ import Control.Monad ((>=>))
 import Control.Monad.Combinators.Expr
 import qualified Data.Char as Char
 import Data.Functor (($>))
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)

--- a/compiler/src/Language/Mimsa/Parser/Pattern.hs
+++ b/compiler/src/Language/Mimsa/Parser/Pattern.hs
@@ -7,7 +7,7 @@ module Language.Mimsa.Parser.Pattern
 where
 
 import Data.Either (partitionEithers)
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Parser.Helpers
 import Language.Mimsa.Parser.Identifiers (moduleNameParser, nameParser, tyConParser)
 import Language.Mimsa.Parser.Lexeme

--- a/compiler/src/Language/Mimsa/Parser/TypeDecl.hs
+++ b/compiler/src/Language/Mimsa/Parser/TypeDecl.hs
@@ -7,8 +7,8 @@ module Language.Mimsa.Parser.TypeDecl
 where
 
 import Data.Functor (($>))
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import Language.Mimsa.Parser.Identifiers
 import Language.Mimsa.Parser.Lexeme

--- a/compiler/src/Language/Mimsa/Printer.hs
+++ b/compiler/src/Language/Mimsa/Printer.hs
@@ -11,8 +11,8 @@ where
 -- prettyPrint is for debug output
 -- prettyDoc returns a Prettyprinter doc for nicer output
 
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)

--- a/compiler/src/Language/Mimsa/Project/Helpers.hs
+++ b/compiler/src/Language/Mimsa/Project/Helpers.hs
@@ -41,8 +41,8 @@ import Data.Bifunctor
 import Data.Coerce
 import Data.Either
 import qualified Data.List.NonEmpty as NE
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Language.Mimsa.Modules.HashModule

--- a/compiler/src/Language/Mimsa/Project/Stdlib.hs
+++ b/compiler/src/Language/Mimsa/Project/Stdlib.hs
@@ -13,8 +13,8 @@ module Language.Mimsa.Project.Stdlib
 where
 
 import Data.Functor
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Language.Mimsa.Actions.AddUnitTest as Actions

--- a/compiler/src/Language/Mimsa/Project/TypeSearch.hs
+++ b/compiler/src/Language/Mimsa/Project/TypeSearch.hs
@@ -13,8 +13,8 @@ import Data.Bifunctor (first)
 import Data.Either (isRight)
 import Data.Functor
 import qualified Data.List.NonEmpty as NE
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import Language.Mimsa.Parser.Language
 import Language.Mimsa.Typechecker.NormaliseTypes

--- a/compiler/src/Language/Mimsa/Project/Usages.hs
+++ b/compiler/src/Language/Mimsa/Project/Usages.hs
@@ -3,8 +3,8 @@
 module Language.Mimsa.Project.Usages where
 
 import Data.Bifunctor
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Language.Mimsa.Project.Helpers (getCurrentBindings)

--- a/compiler/src/Language/Mimsa/Project/Versions.hs
+++ b/compiler/src/Language/Mimsa/Project/Versions.hs
@@ -10,7 +10,7 @@ import Control.Monad.Except
 import Data.Bifunctor (first)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Project

--- a/compiler/src/Language/Mimsa/Store/DepGraph.hs
+++ b/compiler/src/Language/Mimsa/Store/DepGraph.hs
@@ -9,8 +9,8 @@ module Language.Mimsa.Store.DepGraph
   )
 where
 
-import Data.Map ((!))
-import qualified Data.Map as M
+import Data.Map.Strict ((!))
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/compiler/src/Language/Mimsa/Store/ExtractTypes.hs
+++ b/compiler/src/Language/Mimsa/Store/ExtractTypes.hs
@@ -8,7 +8,7 @@ module Language.Mimsa.Store.ExtractTypes
 where
 
 import Data.Coerce
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Language.Mimsa.TypeUtils

--- a/compiler/src/Language/Mimsa/Store/ExtractVars.hs
+++ b/compiler/src/Language/Mimsa/Store/ExtractVars.hs
@@ -3,7 +3,7 @@ module Language.Mimsa.Store.ExtractVars
   )
 where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Language.Mimsa.Types.AST

--- a/compiler/src/Language/Mimsa/Store/Helpers.hs
+++ b/compiler/src/Language/Mimsa/Store/Helpers.hs
@@ -3,7 +3,7 @@
 module Language.Mimsa.Store.Helpers where
 
 import Control.Monad.Except
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Types.Error.StoreError
 import Language.Mimsa.Types.Store
 

--- a/compiler/src/Language/Mimsa/Store/Persistence.hs
+++ b/compiler/src/Language/Mimsa/Store/Persistence.hs
@@ -12,8 +12,8 @@ where
 
 import Control.Monad.Except
 import Control.Monad.Logger
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Language.Mimsa.Project.Helpers

--- a/compiler/src/Language/Mimsa/Store/ResolveDataTypes.hs
+++ b/compiler/src/Language/Mimsa/Store/ResolveDataTypes.hs
@@ -3,8 +3,8 @@
 module Language.Mimsa.Store.ResolveDataTypes (resolveDataTypes, createTypeMap, storeExprToDataTypes) where
 
 import Control.Monad.Except
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Language.Mimsa.Store.ExtractTypes
 import Language.Mimsa.Store.Helpers

--- a/compiler/src/Language/Mimsa/Store/ResolvedDeps.hs
+++ b/compiler/src/Language/Mimsa/Store/ResolvedDeps.hs
@@ -6,8 +6,8 @@ module Language.Mimsa.Store.ResolvedDeps
 where
 
 import Data.Either (partitionEithers)
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Maybe
 import qualified Data.Set as S
 import Language.Mimsa.Store.ExtractTypes

--- a/compiler/src/Language/Mimsa/Store/Resolver.hs
+++ b/compiler/src/Language/Mimsa/Store/Resolver.hs
@@ -6,8 +6,8 @@ module Language.Mimsa.Store.Resolver
 where
 
 import Data.Coerce
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Maybe (catMaybes, isJust)
 import qualified Data.Set as S
 import Language.Mimsa.Store.ExtractTypes (extractTypes)

--- a/compiler/src/Language/Mimsa/Store/Storage.hs
+++ b/compiler/src/Language/Mimsa/Store/Storage.hs
@@ -27,8 +27,8 @@ import qualified Data.ByteString.Lazy as BS
 import Data.Coerce
 import Data.Foldable
 import Data.Functor
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Language.Mimsa.Actions.Types as Actions

--- a/compiler/src/Language/Mimsa/Store/Substitutor.hs
+++ b/compiler/src/Language/Mimsa/Store/Substitutor.hs
@@ -1,7 +1,7 @@
 module Language.Mimsa.Store.Substitutor (getExprPairs) where
 
 import Control.Monad (join)
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Store
 

--- a/compiler/src/Language/Mimsa/Store/UpdateDeps.hs
+++ b/compiler/src/Language/Mimsa/Store/UpdateDeps.hs
@@ -5,8 +5,8 @@ module Language.Mimsa.Store.UpdateDeps
 where
 
 import Data.Bifunctor
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Language.Mimsa.Actions.Monad as Actions
 import qualified Language.Mimsa.Actions.Typecheck as Actions
 import Language.Mimsa.Printer

--- a/compiler/src/Language/Mimsa/Tests/Generate.hs
+++ b/compiler/src/Language/Mimsa/Tests/Generate.hs
@@ -8,8 +8,8 @@ where
 
 import Data.Coerce
 import Data.Functor
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
 import Language.Mimsa.Store.ExtractTypes

--- a/compiler/src/Language/Mimsa/Tests/Test.hs
+++ b/compiler/src/Language/Mimsa/Tests/Test.hs
@@ -12,8 +12,8 @@ where
 
 import Control.Monad.Except
 import qualified Data.List.NonEmpty as NE
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Monoid (All (..), getAll)
 import Data.Set (Set)
 import qualified Data.Set as S

--- a/compiler/src/Language/Mimsa/Transform/BetaReduce.hs
+++ b/compiler/src/Language/Mimsa/Transform/BetaReduce.hs
@@ -1,6 +1,6 @@
 module Language.Mimsa.Transform.BetaReduce (betaReduce) where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.ExprUtils
 import Language.Mimsa.Transform.Shared
 import Language.Mimsa.Types.AST

--- a/compiler/src/Language/Mimsa/Transform/FindUnused.hs
+++ b/compiler/src/Language/Mimsa/Transform/FindUnused.hs
@@ -1,6 +1,6 @@
 module Language.Mimsa.Transform.FindUnused (findUnused, removeBindings, removeUnused) where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Language.Mimsa.ExprUtils

--- a/compiler/src/Language/Mimsa/Transform/FindUses.hs
+++ b/compiler/src/Language/Mimsa/Transform/FindUses.hs
@@ -3,8 +3,8 @@
 
 module Language.Mimsa.Transform.FindUses (findUses, memberInUses, numberOfUses, Uses (..)) where
 
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Monoid
 import Language.Mimsa.ExprUtils
 import Language.Mimsa.Types.AST

--- a/compiler/src/Language/Mimsa/Transform/Inliner.hs
+++ b/compiler/src/Language/Mimsa/Transform/Inliner.hs
@@ -12,8 +12,8 @@ where
 
 import Control.Monad.Reader
 import Control.Monad.State
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Maybe
 import Language.Mimsa.ExprUtils
 import Language.Mimsa.Transform.FindUses

--- a/compiler/src/Language/Mimsa/Transform/TrimDeps.hs
+++ b/compiler/src/Language/Mimsa/Transform/TrimDeps.hs
@@ -1,6 +1,6 @@
 module Language.Mimsa.Transform.TrimDeps where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Transform.FindUses
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers

--- a/compiler/src/Language/Mimsa/TypeUtils.hs
+++ b/compiler/src/Language/Mimsa/TypeUtils.hs
@@ -1,6 +1,6 @@
 module Language.Mimsa.TypeUtils (withMonoid, mapMonoType) where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Types.Typechecker
 
 withMonoid :: (Monoid m) => (Type ann -> m) -> Type ann -> m

--- a/compiler/src/Language/Mimsa/Typechecker/BuiltIns.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/BuiltIns.hs
@@ -7,8 +7,8 @@ module Language.Mimsa.Typechecker.BuiltIns
   )
 where
 
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Types.Identifiers.TypeName
 import Language.Mimsa.Types.Typechecker
 

--- a/compiler/src/Language/Mimsa/Typechecker/CreateEnv.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/CreateEnv.hs
@@ -5,8 +5,8 @@ where
 
 import Data.Bifunctor
 import Data.Coerce
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Language.Mimsa.Typechecker.BuiltIns
 import Language.Mimsa.Typechecker.Unify

--- a/compiler/src/Language/Mimsa/Typechecker/DataTypes.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/DataTypes.hs
@@ -17,8 +17,8 @@ import Data.Bifunctor
 import Data.Coerce
 import Data.Foldable (foldl', traverse_)
 import Data.Functor (($>))
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Language.Mimsa.Typechecker.BuiltIns

--- a/compiler/src/Language/Mimsa/Typechecker/Elaborate.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Elaborate.hs
@@ -17,7 +17,7 @@ import Data.Bifunctor
 import Data.Foldable
 import Data.Functor
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.ExprUtils
 import Language.Mimsa.Typechecker.DataTypes
 import Language.Mimsa.Typechecker.Environment

--- a/compiler/src/Language/Mimsa/Typechecker/Environment.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Environment.hs
@@ -3,8 +3,8 @@
 module Language.Mimsa.Typechecker.Environment (lookupConstructor) where
 
 import Control.Monad.Except
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Identifiers

--- a/compiler/src/Language/Mimsa/Typechecker/Exhaustiveness.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Exhaustiveness.hs
@@ -15,8 +15,8 @@ import Control.Monad.Except
 import Data.Foldable
 import Data.Functor
 import Data.List (nub)
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Language.Mimsa.Printer
 import Language.Mimsa.Typechecker.Environment

--- a/compiler/src/Language/Mimsa/Typechecker/Generalise.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Generalise.hs
@@ -6,7 +6,7 @@ module Language.Mimsa.Typechecker.Generalise
 where
 
 import Data.List ((\\))
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Typechecker

--- a/compiler/src/Language/Mimsa/Typechecker/NormaliseTypes.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/NormaliseTypes.hs
@@ -1,8 +1,8 @@
 module Language.Mimsa.Typechecker.NormaliseTypes (normaliseType) where
 
 import Control.Monad.State
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Typechecker
 

--- a/compiler/src/Language/Mimsa/Typechecker/NumberVars.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/NumberVars.hs
@@ -11,8 +11,8 @@ where
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Language.Mimsa.Types.AST

--- a/compiler/src/Language/Mimsa/Typechecker/ScopeTypeVar.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/ScopeTypeVar.hs
@@ -5,8 +5,8 @@ module Language.Mimsa.Typechecker.ScopeTypeVar (freshNamedType) where
 
 import Control.Monad.State
 import Data.Coerce
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Language.Mimsa.Store.ExtractTypes

--- a/compiler/src/Language/Mimsa/Typechecker/TcMonad.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/TcMonad.hs
@@ -17,8 +17,8 @@ import Control.Monad.Except
 import Control.Monad.State (MonadState, gets, modify)
 import Data.Coerce
 import Data.Functor
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Maybe
 import Language.Mimsa.Typechecker.Generalise
 import Language.Mimsa.Types.AST

--- a/compiler/src/Language/Mimsa/Typechecker/Typecheck.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Typecheck.hs
@@ -9,7 +9,7 @@ where
 import Control.Monad.Except
 import Control.Monad.State (State, runState)
 import Control.Monad.Writer
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import Language.Mimsa.Typechecker.Elaborate
 import Language.Mimsa.Typechecker.Solve
 import Language.Mimsa.Typechecker.TcMonad

--- a/compiler/src/Language/Mimsa/Typechecker/TypedHoles.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/TypedHoles.hs
@@ -9,8 +9,8 @@ where
 
 import Control.Monad.Except
 import Control.Monad.State
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import Language.Mimsa.Project.TypeSearch
 import Language.Mimsa.Typechecker.NormaliseTypes

--- a/compiler/src/Language/Mimsa/Typechecker/Unify.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Unify.hs
@@ -11,8 +11,8 @@ where
 import Control.Monad.Except
 import Control.Monad.State
 import Data.Functor (($>))
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Language.Mimsa.Typechecker.Generalise
 import Language.Mimsa.Typechecker.TcMonad

--- a/compiler/src/Language/Mimsa/Types/AST/DataType.hs
+++ b/compiler/src/Language/Mimsa/Types/AST/DataType.hs
@@ -9,8 +9,8 @@ module Language.Mimsa.Types.AST.DataType
 where
 
 import qualified Data.Aeson as JSON
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import GHC.Generics (Generic)
 import Language.Mimsa.Printer (Printer (prettyDoc))
 import Language.Mimsa.Types.Identifiers

--- a/compiler/src/Language/Mimsa/Types/AST/Expr.hs
+++ b/compiler/src/Language/Mimsa/Types/AST/Expr.hs
@@ -18,8 +18,8 @@ import Data.Bifunctor (first)
 import Data.Bifunctor.TH
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NE
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import GHC.Generics (Generic)
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST.DataType (DataType)

--- a/compiler/src/Language/Mimsa/Types/AST/Pattern.hs
+++ b/compiler/src/Language/Mimsa/Types/AST/Pattern.hs
@@ -17,8 +17,8 @@ where
 
 import qualified Data.Aeson as JSON
 import Data.Bifunctor.TH
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import GHC.Generics
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST.Literal

--- a/compiler/src/Language/Mimsa/Types/Error/InterpreterError.hs
+++ b/compiler/src/Language/Mimsa/Types/Error/InterpreterError.hs
@@ -3,8 +3,8 @@
 
 module Language.Mimsa.Types.Error.InterpreterError (InterpreterError (..)) where
 
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST

--- a/compiler/src/Language/Mimsa/Types/Error/ResolverError.hs
+++ b/compiler/src/Language/Mimsa/Types/Error/ResolverError.hs
@@ -3,7 +3,7 @@
 
 module Language.Mimsa.Types.Error.ResolverError where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import Language.Mimsa.Printer (Printer (prettyPrint))
 import Language.Mimsa.Types.Identifiers (Name, TyCon)

--- a/compiler/src/Language/Mimsa/Types/Error/TypeError.hs
+++ b/compiler/src/Language/Mimsa/Types/Error/TypeError.hs
@@ -16,8 +16,8 @@ module Language.Mimsa.Types.Error.TypeError
 where
 
 import Data.Foldable (fold)
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Maybe
 import Data.Set (Set)
 import qualified Data.Set as S

--- a/compiler/src/Language/Mimsa/Types/Interpreter/Stack.hs
+++ b/compiler/src/Language/Mimsa/Types/Interpreter/Stack.hs
@@ -3,8 +3,8 @@
 
 module Language.Mimsa.Types.Interpreter.Stack (StackFrame (..), ExprData (..)) where
 
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST

--- a/compiler/src/Language/Mimsa/Types/Modules/Module.hs
+++ b/compiler/src/Language/Mimsa/Types/Modules/Module.hs
@@ -13,8 +13,8 @@ module Language.Mimsa.Types.Modules.Module
 where
 
 import qualified Data.Aeson as JSON
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import GHC.Generics

--- a/compiler/src/Language/Mimsa/Types/Project/Project.hs
+++ b/compiler/src/Language/Mimsa/Types/Project/Project.hs
@@ -4,7 +4,7 @@
 
 module Language.Mimsa.Types.Project.Project where
 
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import GHC.Generics (Generic)
 import Language.Mimsa.Types.Modules
 import Language.Mimsa.Types.Project.Versioned

--- a/compiler/src/Language/Mimsa/Types/Project/SaveProject.hs
+++ b/compiler/src/Language/Mimsa/Types/Project/SaveProject.hs
@@ -10,7 +10,7 @@ module Language.Mimsa.Types.Project.SaveProject where
 import Control.Monad (mzero)
 import Data.Aeson
 import qualified Data.Aeson as JSON
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import GHC.Generics (Generic)
 import Language.Mimsa.Types.Project.Versioned
 import Language.Mimsa.Types.Store

--- a/compiler/src/Language/Mimsa/Types/Project/VersionedMap.hs
+++ b/compiler/src/Language/Mimsa/Types/Project/VersionedMap.hs
@@ -7,8 +7,8 @@ import qualified Data.Aeson as JSON
 import Data.List (nub)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 
 ------
 -- A versioned Map is a Map whose contents are a unique nonempty list

--- a/compiler/src/Language/Mimsa/Types/Store/Bindings.hs
+++ b/compiler/src/Language/Mimsa/Types/Store/Bindings.hs
@@ -5,8 +5,8 @@
 module Language.Mimsa.Types.Store.Bindings where
 
 import qualified Data.Aeson as JSON
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.Identifiers

--- a/compiler/src/Language/Mimsa/Types/Store/ResolvedDeps.hs
+++ b/compiler/src/Language/Mimsa/Types/Store/ResolvedDeps.hs
@@ -4,8 +4,8 @@
 
 module Language.Mimsa.Types.Store.ResolvedDeps where
 
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.Identifiers
 import Language.Mimsa.Types.Modules.ModuleName

--- a/compiler/src/Language/Mimsa/Types/Store/ResolvedTypeDeps.hs
+++ b/compiler/src/Language/Mimsa/Types/Store/ResolvedTypeDeps.hs
@@ -1,7 +1,7 @@
 module Language.Mimsa.Types.Store.ResolvedTypeDeps where
 
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Identifiers

--- a/compiler/src/Language/Mimsa/Types/Store/Store.hs
+++ b/compiler/src/Language/Mimsa/Types/Store/Store.hs
@@ -6,8 +6,8 @@
 module Language.Mimsa.Types.Store.Store where
 
 import qualified Data.Aeson as JSON
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.Store.ExprHash

--- a/compiler/src/Language/Mimsa/Types/Store/StoreExpression.hs
+++ b/compiler/src/Language/Mimsa/Types/Store/StoreExpression.hs
@@ -6,7 +6,7 @@
 module Language.Mimsa.Types.Store.StoreExpression where
 
 import qualified Data.Aeson as JSON
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import GHC.Generics
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST

--- a/compiler/src/Language/Mimsa/Types/Store/TypeBindings.hs
+++ b/compiler/src/Language/Mimsa/Types/Store/TypeBindings.hs
@@ -5,8 +5,8 @@
 module Language.Mimsa.Types.Store.TypeBindings where
 
 import qualified Data.Aeson as JSON
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import Language.Mimsa.Printer (Printer (prettyPrint))
 import Language.Mimsa.Types.Identifiers (TyCon)

--- a/compiler/src/Language/Mimsa/Types/Tests.hs
+++ b/compiler/src/Language/Mimsa/Types/Tests.hs
@@ -20,8 +20,8 @@ where
 
 import qualified Data.Aeson as JSON
 import Data.Either (partitionEithers)
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.OpenApi
 import Data.Set (Set)
 import qualified Data.Set as S

--- a/compiler/src/Language/Mimsa/Types/Typechecker/Environment.hs
+++ b/compiler/src/Language/Mimsa/Types/Typechecker/Environment.hs
@@ -3,7 +3,7 @@
 
 module Language.Mimsa.Types.Typechecker.Environment where
 
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST (DataType)
 import Language.Mimsa.Types.AST.InfixOp

--- a/compiler/src/Language/Mimsa/Types/Typechecker/MonoType.hs
+++ b/compiler/src/Language/Mimsa/Types/Typechecker/MonoType.hs
@@ -15,8 +15,8 @@ module Language.Mimsa.Types.Typechecker.MonoType
 where
 
 import qualified Data.Aeson as JSON
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import GHC.Generics
 import Language.Mimsa.Printer
 import Language.Mimsa.Types.AST.Annotation

--- a/compiler/src/Language/Mimsa/Types/Typechecker/Substitutions.hs
+++ b/compiler/src/Language/Mimsa/Types/Typechecker/Substitutions.hs
@@ -9,8 +9,8 @@ module Language.Mimsa.Types.Typechecker.Substitutions
 where
 
 import Data.Functor (($>))
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import Language.Mimsa.Printer

--- a/compiler/src/Language/Mimsa/Utils.hs
+++ b/compiler/src/Language/Mimsa/Utils.hs
@@ -1,8 +1,8 @@
 module Language.Mimsa.Utils (mapWithIndex, setMapMaybe, mapKeys, filterMapKeys, addNumbersToMap) where
 
 import Data.Bifunctor
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import Data.Maybe
 import Data.Set (Set)
 import qualified Data.Set as S

--- a/compiler/test/Test/Actions/BindExpression.hs
+++ b/compiler/test/Test/Actions/BindExpression.hs
@@ -8,7 +8,7 @@ where
 
 import Data.Either (isLeft, isRight)
 import Data.Functor
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Maybe (isJust)
 import qualified Data.Set as S
 import qualified Language.Mimsa.Actions.AddUnitTest as Actions

--- a/compiler/test/Test/Actions/Build.hs
+++ b/compiler/test/Test/Actions/Build.hs
@@ -7,7 +7,7 @@ module Test.Actions.Build
 where
 
 import Control.Monad.IO.Class
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Language.Mimsa.Actions.Helpers.Build as Actions

--- a/compiler/test/Test/Actions/Compile.hs
+++ b/compiler/test/Test/Actions/Compile.hs
@@ -9,7 +9,7 @@ where
 import Data.Either (isRight)
 import Data.Foldable
 import Data.Functor
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Language.Mimsa.Actions.Compile as Actions

--- a/compiler/test/Test/Actions/Optimise.hs
+++ b/compiler/test/Test/Actions/Optimise.hs
@@ -8,7 +8,7 @@ where
 
 import Data.Functor
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Language.Mimsa.Actions.Monad as Actions
 import qualified Language.Mimsa.Actions.Optimise as Actions
 import Language.Mimsa.Project.Versions

--- a/compiler/test/Test/Actions/Typecheck.hs
+++ b/compiler/test/Test/Actions/Typecheck.hs
@@ -7,7 +7,7 @@ module Test.Actions.Typecheck
 where
 
 import Data.Functor
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Language.Mimsa.Actions.Helpers.FindExistingBinding as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions
 import qualified Language.Mimsa.Actions.Typecheck as Actions

--- a/compiler/test/Test/Actions/Upgrade.hs
+++ b/compiler/test/Test/Actions/Upgrade.hs
@@ -8,7 +8,7 @@ where
 
 import Data.Either (isLeft)
 import Data.Functor
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Language.Mimsa.Actions.AddUnitTest as Actions
 import qualified Language.Mimsa.Actions.BindExpression as Actions
 import qualified Language.Mimsa.Actions.Monad as Actions

--- a/compiler/test/Test/Backend/ESModulesJS.hs
+++ b/compiler/test/Test/Backend/ESModulesJS.hs
@@ -10,7 +10,7 @@ import Data.Bifunctor
 import Data.Foldable
 import Data.Functor
 import Data.Hashable
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/compiler/test/Test/Backend/Typescript.hs
+++ b/compiler/test/Test/Backend/Typescript.hs
@@ -10,7 +10,7 @@ import Data.Bifunctor
 import Data.Foldable
 import Data.Functor
 import Data.Hashable
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/compiler/test/Test/Codegen/Shared.hs
+++ b/compiler/test/Test/Codegen/Shared.hs
@@ -24,7 +24,7 @@ where
 
 import Data.Bifunctor (first)
 import Data.Functor
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Language.Mimsa.Actions.Monad as Actions

--- a/compiler/test/Test/Data/Prelude.hs
+++ b/compiler/test/Test/Data/Prelude.hs
@@ -5,7 +5,7 @@ module Test.Data.Prelude (prelude, preludeHash) where
 -- hard coded basic Prelude module used for tests
 
 import Data.Functor
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Language.Mimsa.Modules.HashModule
 import Language.Mimsa.Types.AST

--- a/compiler/test/Test/Modules/Check.hs
+++ b/compiler/test/Test/Modules/Check.hs
@@ -9,8 +9,8 @@ where
 import Control.Monad.IO.Class
 import Data.Either (isLeft, isRight)
 import Data.Functor
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/compiler/test/Test/Modules/Test.hs
+++ b/compiler/test/Test/Modules/Test.hs
@@ -6,7 +6,7 @@ module Test.Modules.Test
 where
 
 import Data.Either (isLeft)
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Language.Mimsa.Actions.Modules.Check as Actions
 import qualified Language.Mimsa.Actions.Modules.RunTests as Actions

--- a/compiler/test/Test/Modules/ToStoreExprs.hs
+++ b/compiler/test/Test/Modules/ToStoreExprs.hs
@@ -6,7 +6,7 @@ module Test.Modules.ToStoreExprs
 where
 
 import Data.Functor
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Modules.HashModule
 import Language.Mimsa.Modules.Parse
 import Language.Mimsa.Modules.ToStoreExprs

--- a/compiler/test/Test/Modules/Uses.hs
+++ b/compiler/test/Test/Modules/Uses.hs
@@ -5,7 +5,7 @@ module Test.Modules.Uses
   )
 where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Language.Mimsa.Modules.Uses
 import Language.Mimsa.Types.AST

--- a/compiler/test/Test/Parser/MonoTypeParser.hs
+++ b/compiler/test/Test/Parser/MonoTypeParser.hs
@@ -8,7 +8,7 @@ where
 import Control.Monad.Except
 import Data.Either (isRight)
 import Data.Functor
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import Language.Mimsa.Parser.Helpers
 import Language.Mimsa.Parser.MonoType

--- a/compiler/test/Test/Parser/Syntax.hs
+++ b/compiler/test/Test/Parser/Syntax.hs
@@ -6,7 +6,7 @@ module Test.Parser.Syntax
 where
 
 import Data.Either (isLeft, isRight)
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import Language.Mimsa.ExprUtils
 import Language.Mimsa.Parser

--- a/compiler/test/Test/Prettier.hs
+++ b/compiler/test/Test/Prettier.hs
@@ -5,7 +5,7 @@ module Test.Prettier
   )
 where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Data.Text.IO as T
 import Language.Mimsa.Printer
 import Language.Mimsa.Typechecker.DataTypes

--- a/compiler/test/Test/Project/Stdlib.hs
+++ b/compiler/test/Test/Project/Stdlib.hs
@@ -9,7 +9,7 @@ import Control.Monad.IO.Class
 import Data.Coerce
 import Data.Either
 import Data.Foldable
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Language.Mimsa.Actions.Helpers.LookupExpression as Actions

--- a/compiler/test/Test/Project/TypeSearch.hs
+++ b/compiler/test/Test/Project/TypeSearch.hs
@@ -6,8 +6,8 @@ module Test.Project.TypeSearch
   )
 where
 
-import Data.Map (Map)
-import qualified Data.Map as M
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
 import qualified Data.Text as T
 import qualified Language.Mimsa.Actions.Monad as Actions
 import qualified Language.Mimsa.Actions.Typecheck as Actions

--- a/compiler/test/Test/Store/Resolver.hs
+++ b/compiler/test/Test/Store/Resolver.hs
@@ -6,7 +6,7 @@ module Test.Store.Resolver
   )
 where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
 import Language.Mimsa.Store.Resolver

--- a/compiler/test/Test/Store/UpdateDeps.hs
+++ b/compiler/test/Test/Store/UpdateDeps.hs
@@ -6,7 +6,7 @@ module Test.Store.UpdateDeps
 where
 
 import Data.Either (isLeft, isRight)
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Store.UpdateDeps
 import Language.Mimsa.Types.Identifiers ()
 import Language.Mimsa.Types.Store

--- a/compiler/test/Test/Tests/Properties.hs
+++ b/compiler/test/Test/Tests/Properties.hs
@@ -10,7 +10,7 @@ where
 import Control.Monad.IO.Class
 import Data.Either (isLeft, isRight)
 import Data.Functor
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Store.ResolveDataTypes
 import Language.Mimsa.Tests.Generate
 import Language.Mimsa.Tests.Helpers

--- a/compiler/test/Test/Tests/UnitTest.hs
+++ b/compiler/test/Test/Tests/UnitTest.hs
@@ -6,7 +6,7 @@ module Test.Tests.UnitTest
 where
 
 import Data.Either (isLeft)
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Project.Helpers
 import Language.Mimsa.Store
 import Language.Mimsa.Tests.Test

--- a/compiler/test/Test/Transform/FindUses.hs
+++ b/compiler/test/Test/Transform/FindUses.hs
@@ -6,7 +6,7 @@ module Test.Transform.FindUses
   )
 where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Monoid
 import Language.Mimsa.Transform.FindUses
 import Language.Mimsa.Types.AST

--- a/compiler/test/Test/Typechecker/Exhaustiveness.hs
+++ b/compiler/test/Test/Typechecker/Exhaustiveness.hs
@@ -8,7 +8,7 @@ where
 import Control.Monad.Except
 import Control.Monad.Identity
 import Data.Either
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Typechecker.Exhaustiveness
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Error

--- a/compiler/test/Test/Typechecker/NumberVars.hs
+++ b/compiler/test/Test/Typechecker/NumberVars.hs
@@ -8,7 +8,7 @@ module Test.Typechecker.NumberVars
 where
 
 import Data.Either
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Language.Mimsa.Typechecker.NumberVars
 import Language.Mimsa.Types.AST

--- a/compiler/test/Test/Typechecker/ScopeTypeVar.hs
+++ b/compiler/test/Test/Typechecker/ScopeTypeVar.hs
@@ -9,7 +9,7 @@ where
 import Control.Monad.Except
 import Control.Monad.Identity
 import Control.Monad.State.Strict
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Typechecker.ScopeTypeVar
 import Language.Mimsa.Typechecker.TcMonad
 import Language.Mimsa.Types.Error

--- a/compiler/test/Test/Typechecker/Substitutions.hs
+++ b/compiler/test/Test/Typechecker/Substitutions.hs
@@ -5,7 +5,7 @@ module Test.Typechecker.Substitutions
   )
 where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Types.AST
 import Language.Mimsa.Types.Typechecker
 import Test.Hspec

--- a/compiler/test/Test/Typechecker/Typecheck.hs
+++ b/compiler/test/Test/Typechecker/Typecheck.hs
@@ -7,7 +7,7 @@ where
 
 import Data.Bifunctor
 import Data.Either (isLeft)
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import Language.Mimsa.Typechecker.DataTypes
 import Language.Mimsa.Typechecker.Elaborate

--- a/compiler/test/Test/Typechecker/Unify.hs
+++ b/compiler/test/Test/Typechecker/Unify.hs
@@ -9,7 +9,7 @@ where
 import Control.Monad.Except
 import Control.Monad.State.Strict (runState)
 import Data.Either (isLeft, isRight)
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Language.Mimsa.Typechecker.TcMonad
 import Language.Mimsa.Typechecker.Unify
 import Language.Mimsa.Types.Error

--- a/compiler/test/Test/Utils/Helpers.hs
+++ b/compiler/test/Test/Utils/Helpers.hs
@@ -4,7 +4,7 @@ module Test.Utils.Helpers where
 
 import Data.Bifunctor (first)
 import Data.Functor
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Language.Mimsa.Actions.Monad as Actions


### PR DESCRIPTION
Thanks to https://kodimensional.dev/space-leak#use-strict-containers

Before:

```


benchmarking build stdlib/allFns
time                 203.0 ms   (197.9 ms .. 207.2 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 199.8 ms   (198.5 ms .. 201.2 ms)
std dev              1.814 ms   (1.310 ms .. 2.374 ms)
variance introduced by outliers: 14% (moderately inflated)

benchmarking compilation/compile either fmap test
time                 10.86 ms   (10.80 ms .. 10.92 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 10.99 ms   (10.95 ms .. 11.04 ms)
std dev              124.8 μs   (93.54 μs .. 171.3 μs)

benchmarking evaluate/evaluate big looping thing
time                 110.8 ms   (108.5 ms .. 113.6 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 107.7 ms   (106.7 ms .. 109.4 ms)
std dev              1.970 ms   (1.454 ms .. 2.431 ms)

benchmarking evaluate/evaluate parsing
time                 76.45 ms   (75.64 ms .. 77.25 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 75.29 ms   (74.88 ms .. 75.69 ms)
std dev              743.5 μs   (598.4 μs .. 954.0 μs)

benchmarking evaluate/evaluate parsing 2
time                 307.1 ms   (304.0 ms .. 309.7 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 309.4 ms   (308.2 ms .. 310.5 ms)
std dev              1.321 ms   (777.8 μs .. 2.039 ms)
variance introduced by outliers: 16% (moderately inflated)
```

After:
```
benchmarking build stdlib/allFns
time                 184.6 ms   (183.1 ms .. 185.9 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 187.4 ms   (186.3 ms .. 189.5 ms)
std dev              2.102 ms   (563.5 μs .. 3.137 ms)
variance introduced by outliers: 14% (moderately inflated)

benchmarking compilation/compile either fmap test
time                 9.968 ms   (9.930 ms .. 10.01 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 10.05 ms   (10.02 ms .. 10.10 ms)
std dev              82.83 μs   (56.34 μs .. 138.1 μs)

benchmarking evaluate/evaluate big looping thing
time                 97.33 ms   (96.58 ms .. 98.55 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 97.44 ms   (97.07 ms .. 97.82 ms)
std dev              610.7 μs   (490.5 μs .. 806.1 μs)

benchmarking evaluate/evaluate parsing
time                 69.64 ms   (68.95 ms .. 70.23 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 70.24 ms   (69.94 ms .. 70.52 ms)
std dev              516.4 μs   (390.8 μs .. 696.4 μs)

benchmarking evaluate/evaluate parsing 2
time                 282.5 ms   (281.0 ms .. 285.1 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 284.5 ms   (283.5 ms .. 285.1 ms)
std dev              1.110 ms   (620.2 μs .. 1.498 ms)
variance introduced by outliers: 16% (moderately inflated)
```