### PR TITLE
Start saving modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,10 @@ format:
 hlint:
 	@hlint $(HS_FILES)
 
+.PHONY: run-server
+run-server:
+	cabal run server:exe:mimsa-server
+
 .PHONY: generate-swagger
 generate-swagger: install
 	$(shell cabal list-bin server:exe:mimsa-server) generate-swagger

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
             pkgs.nodejs-18_x
             pkgs.clang_14
             pkgs.llvmPackages_14.llvm
+            pkgs.nodePackages.yarn
           ];
 
           # put clang_14 on the path

--- a/ui/src/components/Editor/Feedback.tsx
+++ b/ui/src/components/Editor/Feedback.tsx
@@ -38,7 +38,6 @@ export const Feedback: React.FC<Props> = ({ feedback }) => {
       )
 
     case 'ShowModuleData':
-      console.log(feedback.moduleData)
       return (
         <FlexColumnSpaced>
           <Code codeType="type">

--- a/ui/src/reducer/project/actions.ts
+++ b/ui/src/reducer/project/actions.ts
@@ -3,6 +3,7 @@ import type {
   ModuleHash,
   ProjectData,
   GetModuleResponse,
+  BindModuleRequest,
 } from '../../types'
 
 export const storeProjectData = (
@@ -27,8 +28,16 @@ export const fetchModuleSuccess = (
   fetched: GetModuleResponse
 ) => ({ type: 'FetchModuleSuccess' as const, fetched })
 
+export const bindModule = (
+  bindModuleRequest: BindModuleRequest
+) => ({
+  type: 'BindModule' as const,
+  bindModuleRequest,
+})
+
 export type ProjectAction =
   | ReturnType<typeof initialise>
   | ReturnType<typeof storeProjectData>
   | ReturnType<typeof fetchModuleSuccess>
   | ReturnType<typeof fetchModule>
+  | ReturnType<typeof bindModule>


### PR DESCRIPTION
Finally finish #795 and make modules and thus the UI usable again.

Have done nearly no work, this is a statement of intent mostly. Need to use `useBindModule` hook, but actually pass it a name so it saves, and wire it up to a "Save" button in the `Feedback` component. I hate react.