### PR TITLE
Make type literals non empty sets

### DIFF
--- a/smol-core/smol-core.cabal
+++ b/smol-core/smol-core.cabal
@@ -43,6 +43,7 @@ common shared
     , llvm-hs-pure
     , megaparsec
     , mtl
+    , nonempty-containers
     , parser-combinators
     , prettyprinter
     , process

--- a/smol-core/src/Smol/Core/ExprUtils.hs
+++ b/smol-core/src/Smol/Core/ExprUtils.hs
@@ -169,6 +169,5 @@ mapTypeDep resolve = go
     go (TUnknown ann i) = TUnknown ann i
     go (TGlobals ann env inner) = TGlobals ann (go <$> env) (go inner)
     go (TRecord ann as) = TRecord ann (go <$> as)
-    go (TUnion ann a b) = TUnion ann (go a) (go b)
     go (TApp ann a b) = TApp ann (go a) (go b)
     go (TConstructor ann constructor) = TConstructor ann (resolve constructor)

--- a/smol-core/src/Smol/Core/Parser/Primitives.hs
+++ b/smol-core/src/Smol/Core/Parser/Primitives.hs
@@ -11,6 +11,7 @@ module Smol.Core.Parser.Primitives
   )
 where
 
+import qualified Data.Set.NonEmpty as NES
 import Data.Functor (($>))
 import Data.Text (Text)
 import Data.Void
@@ -36,7 +37,7 @@ primParser =
 typeLiteralParser :: Parser TypeLiteral
 typeLiteralParser =
   myLexeme
