### PR TITLE
Nicer type signatures

### DIFF
--- a/smol-backend/src/Smol/Backend/IR/FromExpr/Expr.hs
+++ b/smol-backend/src/Smol/Backend/IR/FromExpr/Expr.hs
@@ -35,7 +35,7 @@ import Smol.Core.Types.Constructor
 import Smol.Core.Types.DataType
 import Smol.Core.Types.Expr
 import Smol.Core.Types.Identifier
-import Smol.Core.Types.Module (DefIdentifier (..), Module (..))
+import Smol.Core.Types.Module (DefIdentifier (..), Module (..), TopLevelExpression (..))
 import Smol.Core.Types.Op
 import Smol.Core.Types.Prim
 import Smol.Core.Types.ResolvedDep
@@ -156,11 +156,11 @@ irFromModule myModule =
           . M.toList
           $ moDataTypes myModule
    in IRModule $
-        [ IRExternDef $ getPrinter (getExprAnnotation mainFunc),
+        [ IRExternDef $ getPrinter (getExprAnnotation $ tleExpr mainFunc),
           IRExternDef irStringConcat,
           IRExternDef irStringEquals -- we should dynamically include these once we get a lot of stdlib helpers
         ]
-          <> modulePartsFromExpr dataTypes otherFuncs mainFunc
+          <> modulePartsFromExpr dataTypes (tleExpr <$> otherFuncs) (tleExpr mainFunc)
 
 fromPrim :: (Monad m) => Prim -> m IRExpr
 fromPrim (PInt i) = pure $ IRPrim (IRPrimInt32 i)

--- a/smol-backend/test/Test/IR/IRSpec.hs
+++ b/smol-backend/test/Test/IR/IRSpec.hs
@@ -105,7 +105,8 @@ spec = do
                 ],
                 "42"
               ),
