### PR TITLE
Use CPS writer

### DIFF
--- a/backends/backends.cabal
+++ b/backends/backends.cabal
@@ -73,6 +73,7 @@ library
     , servant-server
     , text
     , transformers
+    , writer-cps-mtl
 
   default-language:   Haskell2010
 

--- a/backends/src/Language/Mimsa/Backend/Typescript/Monad.hs
+++ b/backends/src/Language/Mimsa/Backend/Typescript/Monad.hs
@@ -22,7 +22,7 @@ where
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
-import Control.Monad.Writer.Strict
+import Control.Monad.Writer.CPS
 import Data.Either
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NE

--- a/compiler/mimsa.cabal
+++ b/compiler/mimsa.cabal
@@ -194,6 +194,7 @@ library
     , text
     , transformers
     , wasm
+    , writer-cps-mtl
 
   default-language:   Haskell2010
 

--- a/compiler/src/Language/Mimsa/Typechecker/Elaborate.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Elaborate.hs
@@ -12,7 +12,7 @@ where
 
 import Control.Monad.Except
 import Control.Monad.State (State)
-import Control.Monad.Writer.Strict
+import Control.Monad.Writer.CPS
 import Data.Bifunctor
 import Data.Foldable
 import Data.Functor

--- a/compiler/src/Language/Mimsa/Typechecker/Typecheck.hs
+++ b/compiler/src/Language/Mimsa/Typechecker/Typecheck.hs
@@ -8,7 +8,7 @@ where
 
 import Control.Monad.Except
 import Control.Monad.State (State, runState)
-import Control.Monad.Writer.Strict
+import Control.Monad.Writer.CPS
 import Data.Map.Strict (Map)
 import Language.Mimsa.Core
 import Language.Mimsa.Typechecker.Elaborate

--- a/smol-core/smol-core.cabal
+++ b/smol-core/smol-core.cabal
@@ -49,6 +49,7 @@ common shared
     , string-conversions
     , text
     , unix
+    , writer-cps-mtl
 
 library
   import:           shared
@@ -81,7 +82,10 @@ library
     Smol.Core.IR.ToLLVM.Patterns
     Smol.Core.IR.ToLLVM.ToLLVM
     Smol.Core.Parser
+    Smol.Core.Parser.DataType
+    Smol.Core.Parser.Expr
     Smol.Core.Parser.Identifiers
+    Smol.Core.Parser.Module
     Smol.Core.Parser.Pattern
     Smol.Core.Parser.Primitives
     Smol.Core.Parser.Shared
@@ -106,6 +110,7 @@ library
     Smol.Core.Types.Expr
     Smol.Core.Types.GetPath
     Smol.Core.Types.Identifier
+    Smol.Core.Types.Module
     Smol.Core.Types.Module.DefIdentifier
     Smol.Core.Types.Module.Entity
     Smol.Core.Types.Module.Module

--- a/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
@@ -13,7 +13,7 @@ where
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
-import Control.Monad.Writer.Strict
+import Control.Monad.Writer.CPS
 import Data.Foldable (foldl')
 import Data.Functor
 import qualified Data.List.NonEmpty as NE

--- a/smol-core/src/Smol/Core/Typecheck/Subtype.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Subtype.hs
@@ -11,7 +11,7 @@ module Smol.Core.Typecheck.Subtype
 where
 
 import Control.Monad.Except
-import Control.Monad.Writer.Strict
+import Control.Monad.Writer.CPS
 import Data.Bifunctor (first)
 import Data.Foldable (foldl', foldrM)
 import Data.Functor (($>))

--- a/smol-core/test/Test/Typecheck/NestingMonadSpec.hs
+++ b/smol-core/test/Test/Typecheck/NestingMonadSpec.hs
@@ -2,7 +2,7 @@
 
 module Test.Typecheck.NestingMonadSpec (spec) where
 
-import Control.Monad.Writer.Strict
+import Control.Monad.Writer.CPS
 import Test.Hspec
 
 spec :: Spec

--- a/smol-core/test/Test/Typecheck/SubtypeSpec.hs
+++ b/smol-core/test/Test/Typecheck/SubtypeSpec.hs
@@ -2,7 +2,7 @@
 
 module Test.Typecheck.SubtypeSpec (spec) where
 
-import Control.Monad.Writer.Strict
+import Control.Monad.Writer.CPS
 import Data.Either
 import Data.Foldable (traverse_)
 import Smol.Core


### PR DESCRIPTION
Let's get a wee speed up pls.

NOW:

```bash
Benchmark mimsa-benchmark: RUNNING...
benchmarking build stdlib/allFns
time                 92.70 ms   (44.99 ms .. 117.2 ms)
                     0.876 R²   (0.684 R² .. 0.993 R²)
mean                 128.1 ms   (114.0 ms .. 155.6 ms)
std dev              29.53 ms   (11.98 ms .. 44.23 ms)
variance introduced by outliers: 61% (severely inflated)

benchmarking evaluate/evaluate big looping thing
time                 88.54 ms   (86.79 ms .. 90.26 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 90.31 ms   (89.32 ms .. 91.40 ms)
std dev              1.858 ms   (1.358 ms .. 2.438 ms)

benchmarking evaluate/evaluate parsing
time                 27.70 ms   (27.51 ms .. 27.84 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 27.89 ms   (27.74 ms .. 28.29 ms)
std dev              543.8 μs   (211.2 μs .. 942.1 μs)

benchmarking evaluate/evaluate parsing 2
time                 226.1 ms   (211.3 ms .. 243.4 ms)
                     0.997 R²   (0.991 R² .. 1.000 R²)
mean                 211.9 ms   (206.1 ms .. 218.9 ms)
std dev              8.788 ms   (5.260 ms .. 11.90 ms)
variance introduced by outliers: 14% (moderately inflated)
```

THEN:

```bash
Benchmark mimsa-benchmark: RUNNING...
benchmarking build stdlib/allFns
time                 101.6 ms   (100.6 ms .. 102.5 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 102.1 ms   (101.7 ms .. 102.3 ms)
std dev              406.4 μs   (227.9 μs .. 623.5 μs)

benchmarking evaluate/evaluate big looping thing
time                 87.15 ms   (86.85 ms .. 87.51 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 87.49 ms   (87.35 ms .. 87.61 ms)
std dev              236.3 μs   (182.1 μs .. 322.7 μs)

benchmarking evaluate/evaluate parsing
time                 28.23 ms   (28.10 ms .. 28.37 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 28.53 ms   (28.40 ms .. 28.72 ms)
std dev              336.3 μs   (205.0 μs .. 493.4 μs)

benchmarking evaluate/evaluate parsing 2
time                 241.0 ms   (203.0 ms .. 289.2 ms)
                     0.971 R²   (0.943 R² .. 1.000 R²)
mean                 212.2 ms   (204.7 ms .. 233.1 ms)
std dev              17.13 ms   (1.123 ms .. 23.65 ms)
variance introduced by outliers: 16% (moderately inflated)
```