### PR TITLE
Implement spread in LLVM pattern match

### DIFF
--- a/smol-backend/test/Test/IR/IRSpec.hs
+++ b/smol-backend/test/Test/IR/IRSpec.hs
@@ -199,8 +199,8 @@ spec = do
               [ ("let arr = [20,22]; case arr of [a,b] -> (a + b : Int) | _ -> 0", "42"),
                 ("let arr = [20,20,2]; case arr of [a,b,c] -> (a + b + c : Int) | _ -> 0", "42"),
                 ("let arr = [1,100]; case arr of [100, a] -> 0 | [1,b] -> b | _ -> 0", "100"),
-                ("let arr = [1,2,3]; case arr of [_,_] -> 0 | _ -> 1", "1") -- ie, are we checking the length of the array?
-                -- ("let arr1 = [1,2,3]; let arr2 = case arr1 of [_,...rest] -> rest | _ -> [1]; case arr2 of [d,e] -> d + e | _ -> 0", "5") -- need malloc to dynamically create new array
+                ("let arr = [1,2,3]; case arr of [_,_] -> 0 | _ -> 1", "1"), -- ie, are we checking the length of the array?
+                ("let arr1 = [1,2,3]; let arr2 = case arr1 of [_,...rest] -> rest | _ -> [1]; case arr2 of [d,e] -> d + e | _ -> 0", "5") -- need malloc to dynamically create new array
               ]
 
         describe "IR compile" $ do


### PR DESCRIPTION
Broken test, fix it. We dynamically know all array sizes for now so lets take advantage of that.