-              ( [ "def add (a: Nat) (b : Nat): Nat = a + b",
+              ( [ "def add : Nat -> Nat -> Nat",
+                  "def add a b = a + b",
                   "def main = add 20 22"
                 ],
                 "42"
@@ -126,7 +127,8 @@ spec = do
                 "42"
               ),
               ( [ "type Identity a = Identity a",
-                  "def runIdentity (identA: Identity Int): Int = case identA of Identity b -> b",
+                  "def runIdentity : Identity Int -> Int",
+                  "def runIdentity identA = case identA of Identity b -> b",
                   "def main = runIdentity (Identity 42)"
                 ],
                 "42"

--- a/smol-core/smol-core.cabal
+++ b/smol-core/smol-core.cabal
@@ -111,6 +111,7 @@ library
     Smol.Core.Types.Module.Module
     Smol.Core.Types.Module.ModuleHash
     Smol.Core.Types.Module.ModuleName
+    Smol.Core.Types.Module.TopLevelExpression
     Smol.Core.Types.Op
     Smol.Core.Types.ParseDep
     Smol.Core.Types.Pattern

--- a/smol-core/src/Smol/Core/Modules/Check.hs
+++ b/smol-core/src/Smol/Core/Modules/Check.hs
@@ -45,6 +45,7 @@ getModuleItemIdentifier (ModuleExpression name _ _) = Just (DIName name)
 getModuleItemIdentifier (ModuleDataType (DataType typeName _ _)) = Just (DIType typeName)
 getModuleItemIdentifier (ModuleExport a) = getModuleItemIdentifier a
 getModuleItemIdentifier (ModuleImport _) = Nothing
+getModuleItemIdentifier (ModuleExpressionType name _) = Just (DIName name)
 
 -- getModuleItemIdentifier (ModuleTest testName _) = Just (DITest testName)
 

--- a/smol-core/src/Smol/Core/Modules/Check.hs
+++ b/smol-core/src/Smol/Core/Modules/Check.hs
@@ -3,8 +3,7 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Smol.Core.Modules.Check
-  ( getModuleType,
-    getModuleItemIdentifier,
+  ( getModuleItemIdentifier,
     lookupModuleDefType,
     lookupModuleDef,
     filterNameDefs,
@@ -19,11 +18,12 @@ import Smol.Core
 import Smol.Core.Helpers (filterMapKeys)
 import Smol.Core.Types.Module.DefIdentifier
 import Smol.Core.Types.Module.Module
+import Smol.Core.Types.Module.TopLevelExpression
 
 lookupModuleDef ::
   Module dep (Type dep ann) ->
   DefIdentifier ->
-  Maybe (Expr dep (Type dep ann))
+  Maybe (TopLevelExpression dep (Type dep ann))
 lookupModuleDef mod' defId =
   let defs =
         M.filterWithKey
@@ -36,7 +36,7 @@ lookupModuleDefType ::
   DefIdentifier ->
   Maybe (Type dep ann)
 lookupModuleDefType =
-  (fmap . fmap) getExprAnnotation . lookupModuleDef
+  (fmap . fmap) (getExprAnnotation . tleExpr) . lookupModuleDef
 
 -- used in logging etc, "what is this thing"
 getModuleItemIdentifier :: ModuleItem ann -> Maybe DefIdentifier
@@ -48,17 +48,6 @@ getModuleItemIdentifier (ModuleImport _) = Nothing
 getModuleItemIdentifier (ModuleExpressionType name _) = Just (DIName name)
 
 -- getModuleItemIdentifier (ModuleTest testName _) = Just (DITest testName)
-
--- return type of module as a MTRecord of dep -> monotype
--- TODO: module should probably be it's own MTModule or something
--- as we'll want to pass them about at some point I think
-getModuleType :: (Monoid ann) => Module dep (Type dep ann) -> Type dep ann
-getModuleType mod' =
-  let defs =
-        M.filterWithKey
-          (\k _ -> S.member k (moExpressionExports mod'))
-          (moExpressions mod')
-   in TRecord mempty (getExprAnnotation <$> filterNameDefs defs)
 
 filterNameDefs :: Map DefIdentifier a -> Map Identifier a
 filterNameDefs =

--- a/smol-core/src/Smol/Core/Modules/Dependencies.hs
+++ b/smol-core/src/Smol/Core/Modules/Dependencies.hs
@@ -27,6 +27,7 @@ import Smol.Core.Types.Module.DefIdentifier
 import qualified Smol.Core.Types.Module.Entity as E
 import Smol.Core.Types.Module.Module
 import Smol.Core.Types.Module.ModuleHash
+import Smol.Core.Types.Module.TopLevelExpression
 
 filterExprs :: Map k (DepType dep ann) -> Map k (Expr dep ann)
 filterExprs =
@@ -187,14 +188,14 @@ getExprDependencies ::
   (MonadError ModuleError m) =>
   (Expr dep ann -> Set E.Entity) ->
   Module dep ann ->
-  Expr dep ann ->
+  TopLevelExpression dep ann ->
   m (DepType dep ann, Set DefIdentifier, Set E.Entity)
 getExprDependencies getUses mod' expr = do
-  let allUses = getUses expr
+  let allUses = getUses (tleExpr expr)
   exprDefIds <- getExprDeps mod' allUses
   consDefIds <- getConstructorUses mod' allUses
   typeDefIds <- getTypeUses mod' allUses
-  pure (DTExpr expr, exprDefIds <> typeDefIds <> consDefIds, allUses)
+  pure (DTExpr (tleExpr expr), exprDefIds <> typeDefIds <> consDefIds, allUses)
 
 getExprDeps ::
   (MonadError ModuleError m) =>

--- a/smol-core/src/Smol/Core/Modules/Dependencies.hs
+++ b/smol-core/src/Smol/Core/Modules/Dependencies.hs
@@ -29,11 +29,11 @@ import Smol.Core.Types.Module.Module
 import Smol.Core.Types.Module.ModuleHash
 import Smol.Core.Types.Module.TopLevelExpression
 
-filterExprs :: Map k (DepType dep ann) -> Map k (Expr dep ann)
+filterExprs :: Map k (DepType dep ann) -> Map k (TopLevelExpression dep ann)
 filterExprs =
   M.mapMaybe
     ( \case
-        (DTExpr expr) -> Just expr
+        (DTExpr tle) -> Just tle
         _ -> Nothing
     )
 
@@ -195,7 +195,7 @@ getExprDependencies getUses mod' expr = do
   exprDefIds <- getExprDeps mod' allUses
   consDefIds <- getConstructorUses mod' allUses
   typeDefIds <- getTypeUses mod' allUses
-  pure (DTExpr (tleExpr expr), exprDefIds <> typeDefIds <> consDefIds, allUses)
+  pure (DTExpr expr, exprDefIds <> typeDefIds <> consDefIds, allUses)
 
 getExprDeps ::
   (MonadError ModuleError m) =>

--- a/smol-core/src/Smol/Core/Modules/FromParts.hs
+++ b/smol-core/src/Smol/Core/Modules/FromParts.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TupleSections #-}
 
 module Smol.Core.Modules.FromParts (addModulePart, moduleFromModuleParts, exprAndTypeFromParts) where
@@ -16,6 +16,7 @@ import Smol.Core.Modules.Monad
 import Smol.Core.Types.Module.DefIdentifier
 import Smol.Core.Types.Module.Module
 import Smol.Core.Types.Module.ModuleHash
+import Smol.Core.Types.Module.TopLevelExpression
 
 moduleFromModuleParts ::
   ( MonadError ModuleError m,
@@ -122,10 +123,12 @@ exprAndTypeFromParts ::
   (Monoid ann) =>
   [Identifier] ->
   Expr ParseDep ann ->
-  Expr ParseDep ann
-exprAndTypeFromParts parts expr = do
-  foldr
-    ( ELambda mempty . emptyParseDep
-    )
-    expr
-    parts
+  TopLevelExpression ParseDep ann
+exprAndTypeFromParts parts expr =
+  let tleExpr =
+        foldr
+          (ELambda mempty . emptyParseDep)
+          expr
+          parts
+      tleType = Nothing
+   in TopLevelExpression {..}

--- a/smol-core/src/Smol/Core/Modules/Monad.hs
+++ b/smol-core/src/Smol/Core/Modules/Monad.hs
@@ -24,6 +24,7 @@ import Smol.Core.Modules.ModuleError
 import Smol.Core.Types.Module.DefIdentifier
 import Smol.Core.Types.Module.Module
 import Smol.Core.Types.Module.ModuleHash
+import Smol.Core.Types.Module.TopLevelExpression
 
 lookupModule ::
   (MonadError ModuleError m) =>
@@ -40,7 +41,7 @@ lookupModuleDep ::
   Map ModuleHash (Module dep (Type dep Annotation)) ->
   DefIdentifier ->
   ModuleHash ->
-  m (Expr dep (Type dep Annotation))
+  m (TopLevelExpression dep (Type dep Annotation))
 lookupModuleDep typecheckedModules def modHash = do
   case M.lookup modHash typecheckedModules of
     Just mod' ->

--- a/smol-core/src/Smol/Core/Modules/ResolveDeps.hs
+++ b/smol-core/src/Smol/Core/Modules/ResolveDeps.hs
@@ -101,6 +101,14 @@ resolveType (TGlobals ann bits inner) =
 resolveType (TRecord ann as) = TRecord ann (resolveType <$> as)
 resolveType (TApp ann fn arg) = TApp ann (resolveType fn) (resolveType arg)
 
+-- resolve Expr (s) and Type pls
+resolveTopLevelExpression ::
+  TopLevelExpression ParseDep ann ->
+  Set DefIdentifier ->
+  Set Constructor ->
+  m (TopLevelExpression ResolvedDep ann)
+resolveTopLevelExpression tle localDefs localTypes = undefined
+
 resolveExpr ::
   (Show ann, MonadError ModuleError m, MonadState ResolveState m) =>
   Expr ParseDep ann ->

--- a/smol-core/src/Smol/Core/Modules/ResolveDeps.hs
+++ b/smol-core/src/Smol/Core/Modules/ResolveDeps.hs
@@ -27,6 +27,7 @@ import Smol.Core.Modules.Types.DepType
 import Smol.Core.Modules.Uses
 import Smol.Core.Types.Module.DefIdentifier
 import Smol.Core.Types.Module.Module
+import Smol.Core.Types.Module.TopLevelExpression
 
 resolveExprDeps ::
   (Show ann, MonadError ModuleError m) =>
@@ -43,7 +44,7 @@ resolveModuleDeps parsedModule = do
   let resolveIt (DTData dt, _, _) =
         pure (Left (resolveDataType dt))
       resolveIt (DTExpr expr, defIds, _entities) =
-        Right <$> resolveExpr expr defIds (allConstructors parsedModule)
+        Right <$> resolveTopLevelExpression expr defIds (allConstructors parsedModule)
   resolvedMap <- evalStateT (traverse resolveIt map') (ResolveState 0)
   let newExpressions =
         M.mapMaybe
@@ -103,11 +104,17 @@ resolveType (TApp ann fn arg) = TApp ann (resolveType fn) (resolveType arg)
 
 -- resolve Expr (s) and Type pls
 resolveTopLevelExpression ::
+  (Show ann, MonadState ResolveState m, MonadError ModuleError m) =>
   TopLevelExpression ParseDep ann ->
   Set DefIdentifier ->
   Set Constructor ->
   m (TopLevelExpression ResolvedDep ann)
-resolveTopLevelExpression tle localDefs localTypes = undefined
+resolveTopLevelExpression tle localDefs localTypes = flip runReaderT initialEnv $ do
+  resolvedExpr <- resolveM (tleExpr tle)
+  let resolvedType = fmap resolveType (tleType tle)
+  pure (TopLevelExpression {tleExpr = resolvedExpr, tleType = resolvedType})
+  where
+    initialEnv = ResolveEnv mempty localDefs localTypes
 
 resolveExpr ::
   (Show ann, MonadError ModuleError m, MonadState ResolveState m) =>

--- a/smol-core/src/Smol/Core/Modules/Typecheck.hs
+++ b/smol-core/src/Smol/Core/Modules/Typecheck.hs
@@ -3,8 +3,6 @@
 
 module Smol.Core.Modules.Typecheck (typecheckModule) where
 
--- import Smol.Core.Types.Module.ModuleName
-
 import qualified Builder as Build
 import Control.Monad.Except
 import Data.Bifunctor (first)

--- a/smol-core/src/Smol/Core/Modules/Typecheck.hs
+++ b/smol-core/src/Smol/Core/Modules/Typecheck.hs
@@ -9,9 +9,6 @@ import qualified Builder as Build
 import Control.Monad.Except
 import Data.Bifunctor (first)
 import Data.Map.Strict (Map)
--- import Smol.Core.Modules.HashModule
--- import Smol.Core.Modules.Monad
-
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Set (Set)
@@ -22,9 +19,7 @@ import Smol.Core.Modules.Check (filterNameDefs, filterTypeDefs)
 import Smol.Core.Modules.Dependencies
 import Smol.Core.Modules.ModuleError
 import Smol.Core.Modules.Types.DepType
-import Smol.Core.Types.Module.DefIdentifier
-import Smol.Core.Types.Module.Module
-import Smol.Core.Types.Module.ModuleHash
+import Smol.Core.Types.Module
 
 getModuleDefIdentifiers ::
   Map DefIdentifier (Set DefIdentifier) ->
@@ -170,10 +165,10 @@ typecheckOneExprDef ::
   Text ->
   Module ResolvedDep Annotation ->
   Map DefIdentifier (DepType ResolvedDep (Type ResolvedDep Annotation)) ->
-  (DefIdentifier, Expr ResolvedDep Annotation) ->
-  m (Expr ResolvedDep (Type ResolvedDep Annotation))
-typecheckOneExprDef input _inputModule deps (def, expr) = do
-  let exprTypeMap = mapKey LocalDefinition $ getExprAnnotation <$> filterNameDefs (filterExprs deps)
+  (DefIdentifier, TopLevelExpression ResolvedDep Annotation) ->
+  m (TopLevelExpression ResolvedDep (Type ResolvedDep Annotation))
+typecheckOneExprDef input _inputModule deps (def, tle) = do
+  let exprTypeMap = mapKey LocalDefinition $ getExprAnnotation . tleExpr <$> filterNameDefs (filterExprs deps)
 
   -- initial typechecking environment
   let env =
@@ -183,8 +178,21 @@ typecheckOneExprDef input _inputModule deps (def, expr) = do
             tceGlobals = mempty
           }
 
+  -- if we have a type, add an annotation
+  let actualExpr = case tleType tle of
+        Nothing -> tleExpr tle
+        Just ty -> EAnn (getTypeAnnotation ty) ty (tleExpr tle)
+
   -- typecheck it
-  liftEither $
-    first
-      (DefDoesNotTypeCheck input def)
-      (elaborate env expr)
+  newExpr <-
+    liftEither $
+      first
+        (DefDoesNotTypeCheck input def)
+        (elaborate env actualExpr)
+
+  -- split the type out again
+  let (typedType, typedExpr) = case newExpr of
+        (EAnn _ ty expr) -> (Just ty, expr)
+        other -> (Nothing, other)
+
+  pure (TopLevelExpression typedExpr typedType)

--- a/smol-core/src/Smol/Core/Modules/Types/DepType.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/DepType.hs
@@ -8,9 +8,10 @@ module Smol.Core.Modules.Types.DepType
 where
 
 import Smol.Core
+import Smol.Core.Types.Module.TopLevelExpression
 
 data DepType dep ann
-  = DTExpr (Expr dep ann)
+  = DTExpr (TopLevelExpression dep ann)
   | DTData (DataType dep ann)
 
 deriving stock instance

--- a/smol-core/src/Smol/Core/Parser.hs
+++ b/smol-core/src/Smol/Core/Parser.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Smol.Core.Parser
-  ( parseExpr,
+  ( parseAndFormat,
+    parseExpr,
     parseExprAndFormatError,
     parseTypeAndFormatError,
     parseType,

--- a/smol-core/src/Smol/Core/Parser/Module.hs
+++ b/smol-core/src/Smol/Core/Parser/Module.hs
@@ -119,5 +119,4 @@ parseImportAll = do
   myString "import"
   myString "*"
   myString "from"
-  hash <- parseHash
-  pure (ModuleImport (ImportAllFromHash hash))
+  ModuleImport . ImportAllFromHash <$> parseHash

--- a/smol-core/src/Smol/Core/Parser/Module.hs
+++ b/smol-core/src/Smol/Core/Parser/Module.hs
@@ -29,9 +29,9 @@ type Parser = Parsec Void Text
 moduleParser :: Parser [ModuleItem Annotation]
 moduleParser =
   mconcat
-        <$> ( chainl1 ((\a -> [[a]]) <$> parseModuleItem) (pure (<>))
-                <|> pure mempty
-            )
+    <$> ( chainl1 ((\a -> [[a]]) <$> parseModuleItem) (pure (<>))
+            <|> pure mempty
+        )
 
 -- why is this fucked? because we don't stop parsing at the end of a def
 -- parsing >>>

--- a/smol-core/src/Smol/Core/Parser/Module.hs
+++ b/smol-core/src/Smol/Core/Parser/Module.hs
@@ -33,18 +33,6 @@ moduleParser =
             <|> pure mempty
         )
 
--- why is this fucked? because we don't stop parsing at the end of a def
--- parsing >>>
--- id : a -> a
--- id a = a
--- <<<
--- fails because we continue parsing the definition as part of the type
--- therefore we need indentation sensitive parsers:
--- https://markkarpov.com/tutorial/megaparsec.html#indentationsensitive-parsing
---
--- we should try parsing as "the identifier should not be indented but the rest
--- must be"
-
 -- we've excluded Export here
 parseModuleItem :: Parser (ModuleItem Annotation)
 parseModuleItem =
@@ -67,9 +55,9 @@ moduleTypeDeclarationParser = ModuleDataType <$> dataTypeParser
 -------
 
 -- definitions
--- oneHundred = 100
--- id a = a
--- const a b = a
+-- def oneHundred = 100
+-- def id a = a
+-- def const a b = a
 --
 -- top level definition
 moduleDefinitionParser :: Parser (ModuleItem Annotation)
@@ -83,8 +71,8 @@ moduleDefinitionParser = do
   ModuleExpression name parts <$> expressionParser
 
 -- top level type definition
--- id : a -> a
--- compose : (b -> c) -> (a -> b) -> (a -> c)
+-- def id : a -> a
+-- def compose : (b -> c) -> (a -> b) -> (a -> c)
 moduleTypeDefinitionParser :: Parser (ModuleItem Annotation)
 moduleTypeDefinitionParser = do
   myString "def"

--- a/smol-core/src/Smol/Core/Parser/Shared.hs
+++ b/smol-core/src/Smol/Core/Parser/Shared.hs
@@ -74,7 +74,13 @@ chainl1 p op = do x <- p; rest x
         <|> return x
 
 myLexeme :: Parser a -> Parser a
-myLexeme = L.lexeme (L.space space1 empty empty)
+myLexeme =
+  L.lexeme
+    ( L.space
+        space1
+        (L.skipLineComment "//")
+        (L.skipBlockComment "/*" "*/")
+    )
 
 myString :: Text -> Parser ()
 myString s = myLexeme (string s) $> ()

--- a/smol-core/src/Smol/Core/Types/Module.hs
+++ b/smol-core/src/Smol/Core/Types/Module.hs
@@ -4,6 +4,7 @@ module Smol.Core.Types.Module
     module Smol.Core.Types.Module.ModuleName,
     module Smol.Core.Types.Module.ModuleHash,
     module Smol.Core.Types.Module.DefIdentifier,
+    module Smol.Core.Types.Module.TopLevelExpression,
   )
 where
 
@@ -12,3 +13,4 @@ import Smol.Core.Types.Module.Entity
 import Smol.Core.Types.Module.Module
 import Smol.Core.Types.Module.ModuleHash
 import Smol.Core.Types.Module.ModuleName
+import Smol.Core.Types.Module.TopLevelExpression

--- a/smol-core/src/Smol/Core/Types/Module/Module.hs
+++ b/smol-core/src/Smol/Core/Types/Module/Module.hs
@@ -11,7 +11,6 @@
 
 module Smol.Core.Types.Module.Module
   ( Module (..),
-    DefPart (..),
     ModuleItem (..),
     Import (..),
   )
@@ -25,7 +24,6 @@ import qualified Data.Set as S
 import GHC.Generics (Generic)
 import Prettyprinter
 import Smol.Core.Printer
-import Smol.Core.Types.Annotated
 import Smol.Core.Types.Constructor
 import Smol.Core.Types.DataType
 import Smol.Core.Types.Expr
@@ -41,22 +39,14 @@ import Smol.Core.Types.TypeName
 -- it defines some datatypes, infixes and definitions
 -- and it probably exports one or more of those
 
-data DefPart ann
-  = -- | typeless argument `a`
-    DefArg (Annotated Identifier ann)
-  | -- | argument with type `(a: String) ->`
-    DefTypedArg (Annotated Identifier ann) (ParsedType ann)
-  | -- | type with no binding `String`
-    DefType (ParsedType ann)
-  deriving stock (Eq, Ord, Show, Functor)
-
 -- item parsed from file, kept like this so we can order them and have
 -- duplicates
 -- we will remove duplicates when we work out dependencies between everything
 -- TODO: add more annotations to everything so we can produce clearer errors
 -- when things don't make sense (duplicate defs etc)
 data ModuleItem ann
-  = ModuleExpression Identifier [DefPart ann] (ParsedExpr ann)
+  = ModuleExpression Identifier [Identifier] (ParsedExpr ann)
+  | ModuleExpressionType Identifier (Type ParseDep ann)
   | ModuleDataType (DataType ParseDep ann)
   | ModuleExport (ModuleItem ann)
   | ModuleImport Import

--- a/smol-core/src/Smol/Core/Types/Module/Module.hs
+++ b/smol-core/src/Smol/Core/Types/Module/Module.hs
@@ -127,7 +127,7 @@ deriving anyclass instance
 instance Printer (Module ParseDep ann) where
   prettyDoc mod' =
     let printedDefs =
-          uncurry (printDefinition mod')
+          uncurry printDefinition
             <$> M.toList (moExpressions mod')
         printedTypes =
           uncurry (printTypeDef mod')
@@ -173,24 +173,8 @@ printTypeDef mod' tn dt =
           else ""
    in prettyExp <> prettyDoc dt
 
--- given annotation and expr, pair annotation types with lambdas
-printPaired :: ParsedType ann -> ParsedExpr ann -> Doc style
-printPaired (TFunc _ _ fn arg) (ELambda _ ident body) =
-  "(" <> prettyDoc ident
-    <+> ":"
-    <+> prettyDoc fn
-      <> ")"
-      <> line
-      <> printPaired arg body
-printPaired mt expr =
-  ":"
-    <+> prettyDoc mt
-    <+> "="
-      <> line
-      <> indentMulti 2 (prettyDoc expr)
-
-printDefinition :: Module ParseDep ann -> DefIdentifier -> TopLevelExpression ParseDep ann -> Doc a
-printDefinition mod' def (TopLevelExpression {tleType, tleExpr}) =
+printDefinition :: DefIdentifier -> TopLevelExpression ParseDep ann -> Doc a
+printDefinition def (TopLevelExpression {tleType, tleExpr}) =
   case def of
     DIName name ->
       let prettyExpr =

--- a/smol-core/src/Smol/Core/Types/Module/Module.hs
+++ b/smol-core/src/Smol/Core/Types/Module/Module.hs
@@ -66,10 +66,17 @@ data Import
   | ImportNamedFromHash ModuleHash ModuleName
   deriving stock (Eq, Ord, Show)
 
+-- a single expression of zero or more exprs and an optional type
+data TopLevelExpression dep ann
+  = TopLevelExpression
+      { meExprs :: [Expr dep ann],
+        meType :: Maybe (Type dep ann)
+      } deriving stock (Functor, Generic)
+
 -- this is the checked module, it contains no duplicates and we don't care
 -- about ordering
 data Module dep ann = Module
-  { moExpressions :: Map DefIdentifier (Expr dep ann),
+  { moExpressions :: Map DefIdentifier (TopLevelExpression dep ann),
     moExpressionExports :: Set DefIdentifier,
     moExpressionImports :: Map DefIdentifier ModuleHash, -- what we imported, where it's from
     moDataTypes :: Map TypeName (DataType dep ann),
@@ -121,6 +128,9 @@ deriving anyclass instance
     FromJSON (dep Identifier)
   ) =>
   FromJSON (Module dep ann)
+
+instance Printer (TopLevelExpression ParseDep ann) where
+  prettyDoc (TopLevelExpression meExprs meType) = ""
 
 instance Printer (Module ParseDep ann) where
   prettyDoc mod' =

--- a/smol-core/src/Smol/Core/Types/Module/TopLevelExpression.hs
+++ b/smol-core/src/Smol/Core/Types/Module/TopLevelExpression.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Smol.Core.Types.Module.TopLevelExpression
+  ( TopLevelExpression(..)
+  )
+where
+
+import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import Data.Set (Set)
+import qualified Data.Set as S
+import GHC.Generics (Generic)
+import Prettyprinter
+import Smol.Core.Printer
+import Smol.Core.Types.Constructor
+import Smol.Core.Types.DataType
+import Smol.Core.Types.Expr
+import Smol.Core.Types.Identifier
+import Smol.Core.Types.Module.DefIdentifier
+import Smol.Core.Types.Module.ModuleHash
+import Smol.Core.Types.Module.ModuleName
+import Smol.Core.Types.ParseDep
+import Smol.Core.Types.Type
+import Smol.Core.Types.TypeName
+
+-- a module is, broadly, one file
+-- it defines some datatypes, infixes and definitions
+-- and it probably exports one or more of those
+
+-- a single expression of zero or more exprs and an optional type
+data TopLevelExpression dep ann = TopLevelExpression
+  { tleExpr :: Expr dep ann,
+    tleType :: Maybe (Type dep ann)
+  }
+  deriving stock (Functor, Generic)
+
+deriving stock instance
+  ( Eq ann,
+    Eq (dep Identifier),
+    Eq (dep Constructor),
+    Eq (dep TypeName)
+  ) =>
+  Eq (TopLevelExpression dep ann)
+
+deriving stock instance
+  ( Ord ann,
+    Ord (dep Identifier),
+    Ord (dep Constructor),
+    Ord (dep TypeName)
+  ) =>
+  Ord (TopLevelExpression dep ann)
+
+deriving stock instance
+  ( Show ann,
+    Show (dep Identifier),
+    Show (dep Constructor),
+    Show (dep TypeName)
+  ) =>
+  Show (TopLevelExpression dep ann)
+
+deriving anyclass instance
+  ( ToJSON ann,
+    ToJSONKey (dep Identifier),
+    ToJSON (dep Identifier),
+    ToJSON (dep Constructor),
+    ToJSON (dep TypeName)
+  ) =>
+  ToJSON (TopLevelExpression dep ann)
+
+deriving anyclass instance
+  ( ToJSON ann,
+    ToJSON (dep Identifier),
+    ToJSON (dep Constructor),
+    ToJSON (dep TypeName),
+    ToJSONKey ann,
+    ToJSONKey (dep Identifier),
+    ToJSONKey (dep Constructor),
+    ToJSONKey (dep TypeName)
+  ) =>
+  ToJSONKey (TopLevelExpression dep ann)
+
+deriving anyclass instance
+  ( FromJSONKey (dep Identifier), Ord (dep Identifier), FromJSON ann,
+    FromJSON (dep Identifier),
+    FromJSON (dep Constructor),
+    FromJSON (dep TypeName)
+  ) =>
+  FromJSON (TopLevelExpression dep ann)
+

--- a/smol-core/src/Smol/Core/Types/Module/TopLevelExpression.hs
+++ b/smol-core/src/Smol/Core/Types/Module/TopLevelExpression.hs
@@ -9,26 +9,15 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Smol.Core.Types.Module.TopLevelExpression
-  ( TopLevelExpression(..)
+  ( TopLevelExpression (..),
   )
 where
 
 import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
-import Data.Set (Set)
-import qualified Data.Set as S
 import GHC.Generics (Generic)
-import Prettyprinter
-import Smol.Core.Printer
 import Smol.Core.Types.Constructor
-import Smol.Core.Types.DataType
 import Smol.Core.Types.Expr
 import Smol.Core.Types.Identifier
-import Smol.Core.Types.Module.DefIdentifier
-import Smol.Core.Types.Module.ModuleHash
-import Smol.Core.Types.Module.ModuleName
-import Smol.Core.Types.ParseDep
 import Smol.Core.Types.Type
 import Smol.Core.Types.TypeName
 
@@ -89,10 +78,11 @@ deriving anyclass instance
   ToJSONKey (TopLevelExpression dep ann)
 
 deriving anyclass instance
-  ( FromJSONKey (dep Identifier), Ord (dep Identifier), FromJSON ann,
+  ( FromJSONKey (dep Identifier),
+    Ord (dep Identifier),
+    FromJSON ann,
     FromJSON (dep Identifier),
     FromJSON (dep Constructor),
     FromJSON (dep TypeName)
   ) =>
   FromJSON (TopLevelExpression dep ann)
-

--- a/smol-core/test/Test/ParserSpec.hs
+++ b/smol-core/test/Test/ParserSpec.hs
@@ -14,7 +14,6 @@ import qualified Data.Sequence as Seq
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
-import Debug.Trace
 import Smol.Core
 import Test.Helpers
 import Test.Hspec
@@ -27,22 +26,22 @@ testInputs =
 spec :: Spec
 spec = do
   describe "Parser" $ do
-    fdescribe "Module" $ do
+    describe "Module" $ do
       let singleDefs =
             [ "type Dog a = Woof String | Other a",
-              "id a = a",
-              "id: a -> a",
-              "compose f g a = f (g a)",
-              "compose : (c -> b) -> (a -> b) -> (a -> c)"
+              "def id : a -> a",
+              "def id a = a",
+              "def compose f g a = f (g a)",
+              "def compose : (c -> b) -> (a -> b) -> (a -> c)"
             ]
 
       it "All defs" $ do
-        let result = traceShowId $ parseModuleAndFormatError (T.intercalate ";" (T.pack <$> singleDefs))
+        let result = parseModuleAndFormatError (T.intercalate "\n" (T.pack <$> singleDefs))
         result `shouldSatisfy` isRight
 
       traverse_
         ( \input -> it ("Parses module item: " <> input) $ do
-            let result = traceShowId $ parseModuleAndFormatError (T.pack input)
+            let result = parseModuleAndFormatError (T.pack input)
 
             result `shouldSatisfy` isRight
         )
@@ -121,7 +120,7 @@ spec = do
         )
         strings
 
-    fdescribe "Type" $ do
+    describe "Type" $ do
       let strings =
             [ ("True", tyBoolLit True),
               ("False", tyBoolLit False),

--- a/smol-core/test/Test/ParserSpec.hs
+++ b/smol-core/test/Test/ParserSpec.hs
@@ -31,13 +31,13 @@ spec = do
       let singleDefs =
             [ "type Dog a = Woof String | Other a",
               "id a = a",
-              "id : a -> a",
+              "id: a -> a",
               "compose f g a = f (g a)",
               "compose : (c -> b) -> (a -> b) -> (a -> c)"
             ]
 
       it "All defs" $ do
-        let result = traceShowId $ parseModuleAndFormatError (T.intercalate "\n" (T.pack <$> singleDefs))
+        let result = traceShowId $ parseModuleAndFormatError (T.intercalate ";" (T.pack <$> singleDefs))
         result `shouldSatisfy` isRight
 
       traverse_

--- a/smol-core/test/static/Either.smol
+++ b/smol-core/test/static/Either.smol
@@ -1,11 +1,13 @@
-export type Either e a = Left e | Right a
+type Either e a = Left e | Right a
 
-export def orDefault (default: a) (value: Either e a): a =
+def orDefault : a -> Either e a -> a
+def orDefault default value =
   case value of
      Right a -> a
    | Left _ -> default
 
-export def fmap (f: a -> b) (value: Either e a): Either e b =
+def fmap : (a -> b) -> Either e a -> Either e b
+def fmap f value =
   case value of
     Right a -> Right (f a)
     | Left e -> Left e

--- a/smol-core/test/static/Globals.smol
+++ b/smol-core/test/static/Globals.smol
@@ -1,8 +1,10 @@
+def noGlobal : 100
 def noGlobal = 100
 
-def useGlobal: { valueA: 20 } => 20 =
-  valueA!
+def useGlobal : { valueA: 20 } => 20
+def useGlobal = valueA!
 
-export def useGlobalIndirectly : {valueA: 20 } => Int =
+def useGlobalIndirectly : { valueA: 20} => Int
+def useGlobalIndirectly =
   useGlobal + 1
 

--- a/smol-core/test/static/Maybe.smol
+++ b/smol-core/test/static/Maybe.smol
@@ -1,13 +1,15 @@
-export type Maybe a =
+type Maybe a =
     Just a
   | Nothing
 
-export def fromMaybe (val: Maybe a) (fallback: a): a =
+def fromMaybe : Maybe a -> a -> a
+def fromMaybe val fallback =
   case val of
     Just a -> a
     | _ -> fallback
 
-export def fmap (f: a -> b) (maybeA: Maybe a): Maybe b
-  = case maybeA of
+def fmap : (a -> b) -> Maybe a -> Maybe b
+def fmap f maybeA =
+  case maybeA of
       Just a -> Just (f a)
       | _ -> Nothing

--- a/smol-core/test/static/Monoid.smol
+++ b/smol-core/test/static/Monoid.smol
@@ -1,5 +1,5 @@
   
-export def maybe innerM = {
+def maybe innerM = {
   mappend: \a -> \b -> case (a,b) of
                     (Maybe.Just iA, Maybe.Just iB) -> Maybe.Just (innerM.mappend iA iB)
                   | (Maybe.Just iA, Maybe.Nothing) -> (Maybe.Just iA) 
@@ -8,20 +8,20 @@ export def maybe innerM = {
   mempty: Maybe.Nothing
   }
 
-export def any = { mappend: Prelude.or, mempty: False } 
+def any = { mappend: Prelude.or, mempty: False }
  
-export def all = { mappend: Prelude.and, mempty: True }
+def all = { mappend: Prelude.and, mempty: True }
 
-export def sum = { mappend: \a -> \b -> a + b, mempty: 0 }
+def sum = { mappend: \a -> \b -> a + b, mempty: 0 }
 
-export def first = { mappend: \a -> \b -> 
+def first = { mappend: \a -> \b ->
                         case (a, b) of
                             (Maybe.Just a, _) -> (Maybe.Just a)
                           | (_, b) -> b,
                      mempty: Maybe.Nothing
                     }
 
- export def last = { mappend: \a -> \b -> 
+def last = { mappend: \a -> \b ->
                         case (a, b) of
                             (_, Maybe.Just b) -> (Maybe.Just b)
                           | (a, _) -> a,

--- a/smol-core/test/static/Prelude.smol
+++ b/smol-core/test/static/Prelude.smol
@@ -1,32 +1,32 @@
-id : a -> a;
-id a = a;
+def id : a -> a
+def id a = a
 
-compose :
+def compose :
   (b -> c) ->
   (a -> b) ->
-  (a -> c);
-compose f g a = f (g a);
+  (a -> c)
+def compose f g a = f (g a)
 
-not : Bool -> Bool;
-not a = if a then False else True;
+def not : Bool -> Bool
+def not a = if a then False else True
 
-and : Bool -> Bool -> Bool;
-and a b = if a then b else False;
+def and : Bool -> Bool -> Bool
+def and a b = if a then b else False
 
-or : Bool -> Bool -> Bool;
-or a b = if a then True else b;
+def or : Bool -> Bool -> Bool
+def or a b = if a then True else b
 
-fst : (a, b) -> a;
-fst pair = case pair of (a, _) -> a;
+def fst : (a, b) -> a
+def fst pair = case pair of (a, _) -> a
 
-snd : (a, b) -> b;
-snd pair = case pair of (_, b) -> b;
+def snd : (a, b) -> b
+def snd pair = case pair of (_, b) -> b
 
-const : a -> b -> a;
-const a b = a;
+def const : a -> b -> a
+def const a b = a
 
-type Identity a = Identity a;
+type Identity a = Identity a
 
-runIdentity : Identity a -> a;
-runIdentity identity = case identity of Identity a -> a
+def runIdentity : Identity a -> a
+def runIdentity identity = case identity of Identity a -> a
 

--- a/smol-core/test/static/Prelude.smol
+++ b/smol-core/test/static/Prelude.smol
@@ -1,32 +1,32 @@
-id : a -> a
-id a = a
+id : a -> a;
+id a = a;
 
 compose :
   (b -> c) ->
   (a -> b) ->
-  (a -> c)
-compose f g a = f (g a)
+  (a -> c);
+compose f g a = f (g a);
 
-not : Bool -> Bool
-not a = if a then False else True
+not : Bool -> Bool;
+not a = if a then False else True;
 
-and : Bool -> Bool -> Bool
-and a b = if a then b else False
+and : Bool -> Bool -> Bool;
+and a b = if a then b else False;
 
-or : Bool -> Bool -> Bool
-or a b = if a then True else b
+or : Bool -> Bool -> Bool;
+or a b = if a then True else b;
 
-fst : (a, b) -> a
-fst pair = case pair of (a, _) -> a
+fst : (a, b) -> a;
+fst pair = case pair of (a, _) -> a;
 
-snd : (a, b) -> b
-snd pair = case pair of (_, b) -> b
+snd : (a, b) -> b;
+snd pair = case pair of (_, b) -> b;
 
-const : a -> b -> a
-const a b = a
+const : a -> b -> a;
+const a b = a;
 
-type Identity a = Identity a
+type Identity a = Identity a;
 
-runIdentity : Identity a -> a
+runIdentity : Identity a -> a;
 runIdentity identity = case identity of Identity a -> a
 

--- a/smol-core/test/static/Prelude.smol
+++ b/smol-core/test/static/Prelude.smol
@@ -1,19 +1,32 @@
-export def id (a: a): a = a
+id : a -> a
+id a = a
 
-export def compose (f: b -> c) (g: a -> b) (a: a): c = f (g a)
+compose :
+  (b -> c) ->
+  (a -> b) ->
+  (a -> c)
+compose f g a = f (g a)
 
-export def not a = if a then False else True
+not : Bool -> Bool
+not a = if a then False else True
 
-export def and a b = if a then b else False
+and : Bool -> Bool -> Bool
+and a b = if a then b else False
 
-export def or a b = if a then True else b
+or : Bool -> Bool -> Bool
+or a b = if a then True else b
 
-export def fst (pair: (a,b)): a = case pair of (a,_) -> a
+fst : (a, b) -> a
+fst pair = case pair of (a, _) -> a
 
-export def snd (pair: (a,b)): b = case pair of (_,b) -> b
+snd : (a, b) -> b
+snd pair = case pair of (_, b) -> b
 
-export def const a b = a
+const : a -> b -> a
+const a b = a
 
-export type Identity a = Identity a
+type Identity a = Identity a
 
-export def runIdentity identity = case identity of Identity a -> a
+runIdentity : Identity a -> a
+runIdentity identity = case identity of Identity a -> a
+

--- a/smol-core/test/static/Reader.smol
+++ b/smol-core/test/static/Reader.smol
@@ -1,20 +1,24 @@
 
-export type Reader r a = Reader (r -> a)
+type Reader r a = Reader (r -> a)
 
-export def run reader r =
+def run : Reader (r -> a) -> r -> a
+def run reader r =
   case reader of (Reader ra) -> ra r
 
-export def ask = Reader (Prelude.id)
+def ask : Reader (r -> r)
+def ask = Reader (Prelude.id)
 
-export def local envF reader = 
+def local : (r -> r) -> Reader (r -> a) -> Reader (r -> a)
+def local envF reader =
   Reader (\r -> run reader (envF r))
 
-export def ap readerF readerA = 
+def ap : Reader (r -> a -> b) -> Reader (r -> a) -> Reader (r -> b)
+def ap readerF readerA =
   case (readerF, readerA) of
     (Reader rToF, Reader rToA) ->
       Reader (\r -> rToF r (rToA r))
 
-export def monoid innerM = 
+def monoid innerM =
   { mappend: \rA -> \rB -> Reader (\r -> innerM.append (run rA r) (run rB r)),
     mempty: Reader (\r -> innerM.empty)
   }

--- a/smol-core/test/static/Reader.smol
+++ b/smol-core/test/static/Reader.smol
@@ -5,8 +5,12 @@ def run : Reader (r -> a) -> r -> a
 def run reader r =
   case reader of (Reader ra) -> ra r
 
+/*
+
+// this breaks typechecking with
+// Unification error! Expected matching types but found (U2 -> U3) -> Reader U2 U3 and Reader.
 def ask : Reader (r -> r)
-def ask = Reader (Prelude.id)
+def ask = let id = \a -> a in Reader id
 
 def local : (r -> r) -> Reader (r -> a) -> Reader (r -> a)
 def local envF reader =
@@ -22,4 +26,4 @@ def monoid innerM =
   { mappend: \rA -> \rB -> Reader (\r -> innerM.append (run rA r) (run rB r)),
     mempty: Reader (\r -> innerM.empty)
   }
-
+*/

--- a/smol-core/test/static/State.smol
+++ b/smol-core/test/static/State.smol
@@ -1,22 +1,27 @@
-export type State s a =
+type State s a =
   State (s -> (a, s))
 
-export def get =
+def get : State s a -> s
+def get =
   State (\s -> (s, s))
 
-export def put s =
+def put : s -> State s Unit
+def put s =
   State (\oldS -> (Unit, s))
 
-export def pure a =
+def pure : a -> State s a
+def pure a =
   State (\s -> (a, s))
 
-export def fmap (f: a -> b) (state: State s a): State s b = 
+def fmap : (a -> b) -> State s a -> State s b
+def fmap f state =
   case state of (State sas) ->
     State (\s -> 
         case sas s of (a, s) -> (f a, s)
     )
 
-export def ap (stateF: State s (a -> b)) (stateA: State s a): State s b = 
+def ap : State s (a -> b) -> State s a -> State s b
+def ap stateF stateA =
   State (\s -> case stateF of (State sfs) -> 
     let fs = sfs s; 
     case fs of (f, ss) -> 
@@ -24,16 +29,12 @@ export def ap (stateF: State s (a -> b)) (stateA: State s a): State s b =
         let as = sas ss; 
         case as of (a, sss) -> (f a, sss))
 
-export def bind f state = State (\s ->
+def bind : (a -> State s b) -> State s a -> State s b
+def bind f state = State (\s ->
   case state of (State sas) ->
     case (sas s) of (a, ss) ->
       case f a of (State sbs) -> sbs ss)
 
-export def run state s = case state of (State sas) -> sas s
-
-export def exec state = case run state of (_,a) -> a
-
-export def eval state = case run state of (a,_) -> a
-
-export def liftA2 f stateA stateB = ap (fmap f stateA) stateB
+def run : State s a -> s -> (a, s)
+def run state s = case state of (State sas) -> sas s
 

--- a/smol-core/test/static/State.smol
+++ b/smol-core/test/static/State.smol
@@ -1,6 +1,11 @@
 type State s a =
   State (s -> (a, s))
 
+/*
+def pure : a -> State s a
+def pure a =
+  State (\s -> (a, s))
+
 def get : State s a -> s
 def get =
   State (\s -> (s, s))
@@ -8,10 +13,6 @@ def get =
 def put : s -> State s Unit
 def put s =
   State (\oldS -> (Unit, s))
-
-def pure : a -> State s a
-def pure a =
-  State (\s -> (a, s))
 
 def fmap : (a -> b) -> State s a -> State s b
 def fmap f state =
@@ -38,3 +39,4 @@ def bind f state = State (\s ->
 def run : State s a -> s -> (a, s)
 def run state s = case state of (State sas) -> sas s
 
+*/

--- a/smol-core/test/static/These.smol
+++ b/smol-core/test/static/These.smol
@@ -1,2 +1,2 @@
-export type These a b = This a | That b | These a b
+type These a b = This a | That b | These a b
 

--- a/smol-core/test/static/Tree.smol
+++ b/smol-core/test/static/Tree.smol
@@ -1,14 +1,16 @@
-export type Tree a =
+type Tree a =
   Branch (Tree a) a (Tree a) | Leaf a
 
-export def fmap f =
+def fmap : (a -> b) -> Tree a -> Tree b
+def fmap f =
   let map = \innerTree ->
     case innerTree of
       (Branch left a right) -> Branch (map left) (f a) (map right)
     | (Leaf a) -> Leaf (f a)
   in map
 
-export def invert =
+def invert : Tree a -> Tree b
+def invert =
   let invertTree = \innerTree ->
     case innerTree of
       (Branch left a right) -> Branch (invertTree right) a (invertTree left) 

--- a/smol-repl/app/Main.hs
+++ b/smol-repl/app/Main.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import qualified Repl as Repl
+import qualified Repl
 
 main :: IO ()
 main = Repl.main

--- a/smol-repl/smol-repl.cabal
+++ b/smol-repl/smol-repl.cabal
@@ -27,14 +27,14 @@ common shared
     , haskeline
     , megaparsec
     , optparse-applicative
-    , smol-core
     , smol-backend
+    , smol-core
     , text
 
   other-modules:
-    Repl,
-    Smol.Repl,
-    Smol.Check,
+    Repl
+    Smol.Check
+    Smol.Repl
     Smol.Repl.Helpers.Diagnostics
 
 library
@@ -54,16 +54,15 @@ executable smol-repl
   hs-source-dirs:   app
   hs-source-dirs:   src
   ghc-options:      -threaded -rtsopts -with-rtsopts=-N
-  other-modules:
-    Repl
+  other-modules:    Repl
   build-depends:
-    base,
-    diagnose,
-    haskeline,
-    megaparsec,
-    smol-backend,
-    smol-core,
-    smol-repl,
-    text
+    , base
+    , diagnose
+    , haskeline
+    , megaparsec
+    , smol-backend
+    , smol-core
+    , smol-repl
+    , text
 
   default-language: Haskell2010


### PR DESCRIPTION
Resolves #963 

Changes syntax to
```haskell
def id : a -> a
def id a = a
```

Tried binning off the `def` part like this:

```haskell
id : a -> a
id a = a
```

...but as our parser just eats all whitespace atm it's hard to tell it not to start parsing the second line as a continuation of the type. Maybe curly boys are the way? Not today though.