### PR TITLE
Oh well

### DIFF
--- a/smol-core/src/Smol/Core/IR/FromExpr/DataTypes.hs
+++ b/smol-core/src/Smol/Core/IR/FromExpr/DataTypes.hs
@@ -123,8 +123,7 @@ howManyInts (DTPrim Smol.TPBool) = 1
 howManyInts (DTPrim Smol.TPNat) = 1
 howManyInts (DTTuple as) = getSum $ foldMap (Sum . howManyInts) as
 howManyInts (DTArray size a) = size * howManyInts a
-howManyInts (DTMany _) = error "soon to be deleted"
-howManyInts (DTDataType _ _) = error "this will probably be 1 as we'll box any subtypes"
+howManyInts (DTDataType whole _) = howManyInts whole -- wrong?
 
 -- given ['e','a'], [TVar _ "a", TVar _ "e"] and [Int, Bool] return [Bool, Int]
 -- putting each arg into place
@@ -165,7 +164,6 @@ data DataTypeInMemory
   | DTPrim Smol.TypePrim -- a primitive llvm type
   | DTTuple [DataTypeInMemory]
   | DTArray Word64 DataTypeInMemory
-  | DTMany (Map Smol.Constructor [DataTypeInMemory]) -- the old way, we'll delete this when we're done
   | DTDataType
       { dtWhole :: DataTypeInMemory, -- a big enough allocation to fill all the constructors
         dtConstructors :: Map Smol.Constructor [DataTypeInMemory] -- the actual constructors (these don't contain the discriminator int)

--- a/smol-core/src/Smol/Core/IR/FromExpr/Type.hs
+++ b/smol-core/src/Smol/Core/IR/FromExpr/Type.hs
@@ -72,10 +72,6 @@ fromDataTypeInMemory = \case
     IRArray size (fromDataTypeInMemory tyInner)
   DTPrim prim -> fromTypePrim prim
   DTDataType whole _ -> fromDataTypeInMemory whole
-  DTMany mems ->
-    -- combine all items from all sums for now
-    let allItems = mconcat $ (fmap . fmap) fromDataTypeInMemory (M.elems mems)
-     in IRStruct ([IRInt32] <> allItems)
 
 fromTypePrim :: Smol.TypePrim -> IRType
 fromTypePrim Smol.TPBool = IRInt2

--- a/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
@@ -68,12 +68,19 @@ builtInTypes =
           []
           ( M.fromList [("LT", mempty), ("EQ", mempty), ("GT", mempty)]
           )
+      listDt =
+        DataType
+          "List"
+          ["a"]
+          (M.fromList [("Cons", [TVar mempty "a", TApp mempty (TConstructor mempty "List") (TVar mempty "a")]),
+                        ("Nil", mempty)])
    in M.fromList
         [ ("Maybe", maybeDt),
           ("Either", eitherDt),
           ("Ord", ordDt),
           ("These", theseDt),
-          ("Identity", identityDt)
+          ("Identity", identityDt),
+          ("List", listDt)
         ]
 
 elaborate ::

--- a/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
@@ -72,8 +72,11 @@ builtInTypes =
         DataType
           "List"
           ["a"]
-          (M.fromList [("Cons", [TVar mempty "a", TApp mempty (TConstructor mempty "List") (TVar mempty "a")]),
-                        ("Nil", mempty)])
+          ( M.fromList
+              [ ("Cons", [TVar mempty "a", TApp mempty (TConstructor mempty "List") (TVar mempty "a")]),
+                ("Nil", mempty)
+              ]
+          )
    in M.fromList
         [ ("Maybe", maybeDt),
           ("Either", eitherDt),

--- a/smol-core/test/Test/IR/IRSpec.hs
+++ b/smol-core/test/Test/IR/IRSpec.hs
@@ -143,10 +143,10 @@ spec = do
               [ ("let maybe = Just (Just 41) in 42", "42"),
                 ("let oneList = Cons 1 Nil in 42", "42"),
                 ("let twoList = Cons 1 (Cons 2 Nil) in 42", "42"),
-                ("(\\maybe -> case maybe of Just a -> (case a of Just aa -> aa + 1 | _ -> 0) | _ -> 0 : Maybe (Maybe Nat) -> Nat) (Just (Just 41))", "42")--,
-                --("let nested = (20, (11,11)) in 42", "42"),
-                --("(\\nested -> case nested of (a,(b,c)) -> a + b + c : (Nat, (Nat, Nat)) -> Nat) (20,(11,11))", "42"),
-                --("(\\maybe -> case maybe of Just (a,b,c) -> a + b + c | Nothing -> 0 : Maybe (Nat,Nat,Nat) -> Nat) (Just (1,2,3))", "6")
+                ("(\\maybe -> case maybe of Just a -> (case a of Just aa -> aa + 1 | _ -> 0) | _ -> 0 : Maybe (Maybe Nat) -> Nat) (Just (Just 41))", "42") -- ,
+                -- ("let nested = (20, (11,11)) in 42", "42"),
+                -- ("(\\nested -> case nested of (a,(b,c)) -> a + b + c : (Nat, (Nat, Nat)) -> Nat) (20,(11,11))", "42"),
+                -- ("(\\maybe -> case maybe of Just (a,b,c) -> a + b + c | Nothing -> 0 : Maybe (Nat,Nat,Nat) -> Nat) (Just (1,2,3))", "6")
               ]
 
         describe "IR compile" $ do

--- a/smol-core/test/Test/IR/IRSpec.hs
+++ b/smol-core/test/Test/IR/IRSpec.hs
@@ -138,6 +138,19 @@ spec = do
         describe "IR compile" $ do
           traverse_ testCompileIR testVals
 
+      xdescribe "Nested datatypes (manually split cases)" $ do
+        let testVals =
+              [ ("let maybe = Just (Just 41) in 42", "42"),
+                ("let oneList = Cons 1 Nil in 42", "42"),
+                ("let twoList = Cons 1 (Cons 2 Nil) in 42", "42"),
+                ("(\\maybe -> case maybe of Just a -> (case a of Just aa -> aa + 1 | _ -> 0) | _ -> 0 : Maybe (Maybe Nat) -> Nat) (Just (Just 41))", "42")--,
+                --("let nested = (20, (11,11)) in 42", "42"),
+                --("(\\nested -> case nested of (a,(b,c)) -> a + b + c : (Nat, (Nat, Nat)) -> Nat) (20,(11,11))", "42"),
+                --("(\\maybe -> case maybe of Just (a,b,c) -> a + b + c | Nothing -> 0 : Maybe (Nat,Nat,Nat) -> Nat) (Just (1,2,3))", "6")
+              ]
+
+        describe "IR compile" $ do
+          traverse_ testCompileIR testVals
       xdescribe "Nested datatypes (currently broken)" $ do
         let testVals =
               [ ("let maybe = Just (Just 41) in 42", "42"),


### PR DESCRIPTION
So far none of our data types have been potentially recursive. This adds `List` and a failing test. Since we don't know how long the list will be, we cannot work out it's data shape in memory from the type. Therefore, we need to be able to describe `List Int` as something like:

```
-- cons shape
(0, value, pointerToNextThing)
-- nil shape
(1, 0, 0) -- discriminator, rubbish, rubbish
```

We won't know what the next thing IS so we'll have to do some casting or something. Once again, probably best to start by manually writing some working IR then stepping back upwards.

This PR adds skipped tests.