### PR TITLE
Save repl contents to new module

### DIFF
--- a/compiler/src/Language/Mimsa/Modules/Pretty.hs
+++ b/compiler/src/Language/Mimsa/Modules/Pretty.hs
@@ -13,8 +13,7 @@ import Prettyprinter
 -- | display types for module in a nice way
 modulePretty :: Module (Type Annotation) -> Doc a
 modulePretty mod' =
-  let useful = filterExported mod'
-      prettyExp (k, a) = indentMulti 2 (prettyDoc k <> ":" <+> prettyDoc (getTypeFromAnn a))
+  let prettyExp (k, a) = indentMulti 2 (prettyDoc k <> ":" <+> prettyDoc (getTypeFromAnn a))
       prettyType (k, a) = indentMulti 2 (prettyDoc k <> ":" <+> prettyDoc a)
    in align
         ( encloseSep
@@ -22,10 +21,10 @@ modulePretty mod' =
             rbrace
             comma
             ( ( prettyExp
-                  <$> M.toList (moExpressions useful)
+                  <$> M.toList (moExpressions mod')
               )
                 <> ( prettyType
-                       <$> M.toList (moDataTypes useful)
+                       <$> M.toList (moDataTypes mod')
                    )
             )
         )

--- a/compiler/src/Language/Mimsa/Modules/Pretty.hs
+++ b/compiler/src/Language/Mimsa/Modules/Pretty.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Language.Mimsa.Modules.Pretty (modulePretty) where
+module Language.Mimsa.Modules.Pretty (modulePretty, filterExported) where
 
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M

--- a/repl/repl.cabal
+++ b/repl/repl.cabal
@@ -32,6 +32,7 @@ executable mimsa-repl
       Init.Main
       Repl.Actions
       Repl.Actions.Bindings
+      Repl.Actions.BindModule
       Repl.Actions.Compile
       Repl.Actions.Evaluate
       Repl.Actions.ListModules

--- a/repl/repl.cabal
+++ b/repl/repl.cabal
@@ -30,17 +30,17 @@ executable mimsa-repl
       Compile.Main
       Eval.Main
       Init.Main
-      ReplNew.Actions
-      ReplNew.Actions.Bindings
-      ReplNew.Actions.Compile
-      ReplNew.Actions.Evaluate
-      ReplNew.Actions.ListModules
-      ReplNew.Helpers
-      ReplNew.Main
-      ReplNew.Parser
-      ReplNew.Persistence
-      ReplNew.ReplM
-      ReplNew.Types
+      Repl.Actions
+      Repl.Actions.Bindings
+      Repl.Actions.Compile
+      Repl.Actions.Evaluate
+      Repl.Actions.ListModules
+      Repl.Helpers
+      Repl.Main
+      Repl.Parser
+      Repl.Persistence
+      Repl.ReplM
+      Repl.Types
       Shared.LoadProject
   hs-source-dirs:
       repl

--- a/repl/repl/Check/Main.hs
+++ b/repl/repl/Check/Main.hs
@@ -17,9 +17,9 @@ import Language.Mimsa.Project.Stdlib
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Store.RootPath
-import ReplNew.Helpers
-import ReplNew.ReplM
-import ReplNew.Types
+import Repl.Helpers
+import Repl.ReplM
+import Repl.Types
 import qualified Shared.LoadProject as Shared
 import System.Directory
 import System.Exit

--- a/repl/repl/Compile/Main.hs
+++ b/repl/repl/Compile/Main.hs
@@ -13,9 +13,9 @@ import Language.Mimsa.Backend.Types
 import Language.Mimsa.Core
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Store.RootPath
-import ReplNew.Helpers
-import ReplNew.ReplM
-import ReplNew.Types
+import Repl.Helpers
+import Repl.ReplM
+import Repl.Types
 import qualified Shared.LoadProject as Shared
 import System.Directory
 import System.Exit

--- a/repl/repl/Eval/Main.hs
+++ b/repl/repl/Eval/Main.hs
@@ -12,9 +12,9 @@ import Language.Mimsa.Core
 import Language.Mimsa.Project.Stdlib
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Store.RootPath
-import ReplNew.Helpers
-import ReplNew.ReplM
-import ReplNew.Types
+import Repl.Helpers
+import Repl.ReplM
+import Repl.Types
 import qualified Shared.LoadProject as Shared
 import System.Directory
 import System.Exit

--- a/repl/repl/Init/Main.hs
+++ b/repl/repl/Init/Main.hs
@@ -14,9 +14,9 @@ import Language.Mimsa.Store.Storage
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Store.RootPath
-import ReplNew.Persistence
-import ReplNew.ReplM
-import ReplNew.Types
+import Repl.Persistence
+import Repl.ReplM
+import Repl.Types
 import System.Directory
 import Prelude hiding (init)
 

--- a/repl/repl/Main.hs
+++ b/repl/repl/Main.hs
@@ -8,7 +8,7 @@ import qualified Eval.Main as Eval
 import qualified Init.Main as Init
 import Language.Mimsa.Backend.Types
 import qualified Options.Applicative as Opt
-import qualified ReplNew.Main as ReplNew
+import qualified Repl.Main as Repl
 import System.IO
 
 -- | this runs the repl
@@ -18,7 +18,7 @@ parseShowLogs =
     <|> pure False
 
 data AppAction
-  = ReplNew
+  = Repl
   | Init
   | Check Text -- check if a file is `ok`
   | Eval Text -- evaluate an expression
@@ -30,7 +30,7 @@ parseAppAction =
     ( Opt.command
         "repl"
         ( Opt.info
-            (pure ReplNew)
+            (pure Repl)
             (Opt.progDesc "Start new module-based Mimsa repl")
         )
         <> Opt.command
@@ -108,7 +108,7 @@ main = do
       (Opt.info (optionsParse <**> Opt.helper) Opt.fullDesc)
   case action of
     Init -> Init.init showLogs
-    ReplNew -> ReplNew.repl showLogs
+    Repl -> Repl.repl showLogs
     Check filePath -> Check.check showLogs filePath
     Eval expr -> Eval.eval showLogs expr
     Compile be -> Compile.compile be showLogs

--- a/repl/repl/Repl/Actions.hs
+++ b/repl/repl/Repl/Actions.hs
@@ -12,6 +12,7 @@ import Data.Text (Text)
 import Language.Mimsa.Core
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Project
+import Repl.Actions.BindModule
 import Repl.Actions.Bindings
 import Repl.Actions.Compile
 import Repl.Actions.Evaluate
@@ -33,6 +34,8 @@ doReplAction prj action =
       catchMimsaError prj (doListModules prj modName $> prj)
     ListBindings ->
       catchMimsaError prj (doListBindings $> prj)
+    BindModule modName ->
+      catchMimsaError prj (doBindModule prj modName)
     (Evaluate expr) ->
       catchMimsaError prj (doEvaluate prj expr $> prj)
     (AddBinding modItem) ->
@@ -52,6 +55,7 @@ doHelp = do
   replOutput @Text ":modules <moduleName> - show a list of modules in the project or details of a module"
   replOutput @Text ":list - show a list of bindings created in this repl session"
   replOutput @Text ":bind <binding> - bind an expression, infix or type"
+  replOutput @Text ":save <moduleName> - save everything created in this repl session into a new module"
   replOutput @Text "<expr> - Evaluate <expr>, returning it's simplified form and type"
   replOutput @Text ":compile <typescript|javascript> <moduleName> - compile module"
   replOutput @Text ":quit - give up and leave"

--- a/repl/repl/Repl/Actions.hs
+++ b/repl/repl/Repl/Actions.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
-module ReplNew.Actions
+module Repl.Actions
   ( doReplAction,
     doHelp,
   )
@@ -12,13 +12,13 @@ import Data.Text (Text)
 import Language.Mimsa.Core
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Project
-import ReplNew.Actions.Bindings
-import ReplNew.Actions.Compile
-import ReplNew.Actions.Evaluate
-import ReplNew.Actions.ListModules
-import ReplNew.Helpers
-import ReplNew.ReplM
-import ReplNew.Types
+import Repl.Actions.Bindings
+import Repl.Actions.Compile
+import Repl.Actions.Evaluate
+import Repl.Actions.ListModules
+import Repl.Helpers
+import Repl.ReplM
+import Repl.Types
 
 doReplAction ::
   Project Annotation ->

--- a/repl/repl/Repl/Actions/BindModule.hs
+++ b/repl/repl/Repl/Actions/BindModule.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
+
 module Repl.Actions.BindModule
-  ( doBindModule
+  ( doBindModule,
   )
 where
 
@@ -22,7 +23,9 @@ doBindModule project modName = do
   let untypedModule = getAnnotationForType <$> typedModule
 
   -- add the new binding
-  (newProject, _) <- toReplM project
+  (newProject, _) <-
+    toReplM
+      project
       (Actions.bindModule untypedModule modName (prettyPrint typedModule))
 
   replOutput $ "Stored repl module to " <> prettyPrint modName
@@ -33,4 +36,3 @@ doBindModule project modName = do
   setStoredModule mempty
 
   pure newProject
-

--- a/repl/repl/Repl/Actions/BindModule.hs
+++ b/repl/repl/Repl/Actions/BindModule.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Repl.Actions.BindModule
+  ( doBindModule
+  )
+where
+
+import qualified Language.Mimsa.Actions.Modules.Bind as Actions
+import Language.Mimsa.Core
+import Language.Mimsa.Types.Error
+import Language.Mimsa.Types.Project
+import Repl.Helpers
+import Repl.ReplM
+
+-- | give the global module a name and clear it
+doBindModule ::
+  Project Annotation ->
+  ModuleName ->
+  ReplM (Error Annotation) (Project Annotation)
+doBindModule project modName = do
+  typedModule <- getStoredModule
+
+  let untypedModule = getAnnotationForType <$> typedModule
+
+  -- add the new binding
+  (newProject, _) <- toReplM project
+      (Actions.bindModule untypedModule modName (prettyPrint typedModule))
+
+  replOutput $ "Stored repl module to " <> prettyPrint modName
+
+  replDocOutput (prettyDoc typedModule)
+
+  -- clear the module in Repl state
+  setStoredModule mempty
+
+  pure newProject
+

--- a/repl/repl/Repl/Actions/Bindings.hs
+++ b/repl/repl/Repl/Actions/Bindings.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module ReplNew.Actions.Bindings
+module Repl.Actions.Bindings
   ( doAddBinding,
     doListBindings,
   )
@@ -12,8 +12,8 @@ import Language.Mimsa.Core
 import Language.Mimsa.Modules.Pretty
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Project
-import ReplNew.Helpers
-import ReplNew.ReplM
+import Repl.Helpers
+import Repl.ReplM
 
 -- | add a binding to the global repl module
 doAddBinding ::

--- a/repl/repl/Repl/Actions/Compile.hs
+++ b/repl/repl/Repl/Actions/Compile.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
-module ReplNew.Actions.Compile
+module Repl.Actions.Compile
   ( doOutputModuleJS,
   )
 where
@@ -15,8 +15,8 @@ import Language.Mimsa.Backend.Types
 import Language.Mimsa.Core
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Project
-import ReplNew.Helpers
-import ReplNew.ReplM
+import Repl.Helpers
+import Repl.ReplM
 
 doOutputModuleJS ::
   Project Annotation ->

--- a/repl/repl/Repl/Actions/Evaluate.hs
+++ b/repl/repl/Repl/Actions/Evaluate.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module ReplNew.Actions.Evaluate
+module Repl.Actions.Evaluate
   ( doEvaluate,
   )
 where
@@ -10,8 +10,8 @@ import Language.Mimsa.Core
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Project
 import Prettyprinter
-import ReplNew.Helpers
-import ReplNew.ReplM
+import Repl.Helpers
+import Repl.ReplM
 
 doEvaluate ::
   Project Annotation ->

--- a/repl/repl/Repl/Actions/ListModules.hs
+++ b/repl/repl/Repl/Actions/ListModules.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
-module ReplNew.Actions.ListModules
+module Repl.Actions.ListModules
   ( doListModules,
   )
 where
@@ -16,8 +16,8 @@ import Language.Mimsa.Modules.Pretty
 import Language.Mimsa.Project
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Project
-import ReplNew.Helpers
-import ReplNew.ReplM
+import Repl.Helpers
+import Repl.ReplM
 
 -- | get module from project
 -- | typecheck it

--- a/repl/repl/Repl/Helpers.hs
+++ b/repl/repl/Repl/Helpers.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
-module ReplNew.Helpers
+module Repl.Helpers
   ( saveExpression,
     toReplM,
     catchMimsaError,
@@ -19,8 +19,8 @@ import Language.Mimsa.Store
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Store
-import ReplNew.ReplM
-import ReplNew.Types
+import Repl.ReplM
+import Repl.Types
 
 -- | if an error has been thrown, log it and return default value
 catchMimsaError ::

--- a/repl/repl/Repl/Main.hs
+++ b/repl/repl/Repl/Main.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
-module ReplNew.Main
+module Repl.Main
   ( repl,
   )
 where
@@ -14,12 +14,12 @@ import Language.Mimsa.Core
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Store.RootPath
-import ReplNew.Actions (doReplAction)
-import ReplNew.Helpers
-import ReplNew.Parser (replParser)
-import ReplNew.Persistence
-import ReplNew.ReplM
-import ReplNew.Types
+import Repl.Actions (doReplAction)
+import Repl.Helpers
+import Repl.Parser (replParser)
+import Repl.Persistence
+import Repl.ReplM
+import Repl.Types
 import qualified Shared.LoadProject as Shared
 import System.Console.Haskeline
 import System.Directory

--- a/repl/repl/Repl/Parser.hs
+++ b/repl/repl/Repl/Parser.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module ReplNew.Parser
+module Repl.Parser
   ( replParser,
   )
 where
@@ -10,7 +10,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as S
 import Language.Mimsa.Backend.Types
 import Language.Mimsa.Core
-import ReplNew.Types
+import Repl.Types
 import Text.Megaparsec
 
 type ReplActionAnn = ReplAction Annotation

--- a/repl/repl/Repl/Parser.hs
+++ b/repl/repl/Repl/Parser.hs
@@ -20,6 +20,7 @@ replParser =
   try helpParser
     <|> listModulesParser
     <|> listBindingsParser
+    <|> bindModuleParser
     <|> try addBindingParser
     <|> try outputJSModuleParser
     <|> evalParser
@@ -56,6 +57,11 @@ addBindingParser = AddBinding <$> singleModuleItemParser
         [] -> explode "Expected a module binding"
         [a] -> pure a
         _other -> explode "Expected a single module binding"
+
+bindModuleParser :: Parser ReplActionAnn
+bindModuleParser = do
+  _ <- myString ":save"
+  BindModule <$> moduleNameParser
 
 backendParser :: Parser (Maybe Backend)
 backendParser =

--- a/repl/repl/Repl/Persistence.hs
+++ b/repl/repl/Repl/Persistence.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module ReplNew.Persistence
+module Repl.Persistence
   ( loadProject,
     saveProject,
   )
@@ -24,7 +24,7 @@ import Language.Mimsa.Store.Persistence
 import Language.Mimsa.Types.Error.StoreError
 import Language.Mimsa.Types.Project
 import Language.Mimsa.Types.Store.RootPath
-import ReplNew.Types
+import Repl.Types
 
 projectFilePath :: RootPath -> String
 projectFilePath (RootPath rp) = rp <> "/mimsa.json"

--- a/repl/repl/Repl/ReplM.hs
+++ b/repl/repl/Repl/ReplM.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 
-module ReplNew.ReplM
+module Repl.ReplM
   ( ReplM (..),
     ReplState (..),
     runReplM,
@@ -27,7 +27,7 @@ import Control.Monad.State
 import qualified Data.Text.IO as T
 import Language.Mimsa.Core
 import Prettyprinter
-import ReplNew.Types
+import Repl.Types
 
 -- | to allow us to do 'bindings' in the repl,
 -- we maintain a current Module and add to it

--- a/repl/repl/Repl/Types.hs
+++ b/repl/repl/Repl/Types.hs
@@ -18,6 +18,7 @@ data ReplAction ann
   | AddBinding (ModuleItem ann)
   | ListModules (Maybe ModuleName)
   | ListBindings
+  | BindModule ModuleName
   | OutputModuleJS (Maybe Backend) ModuleName
 
 data ReplConfig = ReplConfig

--- a/repl/repl/Repl/Types.hs
+++ b/repl/repl/Repl/Types.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 
-module ReplNew.Types
+module Repl.Types
   ( ReplAction (..),
     ReplConfig (..),
   )

--- a/repl/repl/Shared/LoadProject.hs
+++ b/repl/repl/Shared/LoadProject.hs
@@ -7,8 +7,8 @@ import Control.Monad.Except
 import Language.Mimsa.Core
 import Language.Mimsa.Types.Error
 import Language.Mimsa.Types.Project
-import qualified ReplNew.Persistence as Repl
-import ReplNew.ReplM
+import qualified Repl.Persistence as Repl
+import Repl.ReplM
 
 loadProject ::
   ReplM

--- a/server/server/Server/Helpers/ModuleData.hs
+++ b/server/server/Server/Helpers/ModuleData.hs
@@ -37,6 +37,6 @@ makeModuleData typedModule input =
    in ModuleData
         { mdModuleHash = prettyPrint moduleHash,
           mdModulePretty = prettyPrint typedModule,
-          mdModuleType = renderWithWidth 40 (modulePretty typedModule),
+          mdModuleType = renderWithWidth 40 (modulePretty (filterExported typedModule)),
           mdInput = input
         }


### PR DESCRIPTION
Adds `:save <moduleName>` command so the bound items can be put into a new module.

```bash
# make project
mimsa-repl init

# open repl
mimsa-repl repl

# bind a thing
:bind def dog = "dog"

# bind another thing
:bind export def dogs = (dog,dog)

# save Dogs module
:save Dogs

# use it
Dogs.dogs 

# Exit
:quit
```