-    ( TLInt <$> intParser
+    ( TLInt . NES.singleton <$> intParser
         <|> TLBool <$> trueParser
         <|> TLBool <$> falseParser
         <|> TLUnit <$ unitParser

--- a/smol-core/src/Smol/Core/Parser/Primitives.hs
+++ b/smol-core/src/Smol/Core/Parser/Primitives.hs
@@ -11,8 +11,9 @@ module Smol.Core.Parser.Primitives
   )
 where
 
-import qualified Data.Set.NonEmpty as NES
 import Data.Functor (($>))
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Set.NonEmpty as NES
 import Data.Text (Text)
 import Data.Void
 import GHC.Num.Natural
@@ -37,7 +38,7 @@ primParser =
 typeLiteralParser :: Parser TypeLiteral
 typeLiteralParser =
   myLexeme
-    ( TLInt . NES.singleton <$> intParser
+    ( TLInt <$> multiIntParser
         <|> TLBool <$> trueParser
         <|> TLBool <$> falseParser
         <|> TLUnit <$ unitParser
@@ -60,6 +61,14 @@ intPrimParser = PInt <$> intParser
 intParser :: Parser Integer
 intParser =
   L.signed (string "" $> ()) L.decimal
+
+multiIntParser :: Parser (NES.NESet Integer)
+multiIntParser = do
+  ints <-
+    sepBy1
+      (myLexeme intParser)
+      (myString "|")
+  pure (NES.fromList (NE.fromList ints))
 
 ---
 

--- a/smol-core/src/Smol/Core/Parser/Type.hs
+++ b/smol-core/src/Smol/Core/Parser/Type.hs
@@ -68,7 +68,6 @@ parseTypeAndFormatError = parseAndFormat (space *> typeParser <* eof)
 typeParser :: Parser (ParsedType Annotation)
 typeParser =
   try (orInBrackets tyFunctionParser)
-    <|> try tyUnionParser
     <|> simpleTypeParser
 
 -- | all the types except functions
@@ -122,7 +121,6 @@ subParser :: Parser (ParsedType Annotation)
 subParser =
   try simpleTypeParser
     <|> try (inBrackets tyFunctionParser)
-    <|> try (inBrackets tyUnionParser)
 
 tyPrimitiveParser :: Parser (ParsedType Annotation)
 tyPrimitiveParser = TPrim mempty <$> tyPrimParser
@@ -165,12 +163,6 @@ tyTupleParser = do
 
 tyIdentifier :: Parser Text
 tyIdentifier = myLexeme (takeWhile1P (Just "type variable name") Char.isAlphaNum)
-
-tyUnionParser :: Parser (ParsedType Annotation)
-tyUnionParser = do
-  chainl1
-    simpleTypeParser
-    (myString "|" >> pure (TUnion mempty))
 
 inProtectedTypes :: Text -> Maybe Text
 inProtectedTypes tx =

--- a/smol-core/src/Smol/Core/Printer.hs
+++ b/smol-core/src/Smol/Core/Printer.hs
@@ -16,6 +16,7 @@ import qualified Data.Set as S
 import Data.Text (Text)
 import Prettyprinter
 import Prettyprinter.Render.Text
+import qualified Data.Set.NonEmpty as NES
 
 renderWithWidth :: Int -> Doc ann -> Text
 renderWithWidth w doc = renderStrict (layoutPretty layoutOptions (unAnnotate doc))
@@ -67,3 +68,6 @@ instance (Printer a, Printer b, Printer c, Printer d) => Printer (a, b, c, d) wh
 
 instance (Printer a) => Printer (Set a) where
   prettyDoc as = list (prettyDoc <$> S.toList as)
+
+instance (Printer a) => Printer (NES.NESet a) where
+  prettyDoc as = prettyDoc (NES.toSet as)

--- a/smol-core/src/Smol/Core/Printer.hs
+++ b/smol-core/src/Smol/Core/Printer.hs
@@ -13,10 +13,10 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Set (Set)
 import qualified Data.Set as S
+import qualified Data.Set.NonEmpty as NES
 import Data.Text (Text)
 import Prettyprinter
 import Prettyprinter.Render.Text
-import qualified Data.Set.NonEmpty as NES
 
 renderWithWidth :: Int -> Doc ann -> Text
 renderWithWidth w doc = renderStrict (layoutPretty layoutOptions (unAnnotate doc))

--- a/smol-core/src/Smol/Core/TypeUtils.hs
+++ b/smol-core/src/Smol/Core/TypeUtils.hs
@@ -18,8 +18,6 @@ mapType f (TApp ann fn arg) =
   TApp ann (f fn) (f arg)
 mapType f (TGlobals ann globMap expr) =
   TGlobals ann (mapType f <$> globMap) (f expr)
-mapType f (TUnion ann a b) =
-  TUnion ann (f a) (f b)
 mapType _ (TConstructor ann c) = TConstructor ann c
 
 monoidType :: (Monoid a) => (Type dep ann -> a) -> Type dep ann -> a
@@ -38,5 +36,4 @@ monoidType f (TGlobals _ as expr) =
   foldMap f as <> f expr
 monoidType f (TRecord _ as) =
   foldMap f as
-monoidType f (TUnion _ a b) = f a <> f b
 monoidType f (TApp _ fn arg) = f fn <> f arg

--- a/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
@@ -392,15 +392,6 @@ checkPattern checkTy checkPat = do
       pure (PLiteral ty (PNat b), mempty)
     (ty@(TPrim _ TPInt), PLiteral _ (PInt b)) ->
       pure (PLiteral ty (PInt b), mempty)
-    (ty@(TUnion _ l r), pat@(PLiteral _ lit)) -> do
-      result <-
-        tryError
-          ( checkPattern l pat -- is left OK?
-              `catchError` \_ -> checkPattern r pat -- or maybe right is?
-          )
-      case result of
-        Left _ -> throwError (TCPatternMismatch pat ty)
-        Right _ -> pure (PLiteral ty lit, mempty)
     (ty@(TArray _ arrSize tyArr), PArray ann items spread) -> do
       inferEverything <- traverse (checkPattern tyArr) items
       (inferSpread, env2) <- case spread of

--- a/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
@@ -10,7 +10,6 @@ module Smol.Core.Typecheck.Elaborate
   )
 where
 
-import qualified Data.Set.NonEmpty as NES
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
@@ -21,6 +20,7 @@ import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
+import qualified Data.Set.NonEmpty as NES
 import Smol.Core.ExprUtils
 import Smol.Core.Helpers
 import Smol.Core.Typecheck.Shared

--- a/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
@@ -10,6 +10,7 @@ module Smol.Core.Typecheck.Elaborate
   )
 where
 
+import qualified Data.Set.NonEmpty as NES
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
@@ -189,8 +190,8 @@ inferInfix ann OpEquals a b = do
 
 typeLiteralFromPrim :: Prim -> TypeLiteral
 typeLiteralFromPrim (PBool b) = TLBool b
-typeLiteralFromPrim (PInt a) = TLInt a
-typeLiteralFromPrim (PNat a) = TLInt (fromIntegral a)
+typeLiteralFromPrim (PInt a) = TLInt (NES.singleton a)
+typeLiteralFromPrim (PNat a) = TLInt (NES.singleton $ fromIntegral a)
 typeLiteralFromPrim PUnit = TLUnit
 
 -- | infer synthesizes values

--- a/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
@@ -377,6 +377,12 @@ checkPattern checkTy checkPat = do
     (ty, PVar _ ident) ->
       pure (PVar ty ident, M.singleton ident ty)
     (ty, PWildcard _) -> pure (PWildcard ty, mempty)
+    (ty@(TLiteral _ (TLInt as)), PLiteral _ (PInt i))
+      | NES.member i as ->
+          pure (PLiteral ty (PInt i), mempty)
+    (ty@(TLiteral _ (TLInt as)), PLiteral _ (PNat i))
+      | NES.member (fromIntegral i) as ->
+          pure (PLiteral ty (PNat i), mempty)
     (ty@(TLiteral _ tPrim), PLiteral _ pPrim)
       | tPrim == typeLiteralFromPrim pPrim ->
           pure (PLiteral ty pPrim, mempty)

--- a/smol-core/src/Smol/Core/Typecheck/Exhaustiveness.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Exhaustiveness.hs
@@ -170,10 +170,6 @@ generateFromType ty@(TPrim _ TPInt) =
   pure [PWildcard ty]
 generateFromType ty@(TPrim _ TPNat) =
   pure [PWildcard ty]
-generateFromType (TUnion _ a b) =
-  mappend
-    <$> generateFromType a
-    <*> generateFromType b
 generateFromType _ = pure mempty
 
 generateAlways ::

--- a/smol-core/src/Smol/Core/Typecheck/Exhaustiveness.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Exhaustiveness.hs
@@ -160,7 +160,7 @@ generateFromType ::
   ResolvedType Annotation ->
   m [Pattern ResolvedDep (ResolvedType Annotation)]
 generateFromType ty@(TLiteral _ literal) =
-  pure [PLiteral ty (primFromTypeLiteral literal)]
+  pure $ PLiteral ty <$> primsFromTypeLiteral literal
 generateFromType ty@(TPrim _ TPBool) =
   pure
     [ PLiteral ty (PBool True),

--- a/smol-core/src/Smol/Core/Typecheck/Shared.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Shared.hs
@@ -101,7 +101,6 @@ getTypeAnnotation (TVar ann _) = ann
 getTypeAnnotation (TGlobals ann _ _) = ann
 getTypeAnnotation (TLiteral ann _) = ann
 getTypeAnnotation (TRecord ann _) = ann
-getTypeAnnotation (TUnion ann _ _) = ann
 
 primsFromTypeLiteral :: TypeLiteral -> [Prim]
 primsFromTypeLiteral (TLInt i) = PInt <$> S.toList (NES.toSet i)

--- a/smol-core/src/Smol/Core/Typecheck/Shared.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Shared.hs
@@ -28,10 +28,11 @@ module Smol.Core.Typecheck.Shared
     tellGlobal,
     listenGlobals,
     freshen,
-    primFromTypeLiteral,
+    primsFromTypeLiteral,
   )
 where
 
+import qualified Data.Set.NonEmpty as NES
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
@@ -102,10 +103,10 @@ getTypeAnnotation (TLiteral ann _) = ann
 getTypeAnnotation (TRecord ann _) = ann
 getTypeAnnotation (TUnion ann _ _) = ann
 
-primFromTypeLiteral :: TypeLiteral -> Prim
-primFromTypeLiteral (TLInt i) = PInt i
-primFromTypeLiteral (TLBool b) = PBool b
-primFromTypeLiteral TLUnit = PUnit
+primsFromTypeLiteral :: TypeLiteral -> [Prim]
+primsFromTypeLiteral (TLInt i) = PInt <$> S.toList (NES.toSet i)
+primsFromTypeLiteral (TLBool b) = [PBool b]
+primsFromTypeLiteral TLUnit = [PUnit]
 
 getUnknown :: (MonadState (TCState ann) m) => ann -> m (ResolvedType ann)
 getUnknown ann = do

--- a/smol-core/src/Smol/Core/Typecheck/Shared.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Shared.hs
@@ -32,7 +32,6 @@ module Smol.Core.Typecheck.Shared
   )
 where
 
