### PR TITLE
Typechecker boo boos

### DIFF
--- a/smol-core/src/Smol/Core/Helpers.hs
+++ b/smol-core/src/Smol/Core/Helpers.hs
@@ -113,5 +113,5 @@ foldMapM f =
 mapKey :: (Ord k1) => (k -> k1) -> Map k a -> Map k1 a
 mapKey f = M.fromList . fmap (first f) . M.toList
 
-tracePrettyM :: (Printer a, Monad m) => a -> m ()
-tracePrettyM a = traceM (T.unpack $ renderWithWidth 40 $ prettyDoc a)
+tracePrettyM :: (Printer a, Monad m) => String -> a -> m ()
+tracePrettyM msg a = traceM (msg <> ":" <> T.unpack (renderWithWidth 40 $ prettyDoc a))

--- a/smol-core/src/Smol/Core/Typecheck/Substitute.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Substitute.hs
@@ -7,9 +7,12 @@ module Smol.Core.Typecheck.Substitute
   ( Substitution (..),
     SubstitutionMatcher (..),
     substituteMany,
+    getUnknownId,
   )
 where
 
+import qualified Prettyprinter as PP
+import Smol.Core.Printer
 import Smol.Core.Types
 
 data SubstitutionMatcher dep ann
@@ -40,6 +43,9 @@ deriving stock instance
 
 data Substitution dep ann
   = Substitution (SubstitutionMatcher dep ann) (Type dep ann)
+
+instance (Show ann, Show (dep Identifier), Show (dep TypeName)) => Printer (Substitution dep ann) where
+  prettyDoc a = PP.pretty (show a)
 
 deriving stock instance
   (Eq ann, Eq (dep Identifier), Eq (dep TypeName)) =>

--- a/smol-core/test/Test/ParserSpec.hs
+++ b/smol-core/test/Test/ParserSpec.hs
@@ -144,7 +144,8 @@ spec = do
                   )
               ),
               ("Maybe.Maybe", TConstructor () (ParseDep "Maybe" (Just "Maybe"))),
-              ("[Bool]", TArray () 0 tyBool)
+              ("[Bool]", TArray () 0 tyBool),
+              ("Either e a", tyCons "Either" [tyVar "e", tyVar "a"])
             ]
       traverse_
         ( \(str, ty) -> it (T.unpack str) $ do

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -79,6 +79,7 @@ spec = do
               ("(That 1 : These a 1)", "These a 1"),
               ("These 1 True", "These 1 True"),
               ("(Left 1 : Either 1 Bool)", "Either 1 Bool"),
+              ("(Right True : Either e True)", "Either e True"),
               ("(case Just 1 of Just a -> a | _ -> 0 : Nat)", "Nat"),
               ("(\\a -> case a of 1 -> 10 | 2 -> 20 : (1 | 2) -> Nat) 1", "Nat"),
               ("(\\a -> case a of (1,_) -> 10 | (2,_) -> 20 : (1 | 2,Bool) -> Nat) (1,False)", "Nat"),
@@ -89,7 +90,8 @@ spec = do
               ("(\\f -> \\maybe -> case maybe of Just a -> Just (f a) | Nothing -> Nothing : (b -> a) -> Maybe b -> Maybe a)", "(b -> a) -> Maybe b -> Maybe a"),
               ("(case (This 42 : These Nat Nat) of This a -> a : Nat)", "Nat"),
               ("let fmap = (\\f -> \\maybe -> case maybe of Just a -> Just (f a) | Nothing -> Nothing : (a -> b) -> Maybe a -> Maybe b); let inc = (\\a -> True : Nat -> Bool); fmap inc", "Maybe Nat -> Maybe Bool"),
-              -- ("let fmap = (\\f -> \\either -> case either of Right a -> Right (f a) | Left e -> Left e : (a -> b) -> Either e a -> Either e b); let inc = (\\a -> True : Nat -> Bool); fmap inc", "Either e Nat -> Either e Bool"),
+              ("let fmap = (\\f -> \\either -> case either of Right a -> Right (f a) | Left e -> Left e : (a -> b) -> Either e a -> Either e b); let inc = (\\a -> True : Nat -> Bool); fmap inc", "Either e Nat -> Either e Bool"),
+              ("let fmap = (\\f -> \\either -> case either of Right a -> Right (f a) | Left e -> Left e : (a -> b) -> Either e a -> Either e b); fmap", "(a -> b) -> Either e a -> Either e b"),
               ( "let const = (\\a -> \\b -> a : a -> b -> a); const True 100",
                 "True"
               ),
@@ -152,12 +154,12 @@ spec = do
       it "No unknowns" $ do
         let input = fromParsedType $ unsafeParseType "Int -> Int"
             expected = input
-        evalState (freshen input) emptyState `shouldBe` expected
+        evalState (freshen input) emptyState `shouldBe` (expected, [])
 
       it "A -> A becomes 1 -> 1" $ do
         let input = fromParsedType $ TFunc () mempty (tyVar "A") (tyVar "A")
             expected = TFunc () mempty (tyUnknown 0) (tyUnknown 0)
-        evalState (freshen input) emptyState `shouldBe` expected
+        evalState (freshen input) emptyState `shouldBe` (expected, [Substitution (SubUnknown 0) (TVar () "A")])
 
     describe "getApplyReturnType" $ do
       it "Simple function" $ do


### PR DESCRIPTION
Resolves #938 

We were parsing `Either e a` as `Either (e a)` which messed stuff up. Also we generalised stuff and didn't put it back if unneeded, so partially applied functions would lose their types, that is also fixed.