-import qualified Data.Set.NonEmpty as NES
 import Control.Monad.Except
 import Control.Monad.Reader
 import Control.Monad.State
@@ -41,6 +40,7 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Maybe (listToMaybe)
 import qualified Data.Set as S
+import qualified Data.Set.NonEmpty as NES
 import Smol.Core.Helpers
 import Smol.Core.Typecheck.FreeVars
 import Smol.Core.Typecheck.Substitute

--- a/smol-core/src/Smol/Core/Typecheck/Substitute.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Substitute.hs
@@ -88,6 +88,5 @@ substitute sub@(Substitution i ty) = \case
     TGlobals ann (fmap (substitute sub) tGlobs) (substitute sub tBody)
   TRecord ann items ->
     TRecord ann (fmap (substitute sub) items)
-  TUnion ann a b -> TUnion ann (substitute sub a) (substitute sub b)
   prim@TPrim {} -> prim
   lit@TLiteral {} -> lit

--- a/smol-core/src/Smol/Core/Typecheck/Subtype.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Subtype.hs
@@ -87,24 +87,10 @@ combine a b =
       (TLiteral ann (TLBool bA), TLiteral _ (TLBool bB))
         | bA /= bB ->
             pure $ TPrim ann TPBool -- don't have True | False, it's silly
-      (TUnion ann _ _, TLiteral _ (TLInt _)) ->
-        if memberOf b a
-          then pure a
-          else pure $ TUnion ann a b
-      (TLiteral _ (TLInt _), TUnion ann _ _) ->
-        if memberOf a b
-          then pure b
-          else pure $ TUnion ann b a
-      (TUnion ann _ _, TUnion {}) ->
-        pure $ TUnion ann a b -- we're not deduping because we are lazy
       _ -> throwError (TCTypeMismatch a b)
 
 typeEquals :: ResolvedType ann -> ResolvedType ann -> Bool
 typeEquals a b = (a $> ()) == (b $> ())
-
-memberOf :: ResolvedType ann -> ResolvedType ann -> Bool
-memberOf a (TUnion _ l r) = memberOf a l || memberOf a r
-memberOf a b = typeEquals a b
 
 -- | is the RHS an equal or more general expression of the LHS?
 -- | expressed like this so we can try both sides quickly
@@ -115,7 +101,6 @@ isLiteralSubtypeOf (TLiteral _ (TLInt as)) (TLiteral _ (TLInt bs)) | NES.isSubse
 isLiteralSubtypeOf (TLiteral _ (TLInt a)) (TPrim _ TPNat) = all (>= 0) a -- a Int literal is a Nat if its non-negative
 isLiteralSubtypeOf (TLiteral _ (TLInt _)) (TPrim _ TPInt) = True -- a Nat literal is also an Int
 isLiteralSubtypeOf (TPrim _ TPNat) (TPrim _ TPInt) = True -- a Nat is also an Int
-isLiteralSubtypeOf c (TUnion _ l r) | c `memberOf` l || c `memberOf` r = True -- a | b is a more general 'a'
 isLiteralSubtypeOf union (TPrim _ TPNat) | isNatLiteral union = True
 isLiteralSubtypeOf union (TPrim _ TPInt) | isIntLiteral union = True
 isLiteralSubtypeOf _ _ = False
@@ -123,12 +108,10 @@ isLiteralSubtypeOf _ _ = False
 -- | this is a sign we're encoding unions all wrong I think, but let's just
 -- follow this through
 isNatLiteral :: Type dep ann -> Bool
-isNatLiteral (TUnion _ a b) = isNatLiteral a && isNatLiteral b
 isNatLiteral (TLiteral _ (TLInt a)) | all (>= 0) a = True
 isNatLiteral _ = False
 
 isIntLiteral :: Type dep ann -> Bool
-isIntLiteral (TUnion _ a b) = isIntLiteral a && isIntLiteral b
 isIntLiteral (TLiteral _ (TLInt _)) = True
 isIntLiteral _ = False
 

--- a/smol-core/src/Smol/Core/Typecheck/Subtype.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Subtype.hs
@@ -81,9 +81,8 @@ combine a b =
     `catchError` const asUnion
   where
     asUnion = case (a, b) of
-      (TLiteral ann (TLInt bA), TLiteral _ (TLInt bB))
-        | bA /= bB ->
-            pure $ TUnion ann a b
+      (TLiteral ann (TLInt as), TLiteral _ (TLInt bs)) ->
+        pure $ TLiteral ann (TLInt $ as <> bs)
       (TLiteral ann (TLBool bA), TLiteral _ (TLBool bB))
         | bA /= bB ->
             pure $ TPrim ann TPBool -- don't have True | False, it's silly
@@ -111,7 +110,7 @@ memberOf a b = typeEquals a b
 isLiteralSubtypeOf :: ResolvedType ann -> ResolvedType ann -> Bool
 isLiteralSubtypeOf a b | a `typeEquals` b = True
 isLiteralSubtypeOf (TLiteral _ (TLBool _)) (TPrim _ TPBool) = True -- a Bool literal is a Bool
-isLiteralSubtypeOf (TLiteral _ (TLInt a)) (TPrim _ TPNat) = all (>= 0) a-- a Int literal is a Nat if its non-negative
+isLiteralSubtypeOf (TLiteral _ (TLInt a)) (TPrim _ TPNat) = all (>= 0) a -- a Int literal is a Nat if its non-negative
 isLiteralSubtypeOf (TLiteral _ (TLInt _)) (TPrim _ TPInt) = True -- a Nat literal is also an Int
 isLiteralSubtypeOf (TPrim _ TPNat) (TPrim _ TPInt) = True -- a Nat is also an Int
 isLiteralSubtypeOf c (TUnion _ l r) | c `memberOf` l || c `memberOf` r = True -- a | b is a more general 'a'

--- a/smol-core/src/Smol/Core/Typecheck/Subtype.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Subtype.hs
@@ -19,6 +19,7 @@ import Data.Foldable (foldl', foldrM)
 import Data.Functor (($>))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
+import qualified Data.Set.NonEmpty as NES
 import Smol.Core.Helpers
 import Smol.Core.Typecheck.Shared
 import Smol.Core.Typecheck.Substitute
@@ -110,6 +111,7 @@ memberOf a b = typeEquals a b
 isLiteralSubtypeOf :: ResolvedType ann -> ResolvedType ann -> Bool
 isLiteralSubtypeOf a b | a `typeEquals` b = True
 isLiteralSubtypeOf (TLiteral _ (TLBool _)) (TPrim _ TPBool) = True -- a Bool literal is a Bool
+isLiteralSubtypeOf (TLiteral _ (TLInt as)) (TLiteral _ (TLInt bs)) | NES.isSubsetOf as bs = True
 isLiteralSubtypeOf (TLiteral _ (TLInt a)) (TPrim _ TPNat) = all (>= 0) a -- a Int literal is a Nat if its non-negative
 isLiteralSubtypeOf (TLiteral _ (TLInt _)) (TPrim _ TPInt) = True -- a Nat literal is also an Int
 isLiteralSubtypeOf (TPrim _ TPNat) (TPrim _ TPInt) = True -- a Nat is also an Int

--- a/smol-core/src/Smol/Core/Typecheck/Subtype.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Subtype.hs
@@ -46,7 +46,7 @@ generaliseLiteral ::
   ResolvedType ann ->
   ResolvedType ann
 generaliseLiteral (TLiteral ann (TLInt tlA)) =
-  if tlA >= 0
+  if all (>= 0) tlA
     then TPrim ann TPNat
     else TPrim ann TPInt
 generaliseLiteral (TLiteral ann (TLBool _)) =
@@ -111,7 +111,7 @@ memberOf a b = typeEquals a b
 isLiteralSubtypeOf :: ResolvedType ann -> ResolvedType ann -> Bool
 isLiteralSubtypeOf a b | a `typeEquals` b = True
 isLiteralSubtypeOf (TLiteral _ (TLBool _)) (TPrim _ TPBool) = True -- a Bool literal is a Bool
-isLiteralSubtypeOf (TLiteral _ (TLInt a)) (TPrim _ TPNat) = a >= 0 -- a Int literal is a Nat if its non-negative
+isLiteralSubtypeOf (TLiteral _ (TLInt a)) (TPrim _ TPNat) = all (>= 0) a-- a Int literal is a Nat if its non-negative
 isLiteralSubtypeOf (TLiteral _ (TLInt _)) (TPrim _ TPInt) = True -- a Nat literal is also an Int
 isLiteralSubtypeOf (TPrim _ TPNat) (TPrim _ TPInt) = True -- a Nat is also an Int
 isLiteralSubtypeOf c (TUnion _ l r) | c `memberOf` l || c `memberOf` r = True -- a | b is a more general 'a'
@@ -123,7 +123,7 @@ isLiteralSubtypeOf _ _ = False
 -- follow this through
 isNatLiteral :: Type dep ann -> Bool
 isNatLiteral (TUnion _ a b) = isNatLiteral a && isNatLiteral b
-isNatLiteral (TLiteral _ (TLInt a)) | a >= 0 = True
+isNatLiteral (TLiteral _ (TLInt a)) | all (>= 0) a = True
 isNatLiteral _ = False
 
 isIntLiteral :: Type dep ann -> Bool

--- a/smol-core/src/Smol/Core/Types/Type.hs
+++ b/smol-core/src/Smol/Core/Types/Type.hs
@@ -57,7 +57,7 @@ data TypeLiteral
 instance Printer TypeLiteral where
   prettyDoc (TLBool b) = PP.pretty b
   prettyDoc (TLInt neInts) =
-    PP.hsep (PP.punctuate "|" (PP.pretty <$> S.toList (NES.toSet neInts)))
+    PP.hsep (PP.punctuate "| " (PP.pretty <$> S.toList (NES.toSet neInts)))
   prettyDoc TLUnit = "Unit"
 
 data Type dep ann
@@ -70,7 +70,6 @@ data Type dep ann
   | TUnknown ann Integer
   | TGlobals ann (Map Identifier (Type dep ann)) (Type dep ann)
   | TRecord ann (Map Identifier (Type dep ann))
-  | TUnion ann (Type dep ann) (Type dep ann)
   | TApp ann (Type dep ann) (Type dep ann)
   | TConstructor ann (dep TypeName)
   deriving stock (Functor, Foldable, Generic, Traversable)
@@ -133,7 +132,6 @@ renderType (TPrim _ a) = prettyDoc a
 renderType (TLiteral _ l) = prettyDoc l
 renderType (TUnknown _ i) = "U" <> PP.pretty i
 renderType (TArray _ _ as) = "[" <> prettyDoc as <> "]"
-renderType (TUnion _ a b) = prettyDoc a <+> "|" <+> prettyDoc b
 renderType (TFunc _ _ a b) =
   withParens a <+> "->" <+> renderType b
 renderType (TTuple _ a as) =

--- a/smol-core/src/Smol/Core/Types/Type.hs
+++ b/smol-core/src/Smol/Core/Types/Type.hs
@@ -18,11 +18,12 @@ module Smol.Core.Types.Type
   )
 where
 
-import qualified Data.Set as S
 import Data.Aeson (FromJSON, FromJSONKey, ToJSON)
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict
 import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import qualified Data.Set.NonEmpty as NES
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import Prettyprinter ((<+>))
@@ -32,7 +33,6 @@ import Smol.Core.Types.Identifier
 import Smol.Core.Types.ParseDep
 import Smol.Core.Types.ResolvedDep
 import Smol.Core.Types.TypeName
-import qualified Data.Set.NonEmpty as NES
 
 type ParsedType ann = Type ParseDep ann
 
@@ -47,15 +47,17 @@ instance Printer TypePrim where
   prettyDoc TPInt = "Int"
   prettyDoc TPBool = "Bool"
 
-data TypeLiteral = TLBool Bool | TLInt (NES.NESet Integer) 
-                  | TLUnit
+data TypeLiteral
+  = TLBool Bool
+  | TLInt (NES.NESet Integer)
+  | TLUnit
   deriving stock (Eq, Ord, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
 instance Printer TypeLiteral where
   prettyDoc (TLBool b) = PP.pretty b
-  prettyDoc (TLInt neInts) = 
-    PP.hsep (PP.punctuate "|" (PP.pretty <$> S.toList (NES.toSet neInts))) 
+  prettyDoc (TLInt neInts) =
+    PP.hsep (PP.punctuate "|" (PP.pretty <$> S.toList (NES.toSet neInts)))
   prettyDoc TLUnit = "Unit"
 
 data Type dep ann

--- a/smol-core/src/Smol/Core/Types/Type.hs
+++ b/smol-core/src/Smol/Core/Types/Type.hs
@@ -18,6 +18,7 @@ module Smol.Core.Types.Type
   )
 where
 
+import qualified Data.Set as S
 import Data.Aeson (FromJSON, FromJSONKey, ToJSON)
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict
@@ -31,6 +32,7 @@ import Smol.Core.Types.Identifier
 import Smol.Core.Types.ParseDep
 import Smol.Core.Types.ResolvedDep
 import Smol.Core.Types.TypeName
+import qualified Data.Set.NonEmpty as NES
 
 type ParsedType ann = Type ParseDep ann
 
@@ -45,13 +47,15 @@ instance Printer TypePrim where
   prettyDoc TPInt = "Int"
   prettyDoc TPBool = "Bool"
 
-data TypeLiteral = TLBool Bool | TLInt Integer | TLUnit
+data TypeLiteral = TLBool Bool | TLInt (NES.NESet Integer) 
+                  | TLUnit
   deriving stock (Eq, Ord, Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
 
 instance Printer TypeLiteral where
   prettyDoc (TLBool b) = PP.pretty b
-  prettyDoc (TLInt i) = PP.pretty i
+  prettyDoc (TLInt neInts) = 
+    PP.hsep (PP.punctuate "|" (PP.pretty <$> S.toList (NES.toSet neInts))) 
   prettyDoc TLUnit = "Unit"
 
 data Type dep ann

--- a/smol-core/test/Test/Helpers.hs
+++ b/smol-core/test/Test/Helpers.hs
@@ -7,7 +7,6 @@ module Test.Helpers
     tyVar,
     tyUnknown,
     tyTuple,
-    tyUnion,
     tyCons,
     bool,
     int,
@@ -62,13 +61,6 @@ tyTuple ::
   [Type dep ann] ->
   Type dep ann
 tyTuple a as = TTuple mempty a (NE.fromList as)
-
-tyUnion ::
-  (Monoid ann) =>
-  Type dep ann ->
-  Type dep ann ->
-  Type dep ann
-tyUnion = TUnion mempty
 
 tyCons ::
   (Monoid ann) =>

--- a/smol-core/test/Test/Helpers.hs
+++ b/smol-core/test/Test/Helpers.hs
@@ -29,11 +29,11 @@ import Data.Foldable (foldl')
 import Data.Functor
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Sequence as Seq
+import qualified Data.Set.NonEmpty as NES
 import Data.Text (Text)
 import GHC.Natural
 import Smol.Core
 import Smol.Core.Typecheck.FromParsedExpr
-import qualified Data.Set.NonEmpty as NES
 
 tyBool :: (Monoid ann) => Type dep ann
 tyBool = TPrim mempty TPBool
@@ -44,8 +44,8 @@ tyBoolLit = TLiteral mempty . TLBool
 tyInt :: (Monoid ann) => Type dep ann
 tyInt = TPrim mempty TPInt
 
-tyIntLit :: (Monoid ann) => Integer -> Type dep ann
-tyIntLit = TLiteral mempty . TLInt . NES.singleton
+tyIntLit :: (Monoid ann) => [Integer] -> Type dep ann
+tyIntLit = TLiteral mempty . TLInt . NES.fromList . NE.fromList
 
 tyNat :: (Monoid ann) => Type dep ann
 tyNat = TPrim mempty TPNat

--- a/smol-core/test/Test/Helpers.hs
+++ b/smol-core/test/Test/Helpers.hs
@@ -33,6 +33,7 @@ import Data.Text (Text)
 import GHC.Natural
 import Smol.Core
 import Smol.Core.Typecheck.FromParsedExpr
+import qualified Data.Set.NonEmpty as NES
 
 tyBool :: (Monoid ann) => Type dep ann
 tyBool = TPrim mempty TPBool
@@ -44,7 +45,7 @@ tyInt :: (Monoid ann) => Type dep ann
 tyInt = TPrim mempty TPInt
 
 tyIntLit :: (Monoid ann) => Integer -> Type dep ann
-tyIntLit = TLiteral mempty . TLInt
+tyIntLit = TLiteral mempty . TLInt . NES.singleton
 
 tyNat :: (Monoid ann) => Type dep ann
 tyNat = TPrim mempty TPNat

--- a/smol-core/test/Test/ParserSpec.hs
+++ b/smol-core/test/Test/ParserSpec.hs
@@ -25,7 +25,7 @@ testInputs =
 
 spec :: Spec
 spec = do
-  fdescribe "Parser" $ do
+  describe "Parser" $ do
     describe "Module" $ do
       it "Parses a single type" $ do
         let result = parseModuleAndFormatError "type Dog a = Woof String | Other a"

--- a/smol-core/test/Test/ParserSpec.hs
+++ b/smol-core/test/Test/ParserSpec.hs
@@ -25,7 +25,7 @@ testInputs =
 
 spec :: Spec
 spec = do
-  describe "Parser" $ do
+  fdescribe "Parser" $ do
     describe "Module" $ do
       it "Parses a single type" $ do
         let result = parseModuleAndFormatError "type Dog a = Woof String | Other a"
@@ -110,6 +110,7 @@ spec = do
       let strings =
             [ ("True", tyBoolLit True),
               ("False", tyBoolLit False),
+              ("1 | 2 | 3", tyIntLit [1, 2, 3]),
               ( "(a -> b) -> Maybe a -> Maybe b",
                 TFunc
                   ()

--- a/smol-core/test/Test/Typecheck/ExhaustivenessSpec.hs
+++ b/smol-core/test/Test/Typecheck/ExhaustivenessSpec.hs
@@ -104,7 +104,7 @@ spec = do
             `shouldBe` Right []
 
         it "Int literal is complete in itself" $ do
-          let ty = tyIntLit 100
+          let ty = tyIntLit [100]
           exhaustiveCheck [PLiteral ty (PInt 100)]
             `shouldBe` Right mempty
 
@@ -117,9 +117,9 @@ spec = do
             `shouldBe` Right [PWildcard tyNat]
 
         it "Union of int literals" $ do
-          let ty = tyUnion (tyIntLit 1) (tyIntLit 2)
+          let ty = tyUnion (tyIntLit [1]) (tyIntLit [2])
           exhaustiveCheck [PLiteral ty (PInt 1)]
-            `shouldBe` Right [PLiteral (tyIntLit 2) (PInt 2)]
+            `shouldBe` Right [PLiteral (tyIntLit [2]) (PInt 2)]
 
         it "Wildcard is fine" $ do
           exhaustiveCheck [PWildcard tyInt] `shouldBe` Right []

--- a/smol-core/test/Test/Typecheck/ExhaustivenessSpec.hs
+++ b/smol-core/test/Test/Typecheck/ExhaustivenessSpec.hs
@@ -117,9 +117,9 @@ spec = do
             `shouldBe` Right [PWildcard tyNat]
 
         it "Union of int literals" $ do
-          let ty = tyUnion (tyIntLit [1]) (tyIntLit [2])
+          let ty = tyIntLit [1, 2]
           exhaustiveCheck [PLiteral ty (PInt 1)]
-            `shouldBe` Right [PLiteral (tyIntLit [2]) (PInt 2)]
+            `shouldBe` Right [PLiteral (tyIntLit [1, 2]) (PInt 2)]
 
         it "Wildcard is fine" $ do
           exhaustiveCheck [PWildcard tyInt] `shouldBe` Right []

--- a/smol-core/test/Test/Typecheck/SubtypeSpec.hs
+++ b/smol-core/test/Test/Typecheck/SubtypeSpec.hs
@@ -117,7 +117,8 @@ spec = do
                 ("Maybe", "Maybe"),
                 ("Maybe 1", "Maybe a"),
                 ("{ item: 1 }", "{}"),
-                ("[1 | 2]", "[Nat]")
+                ("[1 | 2]", "[Nat]"),
+                ("1", "1 | 2")
               ]
         traverse_
           ( \(lhs, rhs) -> it (show lhs <> " <: " <> show rhs) $ do
@@ -128,5 +129,22 @@ spec = do
                       (fromParsedType $ unsafeParseType rhs)
                   )
                 `shouldSatisfy` isRight
+          )
+          validPairs
+
+      describe "Invalid pairs" $ do
+        let validPairs =
+              [ ("Bool", "True"),
+                ("1", "2 | 3")
+              ]
+        traverse_
+          ( \(lhs, rhs) -> it (show lhs <> " <: " <> show rhs) $ do
+              fst
+                <$> runWriterT
+                  ( isSubtypeOf
+                      (fromParsedType $ unsafeParseType lhs)
+                      (fromParsedType $ unsafeParseType rhs)
+                  )
+                `shouldSatisfy` isLeft
           )
           validPairs

--- a/smol-core/test/Test/Typecheck/SubtypeSpec.hs
+++ b/smol-core/test/Test/Typecheck/SubtypeSpec.hs
@@ -24,10 +24,10 @@ spec = do
   describe "Subtyping" $ do
     describe "generaliseLiteral" $ do
       it "Negative literal makes int" $ do
-        generaliseLiteral (tyIntLit (-1))
+        generaliseLiteral (tyIntLit [-1])
           `shouldBe` TPrim () TPInt
       it "Non-negative literal makes nat" $ do
-        generaliseLiteral (tyIntLit 0)
+        generaliseLiteral (tyIntLit [0])
           `shouldBe` TPrim () TPNat
 
     describe "Subtype" $ do

--- a/smol-core/test/Test/Typecheck/SubtypeSpec.hs
+++ b/smol-core/test/Test/Typecheck/SubtypeSpec.hs
@@ -24,10 +24,10 @@ spec = do
   describe "Subtyping" $ do
     describe "generaliseLiteral" $ do
       it "Negative literal makes int" $ do
-        generaliseLiteral (TLiteral () (TLInt (-1)))
+        generaliseLiteral (tyIntLit (-1))
           `shouldBe` TPrim () TPInt
       it "Non-negative literal makes nat" $ do
-        generaliseLiteral (TLiteral () (TLInt 0))
+        generaliseLiteral (tyIntLit 0)
           `shouldBe` TPrim () TPNat
 
     describe "Subtype" $ do

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -48,7 +48,7 @@ testElaborate expr = do
 
 spec :: Spec
 spec = do
-  describe "TypecheckSpec" $ do
+  fdescribe "TypecheckSpec" $ do
     describe "Parse and typecheck" $ do
       let inputs =
             [ ("True", "True"),
@@ -221,7 +221,7 @@ spec = do
     describe "Typecheck" $ do
       it "Infers nat" $ do
         let input = EPrim () (PNat 1)
-            expected = tyIntLit 1
+            expected = tyIntLit [1]
         getExprAnnotation <$> testElaborate input `shouldBe` Right expected
 
       it "Nat literal becomes Nat under annotation" $ do
@@ -240,7 +240,7 @@ spec = do
 
       it "Infers int" $ do
         let input = EPrim () (PInt (-1))
-            expected = tyIntLit (-1)
+            expected = tyIntLit [-1]
         getExprAnnotation <$> testElaborate input `shouldBe` Right expected
 
       it "Nat becomes int under annotation" $ do
@@ -347,7 +347,7 @@ spec = do
       it "Function use in if no annotation" $ do
         let input = unsafeParseExpr "if ((\\a -> a) True) then 1 else 2"
             expected :: Type dep ()
-            expected = tyUnion (tyIntLit 1) (tyIntLit 2)
+            expected = tyUnion (tyIntLit [1]) (tyIntLit [2])
         getExprAnnotation <$> testElaborate input `shouldBe` Right expected
 
       it "If statement combines return types but generalises to Int" $ do
@@ -375,7 +375,7 @@ spec = do
         let input =
               tuple (int 1) [bool True, int 2]
             expected :: Type dep ()
-            expected = tyTuple (tyIntLit 1) [tyBoolLit True, tyIntLit 2]
+            expected = tyTuple (tyIntLit [1]) [tyBoolLit True, tyIntLit [2]]
         getExprAnnotation <$> testElaborate input `shouldBe` Right expected
 
       it "Detects annotated tuple with wrong values" $ do
@@ -424,7 +424,7 @@ spec = do
             input = EApp () argInput (int 1)
 
             expected :: Type dep ()
-            expected = tyIntLit 1
+            expected = tyIntLit [1]
 
         getExprAnnotation <$> testElaborate input
           `shouldBe` Right expected
@@ -442,7 +442,7 @@ spec = do
                 (EApp () (var "f") (int 1))
             input = EApp () fnInput argInput
             expected :: Type dep ()
-            expected = tyIntLit 1
+            expected = tyIntLit [1]
 
         getExprAnnotation <$> testElaborate input
           `shouldBe` Right expected
@@ -456,7 +456,7 @@ spec = do
             fnInput = unsafeParseExpr "\\f -> (f 1, f True)"
             input = EApp () fnInput argInput
             expected :: Type dep ()
-            expected = tyTuple (tyIntLit 1) [tyBoolLit True]
+            expected = tyTuple (tyIntLit [1]) [tyBoolLit True]
 
         getExprAnnotation <$> testElaborate input
           `shouldBe` Right expected
@@ -612,7 +612,7 @@ spec = do
                 ()
                 ( M.fromList
                     [ ("a", tyBoolLit True),
-                      ("b", tyIntLit 1)
+                      ("b", tyIntLit [1])
                     ]
                 )
 
@@ -699,7 +699,7 @@ spec = do
 
       it "Basic let binding" $ do
         let input = unsafeParseExpr "let a = 1; a"
-            expected = ELet (tyIntLit 1) "a" (EPrim (tyIntLit 1) (PNat 1)) (EVar (tyIntLit 1) "a")
+            expected = ELet (tyIntLit [1]) "a" (EPrim (tyIntLit [1]) (PNat 1)) (EVar (tyIntLit [1]) "a")
         testElaborate input `shouldBe` Right expected
 
       it "Function knows about it's external deps" $ do

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -48,7 +48,7 @@ testElaborate expr = do
 
 spec :: Spec
 spec = do
-  fdescribe "TypecheckSpec" $ do
+  describe "TypecheckSpec" $ do
     describe "Parse and typecheck" $ do
       let inputs =
             [ ("True", "True"),
@@ -347,7 +347,7 @@ spec = do
       it "Function use in if no annotation" $ do
         let input = unsafeParseExpr "if ((\\a -> a) True) then 1 else 2"
             expected :: Type dep ()
-            expected = tyUnion (tyIntLit [1]) (tyIntLit [2])
+            expected = tyIntLit [1, 2]
         getExprAnnotation <$> testElaborate input `shouldBe` Right expected
 
       it "If statement combines return types but generalises to Int" $ do


### PR DESCRIPTION
Get rid of `TUnion` because we can't have many unions. Instead make `TLiteral` for ints be a NonEmptySet. When we add string literals, these will also be a NonEmptySet.

- [x] Make TLiteral nonempty type
- [x] Fix the parser
- [x] make everything work
- [x] remove `TUnion`