### PR TITLE
Fuck it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ install:
 
 .PHONY: smol-repl
 smol-repl:
-	cabal run smol-repl:exe:smol-repl
+	cabal run smol-repl:exe:smol-repl -- repl
 
 .PHONY: run-server
 run-server:

--- a/cabal.project
+++ b/cabal.project
@@ -19,10 +19,4 @@ with-compiler: ghc-9.6.2
 package diagnose
   flags: +megaparsec-compat
 
-source-repository-package
-  type: git
-  location: https://github.com/9999years/prometheus-haskell
-  tag: d1809083b0543fff6e997fd1fbbe63e25ae21622
-  subdir: prometheus-client
-
 allow-newer: all

--- a/core/src/Language/Mimsa/Core/Parser/Language.hs
+++ b/core/src/Language/Mimsa/Core/Parser/Language.hs
@@ -367,7 +367,7 @@ patternMatchParser = addLocation $ do
   patterns <-
     try patternMatchesParser
       <|> pure
-      <$> patternCaseParser
+        <$> patternCaseParser
   pure $ MyPatternMatch mempty matchExpr patterns
 
 matchExprWithParser :: Parser ParserExpr

--- a/core/src/Language/Mimsa/Core/Parser/Language.hs
+++ b/core/src/Language/Mimsa/Core/Parser/Language.hs
@@ -367,7 +367,7 @@ patternMatchParser = addLocation $ do
   patterns <-
     try patternMatchesParser
       <|> pure
-        <$> patternCaseParser
+      <$> patternCaseParser
   pure $ MyPatternMatch mempty matchExpr patterns
 
 matchExprWithParser :: Parser ParserExpr

--- a/core/src/Language/Mimsa/Core/Parser/Language.hs
+++ b/core/src/Language/Mimsa/Core/Parser/Language.hs
@@ -366,7 +366,8 @@ patternMatchParser = addLocation $ do
   matchExpr <- matchExprWithParser
   patterns <-
     try patternMatchesParser
-      <|> pure <$> patternCaseParser
+      <|> pure
+      <$> patternCaseParser
   pure $ MyPatternMatch mempty matchExpr patterns
 
 matchExprWithParser :: Parser ParserExpr

--- a/core/src/Language/Mimsa/Core/Types/AST/DataType.hs
+++ b/core/src/Language/Mimsa/Core/Types/AST/DataType.hs
@@ -51,7 +51,7 @@ renderDataType :: DataType -> Doc style
 renderDataType (DataType tyCon vars' constructors') =
   "type"
     <+> prettyDoc tyCon
-    <> printVars vars'
+      <> printVars vars'
     <+> if M.null constructors'
       then mempty
       else

--- a/core/src/Language/Mimsa/Core/Types/AST/DataType.hs
+++ b/core/src/Language/Mimsa/Core/Types/AST/DataType.hs
@@ -51,7 +51,7 @@ renderDataType :: DataType -> Doc style
 renderDataType (DataType tyCon vars' constructors') =
   "type"
     <+> prettyDoc tyCon
-      <> printVars vars'
+    <> printVars vars'
     <+> if M.null constructors'
       then mempty
       else

--- a/core/src/Language/Mimsa/Core/Types/AST/Expr.hs
+++ b/core/src/Language/Mimsa/Core/Types/AST/Expr.hs
@@ -180,12 +180,12 @@ prettyLet var expr1 expr2 =
    in group
         ( "let"
             <+> prettyVar
-            <> prettyArgs args
+              <> prettyArgs args
             <+> "="
-            <> line
-            <> indentMulti 2 (prettyDoc letExpr)
-            <> newlineOrIn
-            <> prettyDoc expr2
+              <> line
+              <> indentMulti 2 (prettyDoc letExpr)
+              <> newlineOrIn
+              <> prettyDoc expr2
         )
   where
     prettyArgs [] = ""
@@ -211,10 +211,10 @@ prettyLetPattern pat expr body =
     ( "let"
         <+> printSubPattern pat
         <+> "="
-        <> line
-        <> indentMulti 2 (printSubExpr expr)
-        <> newlineOrIn
-        <> printSubExpr body
+          <> line
+          <> indentMulti 2 (printSubExpr expr)
+          <> newlineOrIn
+          <> printSubExpr body
     )
 
 newlineOrIn :: Doc style
@@ -321,22 +321,22 @@ prettyPatternMatch sumExpr matches =
     <+> printSubExpr sumExpr
     <+> "with"
     <+> line
-    <> indent
-      2
-      ( align $
-          vsep
-            ( zipWith
-                (<+>)
-                (" " : repeat "|")
-                (printMatch <$> matches)
-            )
-      )
+      <> indent
+        2
+        ( align $
+            vsep
+              ( zipWith
+                  (<+>)
+                  (" " : repeat "|")
+                  (printMatch <$> matches)
+              )
+        )
   where
     printMatch (construct, expr') =
       printSubPattern construct
         <+> "->"
         <+> line
-        <> indentMulti 4 (printSubExpr expr')
+          <> indentMulti 4 (printSubExpr expr')
 
 -- just for debugging
 instance (Printer var) => Printer (Expr (var, a) ann) where

--- a/core/src/Language/Mimsa/Core/Types/AST/Expr.hs
+++ b/core/src/Language/Mimsa/Core/Types/AST/Expr.hs
@@ -180,12 +180,12 @@ prettyLet var expr1 expr2 =
    in group
         ( "let"
             <+> prettyVar
-              <> prettyArgs args
+            <> prettyArgs args
             <+> "="
-              <> line
-              <> indentMulti 2 (prettyDoc letExpr)
-              <> newlineOrIn
-              <> prettyDoc expr2
+            <> line
+            <> indentMulti 2 (prettyDoc letExpr)
+            <> newlineOrIn
+            <> prettyDoc expr2
         )
   where
     prettyArgs [] = ""
@@ -211,10 +211,10 @@ prettyLetPattern pat expr body =
     ( "let"
         <+> printSubPattern pat
         <+> "="
-          <> line
-          <> indentMulti 2 (printSubExpr expr)
-          <> newlineOrIn
-          <> printSubExpr body
+        <> line
+        <> indentMulti 2 (printSubExpr expr)
+        <> newlineOrIn
+        <> printSubExpr body
     )
 
 newlineOrIn :: Doc style
@@ -321,22 +321,22 @@ prettyPatternMatch sumExpr matches =
     <+> printSubExpr sumExpr
     <+> "with"
     <+> line
-      <> indent
-        2
-        ( align $
-            vsep
-              ( zipWith
-                  (<+>)
-                  (" " : repeat "|")
-                  (printMatch <$> matches)
-              )
-        )
+    <> indent
+      2
+      ( align $
+          vsep
+            ( zipWith
+                (<+>)
+                (" " : repeat "|")
+                (printMatch <$> matches)
+            )
+      )
   where
     printMatch (construct, expr') =
       printSubPattern construct
         <+> "->"
         <+> line
-          <> indentMulti 4 (printSubExpr expr')
+        <> indentMulti 4 (printSubExpr expr')
 
 -- just for debugging
 instance (Printer var) => Printer (Expr (var, a) ann) where

--- a/core/src/Language/Mimsa/Core/Types/AST/Expr.hs
+++ b/core/src/Language/Mimsa/Core/Types/AST/Expr.hs
@@ -179,12 +179,13 @@ prettyLet var expr1 expr2 =
           prettyDoc var
    in group
         ( "let"
-            <+> prettyVar <> prettyArgs args
+            <+> prettyVar
+            <> prettyArgs args
             <+> "="
-              <> line
-              <> indentMulti 2 (prettyDoc letExpr)
-              <> newlineOrIn
-              <> prettyDoc expr2
+            <> line
+            <> indentMulti 2 (prettyDoc letExpr)
+            <> newlineOrIn
+            <> prettyDoc expr2
         )
   where
     prettyArgs [] = ""
@@ -210,10 +211,10 @@ prettyLetPattern pat expr body =
     ( "let"
         <+> printSubPattern pat
         <+> "="
-          <> line
-          <> indentMulti 2 (printSubExpr expr)
-          <> newlineOrIn
-          <> printSubExpr body
+        <> line
+        <> indentMulti 2 (printSubExpr expr)
+        <> newlineOrIn
+        <> printSubExpr body
     )
 
 newlineOrIn :: Doc style
@@ -320,22 +321,22 @@ prettyPatternMatch sumExpr matches =
     <+> printSubExpr sumExpr
     <+> "with"
     <+> line
-      <> indent
-        2
-        ( align $
-            vsep
-              ( zipWith
-                  (<+>)
-                  (" " : repeat "|")
-                  (printMatch <$> matches)
-              )
-        )
+    <> indent
+      2
+      ( align $
+          vsep
+            ( zipWith
+                (<+>)
+                (" " : repeat "|")
+                (printMatch <$> matches)
+            )
+      )
   where
     printMatch (construct, expr') =
       printSubPattern construct
         <+> "->"
         <+> line
-          <> indentMulti 4 (printSubExpr expr')
+        <> indentMulti 4 (printSubExpr expr')
 
 -- just for debugging
 instance (Printer var) => Printer (Expr (var, a) ann) where

--- a/core/src/Language/Mimsa/Core/Types/Module/Module.hs
+++ b/core/src/Language/Mimsa/Core/Types/Module/Module.hs
@@ -132,15 +132,15 @@ printPaired (MTFunction _ fn arg) (MyLambda _ ident body) =
     <> prettyDoc ident
     <+> ":"
     <+> prettyDoc fn
-    <> ")"
-    <> line
-    <> printPaired arg body
+      <> ")"
+      <> line
+      <> printPaired arg body
 printPaired mt expr =
   ":"
     <+> prettyDoc mt
     <+> "="
-    <> line
-    <> indentMulti 2 (prettyDoc expr)
+      <> line
+      <> indentMulti 2 (prettyDoc expr)
 
 printDefinition :: Module ann -> DefIdentifier -> Expr Name ann -> Doc a
 printDefinition mod' def expr =
@@ -153,14 +153,14 @@ printDefinition mod' def expr =
           (MyAnnotation _ mt rest) ->
             "def"
               <+> prettyDoc name
-              <> line
-              <> indentMulti 2 (printPaired mt rest)
+                <> line
+                <> indentMulti 2 (printPaired mt rest)
           other ->
             "def"
               <+> prettyDoc name
               <+> "="
-              <> line
-              <> indentMulti 2 (prettyDoc other)
+                <> line
+                <> indentMulti 2 (prettyDoc other)
         DIInfix infixOp ->
           "infix" <+> prettyDoc infixOp <+> "=" <+> prettyDoc expr
         DIType _ -> error "printDefinition is printing type oh no"

--- a/core/src/Language/Mimsa/Core/Types/Module/Module.hs
+++ b/core/src/Language/Mimsa/Core/Types/Module/Module.hs
@@ -132,15 +132,15 @@ printPaired (MTFunction _ fn arg) (MyLambda _ ident body) =
     <> prettyDoc ident
     <+> ":"
     <+> prettyDoc fn
-      <> ")"
-      <> line
-      <> printPaired arg body
+    <> ")"
+    <> line
+    <> printPaired arg body
 printPaired mt expr =
   ":"
     <+> prettyDoc mt
     <+> "="
-      <> line
-      <> indentMulti 2 (prettyDoc expr)
+    <> line
+    <> indentMulti 2 (prettyDoc expr)
 
 printDefinition :: Module ann -> DefIdentifier -> Expr Name ann -> Doc a
 printDefinition mod' def expr =
@@ -153,14 +153,14 @@ printDefinition mod' def expr =
           (MyAnnotation _ mt rest) ->
             "def"
               <+> prettyDoc name
-                <> line
-                <> indentMulti 2 (printPaired mt rest)
+              <> line
+              <> indentMulti 2 (printPaired mt rest)
           other ->
             "def"
               <+> prettyDoc name
               <+> "="
-                <> line
-                <> indentMulti 2 (prettyDoc other)
+              <> line
+              <> indentMulti 2 (prettyDoc other)
         DIInfix infixOp ->
           "infix" <+> prettyDoc infixOp <+> "=" <+> prettyDoc expr
         DIType _ -> error "printDefinition is printing type oh no"

--- a/core/src/Language/Mimsa/Core/Types/Module/Module.hs
+++ b/core/src/Language/Mimsa/Core/Types/Module/Module.hs
@@ -128,18 +128,19 @@ printTypeDef mod' tn dt =
 -- given annotation and expr, pair annotation types with lambdas
 printPaired :: Type ann -> Expr Name ann -> Doc a
 printPaired (MTFunction _ fn arg) (MyLambda _ ident body) =
-  "(" <> prettyDoc ident
+  "("
+    <> prettyDoc ident
     <+> ":"
     <+> prettyDoc fn
-      <> ")"
-      <> line
-      <> printPaired arg body
+    <> ")"
+    <> line
+    <> printPaired arg body
 printPaired mt expr =
   ":"
     <+> prettyDoc mt
     <+> "="
-      <> line
-      <> indentMulti 2 (prettyDoc expr)
+    <> line
+    <> indentMulti 2 (prettyDoc expr)
 
 printDefinition :: Module ann -> DefIdentifier -> Expr Name ann -> Doc a
 printDefinition mod' def expr =
@@ -152,14 +153,14 @@ printDefinition mod' def expr =
           (MyAnnotation _ mt rest) ->
             "def"
               <+> prettyDoc name
-                <> line
-                <> indentMulti 2 (printPaired mt rest)
+              <> line
+              <> indentMulti 2 (printPaired mt rest)
           other ->
             "def"
               <+> prettyDoc name
               <+> "="
-                <> line
-                <> indentMulti 2 (prettyDoc other)
+              <> line
+              <> indentMulti 2 (prettyDoc other)
         DIInfix infixOp ->
           "infix" <+> prettyDoc infixOp <+> "=" <+> prettyDoc expr
         DIType _ -> error "printDefinition is printing type oh no"

--- a/repl/repl/Repl/Parser.hs
+++ b/repl/repl/Repl/Parser.hs
@@ -65,9 +65,11 @@ bindModuleParser = do
 
 backendParser :: Parser (Maybe Backend)
 backendParser =
-  myString "javascript" $> Just ESModulesJS
-    <|> myString "typescript" $> Just Typescript
-    <|> pure Nothing
+  myString "javascript"
+    $> Just ESModulesJS
+      <|> myString "typescript"
+    $> Just Typescript
+      <|> pure Nothing
 
 outputJSModuleParser :: Parser ReplActionAnn
 outputJSModuleParser = do

--- a/repl/repl/Repl/Parser.hs
+++ b/repl/repl/Repl/Parser.hs
@@ -67,9 +67,9 @@ backendParser :: Parser (Maybe Backend)
 backendParser =
   myString "javascript"
     $> Just ESModulesJS
-    <|> myString "typescript"
-      $> Just Typescript
-    <|> pure Nothing
+      <|> myString "typescript"
+    $> Just Typescript
+      <|> pure Nothing
 
 outputJSModuleParser :: Parser ReplActionAnn
 outputJSModuleParser = do

--- a/repl/repl/Repl/Parser.hs
+++ b/repl/repl/Repl/Parser.hs
@@ -67,9 +67,9 @@ backendParser :: Parser (Maybe Backend)
 backendParser =
   myString "javascript"
     $> Just ESModulesJS
-      <|> myString "typescript"
-    $> Just Typescript
-      <|> pure Nothing
+    <|> myString "typescript"
+      $> Just Typescript
+    <|> pure Nothing
 
 outputJSModuleParser :: Parser ReplActionAnn
 outputJSModuleParser = do

--- a/smol-backend/src/Smol/Backend/IR/FromExpr/Helpers.hs
+++ b/smol-backend/src/Smol/Backend/IR/FromExpr/Helpers.hs
@@ -27,10 +27,12 @@ import Smol.Core.Types.ResolvedDep
 resolveConstructor :: Smol.ResolvedDep Smol.Constructor -> Smol.Constructor
 resolveConstructor (LocalDefinition c) = c
 resolveConstructor (UniqueDefinition c idx) = c <> fromString ("_" <> show idx)
+resolveConstructor (TypeclassCall c idx) = fromString "tc_" <> c <> fromString ("_" <> show idx)
 
 resolveIdentifier :: Smol.ResolvedDep Smol.Identifier -> Smol.Identifier
 resolveIdentifier (LocalDefinition c) = c
 resolveIdentifier (UniqueDefinition i idx) = i <> fromString ("_" <> show idx)
+resolveIdentifier (TypeclassCall i idx) = fromString "tc_" <> i <> fromString ("_" <> show idx)
 
 isStringType :: Smol.Type dep ann -> Bool
 isStringType (Smol.TPrim _ Smol.TPString) = True

--- a/smol-backend/test/Test/IR/FromExprSpec.hs
+++ b/smol-backend/test/Test/IR/FromExprSpec.hs
@@ -25,10 +25,12 @@ evalExpr input =
         TCEnv
           { tceDataTypes = builtInTypes emptyResolvedDep,
             tceVars = mempty,
-            tceGlobals = mempty
+            tceClasses = mempty,
+            tceInstances = mempty,
+            tceConstraints = mempty
           }
    in case elaborate env (unsafeParseTypedExpr input $> mempty) of
-        Right typedExpr -> typedExpr
+        Right (typedExpr, _) -> typedExpr
         Left e -> error (show e)
 
 testEnv :: (Monoid ann) => IR.FromExprState ann

--- a/smol-core/smol-core.cabal
+++ b/smol-core/smol-core.cabal
@@ -115,8 +115,10 @@ library
     Smol.Core.Typecheck.Substitute
     Smol.Core.Typecheck.Subtype
     Smol.Core.Typecheck.Types
+    Smol.Core.Typecheck.Types.Substitution
     Smol.Core.Typecheck.Types.TCError
     Smol.Core.Typecheck.Types.TCState
+    Smol.Core.Typecheck.Types.TCWrite
     Smol.Core.Types
     Smol.Core.Types.Annotated
     Smol.Core.Types.Annotation

--- a/smol-core/smol-core.cabal
+++ b/smol-core/smol-core.cabal
@@ -101,6 +101,7 @@ library
     Smol.Core.Parser.Primitives
     Smol.Core.Parser.Shared
     Smol.Core.Parser.Type
+    Smol.Core.Parser.Typeclass
     Smol.Core.Printer
     Smol.Core.SourceSpan
     Smol.Core.Typecheck
@@ -117,6 +118,7 @@ library
     Smol.Core.Typecheck.Typecheck
     Smol.Core.Typecheck.Typeclass
     Smol.Core.Typecheck.Typeclass.Helpers
+    Smol.Core.Typecheck.Typeclass.Types
     Smol.Core.Typecheck.Types
     Smol.Core.Typecheck.Types.Substitution
     Smol.Core.Typecheck.Types.TCError

--- a/smol-core/smol-core.cabal
+++ b/smol-core/smol-core.cabal
@@ -164,6 +164,7 @@ test-suite smol-core-tests
     Test.Typecheck.NestingMonadSpec
     Test.Typecheck.PatternSpec
     Test.Typecheck.SubtypeSpec
+    Test.Typecheck.TypeclassSpec
     Test.TypecheckSpec
 
   main-is:          Main.hs

--- a/smol-core/smol-core.cabal
+++ b/smol-core/smol-core.cabal
@@ -115,6 +115,8 @@ library
     Smol.Core.Typecheck.Substitute
     Smol.Core.Typecheck.Subtype
     Smol.Core.Typecheck.Types
+    Smol.Core.Typecheck.Types.TCError
+    Smol.Core.Typecheck.Types.TCState
     Smol.Core.Types
     Smol.Core.Types.Annotated
     Smol.Core.Types.Annotation

--- a/smol-core/smol-core.cabal
+++ b/smol-core/smol-core.cabal
@@ -114,6 +114,7 @@ library
     Smol.Core.Typecheck.Simplify
     Smol.Core.Typecheck.Substitute
     Smol.Core.Typecheck.Subtype
+    Smol.Core.Typecheck.Typecheck
     Smol.Core.Typecheck.Typeclass
     Smol.Core.Typecheck.Typeclass.Helpers
     Smol.Core.Typecheck.Types

--- a/smol-core/smol-core.cabal
+++ b/smol-core/smol-core.cabal
@@ -114,6 +114,8 @@ library
     Smol.Core.Typecheck.Simplify
     Smol.Core.Typecheck.Substitute
     Smol.Core.Typecheck.Subtype
+    Smol.Core.Typecheck.Typeclass
+    Smol.Core.Typecheck.Typeclass.Helpers
     Smol.Core.Typecheck.Types
     Smol.Core.Typecheck.Types.Substitution
     Smol.Core.Typecheck.Types.TCError

--- a/smol-core/smol-core.cabal
+++ b/smol-core/smol-core.cabal
@@ -117,8 +117,11 @@ library
     Smol.Core.Typecheck.Subtype
     Smol.Core.Typecheck.Typecheck
     Smol.Core.Typecheck.Typeclass
+    Smol.Core.Typecheck.Typeclass.BuiltIns
+    Smol.Core.Typecheck.Typeclass.Deduplicate
     Smol.Core.Typecheck.Typeclass.Helpers
     Smol.Core.Typecheck.Typeclass.Types
+    Smol.Core.Typecheck.Typeclass.Types.TypeclassName
     Smol.Core.Typecheck.Types
     Smol.Core.Typecheck.Types.Substitution
     Smol.Core.Typecheck.Types.TCError

--- a/smol-core/src/Smol/Core/Modules/Check.hs
+++ b/smol-core/src/Smol/Core/Modules/Check.hs
@@ -12,7 +12,6 @@ import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
 import Smol.Core
-import Smol.Core.Helpers
 import Smol.Core.Modules.FromParts
 import Smol.Core.Modules.ResolveDeps
 import Smol.Core.Modules.Typecheck
@@ -58,14 +57,10 @@ passModuleDictionaries inputModule = do
                   tceConstraints = constraints
                 }
 
-        tracePrettyM "old expr" expr 
-
         newExpr <-
           modifyError
             (DefDoesNotTypeCheck mempty (DIName ident))
             (passOuterDictionaries env constraints <=< passDictionaries env $ expr)
-
-        tracePrettyM "new expr" newExpr
 
         pure $ (ident, tle {tleExpr = newExpr})
 

--- a/smol-core/src/Smol/Core/Modules/Check.hs
+++ b/smol-core/src/Smol/Core/Modules/Check.hs
@@ -82,7 +82,7 @@ passModuleDictionaries inputModule = do
             (DefDoesNotTypeCheck mempty (DIName ident))
             (toDictionaryPassing varsInScope instances constraints expr)
 
-        pure $ (ident, tle {tleExpr = newExpr})
+        pure (ident, tle {tleExpr = newExpr})
 
   newExpressions <- M.fromList <$> traverse passDictToTopLevelExpression (M.toList $ moExpressions inputModule)
   pure $ inputModule {moExpressions = newExpressions}

--- a/smol-core/src/Smol/Core/Modules/Check.hs
+++ b/smol-core/src/Smol/Core/Modules/Check.hs
@@ -22,5 +22,6 @@ checkModule ::
   [ModuleItem Annotation] ->
   m (Module ResolvedDep (Type ResolvedDep Annotation))
 checkModule input moduleItems = do
-  (myModule, deps) <- moduleFromModuleParts moduleItems >>= resolveModuleDeps mempty
-  typecheckModule input myModule deps
+  myModule <- moduleFromModuleParts moduleItems
+  (resolvedModule, deps) <- modifyError ErrorInResolveDeps (resolveModuleDeps mempty myModule)
+  typecheckModule input resolvedModule deps

--- a/smol-core/src/Smol/Core/Modules/Check.hs
+++ b/smol-core/src/Smol/Core/Modules/Check.hs
@@ -72,7 +72,7 @@ passModuleDictionaries inputModule = do
         newExpr <-
           modifyError
             (DefDoesNotTypeCheck mempty (DIName ident))
-            (passAllDictionaries varsInScope constraints expr)
+            (toDictionaryPassing varsInScope constraints expr)
 
         pure $ (ident, tle {tleExpr = newExpr})
 

--- a/smol-core/src/Smol/Core/Modules/Check.hs
+++ b/smol-core/src/Smol/Core/Modules/Check.hs
@@ -6,13 +6,11 @@ module Smol.Core.Modules.Check
   )
 where
 
-import Control.Monad
 import Control.Monad.Except
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
 import Smol.Core
-import Smol.Core.Helpers
 import Smol.Core.Modules.FromParts
 import Smol.Core.Modules.ResolveDeps
 import Smol.Core.Modules.Typecheck
@@ -48,26 +46,10 @@ passModuleDictionaries inputModule = do
         let constraints = (fmap . fmap) getTypeAnnotation (tleConstraints tle)
             expr = tleExpr tle
 
-        tracePrettyM "ident" ident
-        tracePrettyM "expr" expr
-        tracePrettyM "constraints" constraints
-
-        -- initial typechecking environment
-        let env =
-              TCEnv
-                { tceVars = mempty,
-                  tceDataTypes = mempty,
-                  tceClasses = builtInClasses,
-                  tceInstances = builtInInstances,
-                  tceConstraints = constraints
-                }
-
         newExpr <-
           modifyError
             (DefDoesNotTypeCheck mempty (DIName ident))
-            (passOuterDictionaries env constraints <=< passDictionaries env $ expr)
-
-        tracePrettyM "newExpr" newExpr
+            (passAllDictionaries constraints expr)
 
         pure $ (ident, tle {tleExpr = newExpr})
 

--- a/smol-core/src/Smol/Core/Modules/Check.hs
+++ b/smol-core/src/Smol/Core/Modules/Check.hs
@@ -22,5 +22,5 @@ checkModule ::
   [ModuleItem Annotation] ->
   m (Module ResolvedDep (Type ResolvedDep Annotation))
 checkModule input moduleItems = do
-  (myModule, deps) <- moduleFromModuleParts moduleItems >>= resolveModuleDeps
+  (myModule, deps) <- moduleFromModuleParts moduleItems >>= resolveModuleDeps mempty
   typecheckModule input myModule deps

--- a/smol-core/src/Smol/Core/Modules/Check.hs
+++ b/smol-core/src/Smol/Core/Modules/Check.hs
@@ -11,12 +11,16 @@ import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
 import Smol.Core
+import Smol.Core.Helpers
 import Smol.Core.Modules.FromParts
 import Smol.Core.Modules.ResolveDeps
 import Smol.Core.Modules.Typecheck
+import Smol.Core.Modules.Types.DefIdentifier
 import Smol.Core.Modules.Types.Module
 import Smol.Core.Modules.Types.ModuleError
 import Smol.Core.Modules.Types.ModuleItem
+import Smol.Core.Modules.Types.TopLevelExpression
+import Smol.Core.Typecheck.Typeclass
 import Smol.Core.Typecheck.Typeclass.BuiltIns
 
 -- this is the front door as such
@@ -31,5 +35,35 @@ checkModule input moduleItems = do
   (resolvedModule, deps) <-
     modifyError ErrorInResolveDeps (resolveModuleDeps typeclassMethods myModule)
   typedModule <- typecheckModule input resolvedModule deps
-  _ <- error "now do passDictionaries to all the stuff in the module pls"
-  pure typedModule
+
+  passModuleDictionaries typedModule
+
+passModuleDictionaries ::
+  (MonadError (ModuleError Annotation) m) =>
+  Module ResolvedDep (Type ResolvedDep Annotation) ->
+  m (Module ResolvedDep (Type ResolvedDep Annotation))
+passModuleDictionaries inputModule = do
+  -- initial typechecking environment
+  let passDictToTopLevelExpression (ident, tle) = do
+        let constraints = (fmap . fmap) getTypeAnnotation (tleConstraints tle)
+
+        let env =
+              TCEnv
+                { tceVars = mempty,
+                  tceDataTypes = mempty,
+                  tceClasses = builtInClasses,
+                  tceInstances = builtInInstances,
+                  tceConstraints = constraints
+                }
+
+        newExpr <-
+          modifyError
+            (DefDoesNotTypeCheck mempty (DIName ident))
+            (passOuterDictionaries env constraints $ tleExpr tle)
+        
+        tracePrettyM "new expr" newExpr
+
+        pure $ (ident, tle {tleExpr = newExpr})
+
+  newExpressions <- M.fromList <$> traverse passDictToTopLevelExpression (M.toList $ moExpressions inputModule)
+  pure $ inputModule {moExpressions = newExpressions}

--- a/smol-core/src/Smol/Core/Modules/Check.hs
+++ b/smol-core/src/Smol/Core/Modules/Check.hs
@@ -6,13 +6,13 @@ module Smol.Core.Modules.Check
   )
 where
 
-import Smol.Core.Helpers
 import Control.Monad
 import Control.Monad.Except
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
 import Smol.Core
+import Smol.Core.Helpers
 import Smol.Core.Modules.FromParts
 import Smol.Core.Modules.ResolveDeps
 import Smol.Core.Modules.Typecheck

--- a/smol-core/src/Smol/Core/Modules/Check.hs
+++ b/smol-core/src/Smol/Core/Modules/Check.hs
@@ -6,6 +6,7 @@ module Smol.Core.Modules.Check
   )
 where
 
+import Smol.Core.Helpers
 import Control.Monad
 import Control.Monad.Except
 import qualified Data.Map.Strict as M
@@ -47,6 +48,10 @@ passModuleDictionaries inputModule = do
         let constraints = (fmap . fmap) getTypeAnnotation (tleConstraints tle)
             expr = tleExpr tle
 
+        tracePrettyM "ident" ident
+        tracePrettyM "expr" expr
+        tracePrettyM "constraints" constraints
+
         -- initial typechecking environment
         let env =
               TCEnv
@@ -61,6 +66,8 @@ passModuleDictionaries inputModule = do
           modifyError
             (DefDoesNotTypeCheck mempty (DIName ident))
             (passOuterDictionaries env constraints <=< passDictionaries env $ expr)
+
+        tracePrettyM "newExpr" newExpr
 
         pure $ (ident, tle {tleExpr = newExpr})
 

--- a/smol-core/src/Smol/Core/Modules/Dependencies.hs
+++ b/smol-core/src/Smol/Core/Modules/Dependencies.hs
@@ -76,7 +76,7 @@ filterTypes =
 -- get the vars used by each def
 -- explode if there's not available
 getDependencies ::
-  (MonadError (ModuleError ann) m) =>
+  (MonadError ResolveDepsError m) =>
   (Expr ParseDep ann -> Set E.Entity) ->
   Module ParseDep ann ->
   m
@@ -102,7 +102,7 @@ getDependencies getUses mod' = do
 
 -- get all dependencies of a type definition
 getTypeDependencies ::
-  (MonadError (ModuleError ann) m) =>
+  (MonadError ResolveDepsError m) =>
   Module ParseDep ann ->
   DataType ParseDep ann ->
   m (DepType ParseDep ann, Set DefIdentifier, Set E.Entity)
@@ -113,7 +113,7 @@ getTypeDependencies mod' dt = do
   pure (DTData dt, typeDefIds <> exprDefIds, allUses)
 
 getTypeUses ::
-  (MonadError (ModuleError ann) m) =>
+  (MonadError ResolveDepsError m) =>
   Module dep ann ->
   Set E.Entity ->
   m (Set DefIdentifier)
@@ -158,7 +158,7 @@ findTypesForConstructors mod' =
   S.fromList . mapMaybe (findTypenameInModule mod') . S.toList
 
 getConstructorUses ::
-  (MonadError (ModuleError ann) m) =>
+  (MonadError ResolveDepsError m) =>
   Module dep ann ->
   Set E.Entity ->
   m (Set DefIdentifier)
@@ -182,7 +182,7 @@ getConstructorUses mod' uses = do
         else throwError (CannotFindTypes unknownTypeDeps)
 
 getExprDependencies ::
-  (MonadError (ModuleError ann) m) =>
+  (MonadError ResolveDepsError m) =>
   (Expr dep ann -> Set E.Entity) ->
   Module dep ann ->
   TopLevelExpression dep ann ->

--- a/smol-core/src/Smol/Core/Modules/Dependencies.hs
+++ b/smol-core/src/Smol/Core/Modules/Dependencies.hs
@@ -195,25 +195,14 @@ getExprDependencies getUses mod' expr = do
   pure (DTExpr expr, exprDefIds <> typeDefIds <> consDefIds, allUses)
 
 getExprDeps ::
-  (MonadError (ModuleError ann) m) =>
+  (Monad m) =>
   Module dep ann ->
   Set E.Entity ->
   m (Set Identifier)
 getExprDeps mod' uses =
-  let nameDeps = filterDefs uses
-      unknownNameDeps =
-        S.filter
-          ( \dep ->
-              S.notMember dep (M.keysSet (moExpressions mod'))
-          )
-          nameDeps
-   in if S.null unknownNameDeps
-        then
-          let localNameDeps =
-                S.filter
-                  ( `S.member`
-                      M.keysSet (moExpressions mod')
-                  )
-                  nameDeps
-           in pure localNameDeps
-        else throwError (CannotFindValues unknownNameDeps)
+  pure $
+    S.filter
+      ( `S.member`
+          M.keysSet (moExpressions mod')
+      )
+      (filterDefs uses)

--- a/smol-core/src/Smol/Core/Modules/FromParts.hs
+++ b/smol-core/src/Smol/Core/Modules/FromParts.hs
@@ -64,7 +64,9 @@ addModulePart allParts part mod' =
               { moTests = UnitTest testName ident : moTests mod'
               }
         else throwError (ErrorInResolveDeps $ VarNotFound ident)
-    ModuleClass _ -> pure mod' -- TODO
+    ModuleClass tc ->
+      -- TODO: check duplicates and explode
+      pure $ mod' {moClasses = M.singleton (tcName tc) tc <> moClasses mod'}
     ModuleInstance constraint expr ->
       pure $
         mod'

--- a/smol-core/src/Smol/Core/Modules/FromParts.hs
+++ b/smol-core/src/Smol/Core/Modules/FromParts.hs
@@ -59,7 +59,7 @@ addModulePart allParts part mod' =
             mod'
               { moTests = UnitTest testName ident : moTests mod'
               }
-        else throwError (VarNotFound ident)
+        else throwError (ErrorInResolveDeps $ VarNotFound ident)
     ModuleDataType dt@(DataType tyCon _ _) -> do
       let typeName = coerce tyCon
       checkDataType mod' dt

--- a/smol-core/src/Smol/Core/Modules/FromParts.hs
+++ b/smol-core/src/Smol/Core/Modules/FromParts.hs
@@ -88,6 +88,7 @@ exprAndTypeFromParts moduleItems ident idents expr =
           expr
           idents
       tleType = findTypeExpression ident moduleItems
+      tleConstraints = mempty
    in TopLevelExpression {..}
 
 expressionExists :: Identifier -> [ModuleItem ann] -> Bool

--- a/smol-core/src/Smol/Core/Modules/FromParts.hs
+++ b/smol-core/src/Smol/Core/Modules/FromParts.hs
@@ -64,9 +64,8 @@ addModulePart allParts part mod' =
               { moTests = UnitTest testName ident : moTests mod'
               }
         else throwError (ErrorInResolveDeps $ VarNotFound ident)
-    ModuleInstance constraint ident ->
-      case findExpression ident allParts of
-        Just tle ->
+    ModuleClass _ -> pure mod' -- TODO
+    ModuleInstance constraint expr ->
           pure $
             mod'
               { moInstances =
@@ -74,13 +73,11 @@ addModulePart allParts part mod' =
                     (void constraint)
                     ( Instance
                         { inConstraints = mempty,
-                          inExpr = identityFromParseDep (tleExpr tle)
+                          inExpr = identityFromParseDep expr
                         }
                     )
                     <> moInstances mod'
               }
-        Nothing ->
-          throwError (ErrorInResolveDeps $ VarNotFound ident)
     ModuleDataType dt@(DataType tyCon _ _) -> do
       let typeName = coerce tyCon
       checkDataType mod' dt

--- a/smol-core/src/Smol/Core/Modules/FromParts.hs
+++ b/smol-core/src/Smol/Core/Modules/FromParts.hs
@@ -66,18 +66,18 @@ addModulePart allParts part mod' =
         else throwError (ErrorInResolveDeps $ VarNotFound ident)
     ModuleClass _ -> pure mod' -- TODO
     ModuleInstance constraint expr ->
-          pure $
-            mod'
-              { moInstances =
-                  M.singleton
-                    (void constraint)
-                    ( Instance
-                        { inConstraints = mempty,
-                          inExpr = identityFromParseDep expr
-                        }
-                    )
-                    <> moInstances mod'
-              }
+      pure $
+        mod'
+          { moInstances =
+              M.singleton
+                (void constraint)
+                ( Instance
+                    { inConstraints = mempty,
+                      inExpr = identityFromParseDep expr
+                    }
+                )
+                <> moInstances mod'
+          }
     ModuleDataType dt@(DataType tyCon _ _) -> do
       let typeName = coerce tyCon
       checkDataType mod' dt

--- a/smol-core/src/Smol/Core/Modules/ResolveDeps.hs
+++ b/smol-core/src/Smol/Core/Modules/ResolveDeps.hs
@@ -127,7 +127,14 @@ resolveTopLevelExpression ::
 resolveTopLevelExpression tle typeclassMethods localDefs localTypes = flip runReaderT initialEnv $ do
   resolvedExpr <- resolveM (tleExpr tle)
   let resolvedType = fmap resolveType (tleType tle)
-  pure (TopLevelExpression {tleExpr = resolvedExpr, tleType = resolvedType})
+
+  pure
+    ( TopLevelExpression
+        { tleConstraints = tleConstraints tle,
+          tleExpr = resolvedExpr,
+          tleType = resolvedType
+        }
+    )
   where
     initialEnv = ResolveEnv mempty localDefs localTypes typeclassMethods
 

--- a/smol-core/src/Smol/Core/Modules/ResolveDeps.hs
+++ b/smol-core/src/Smol/Core/Modules/ResolveDeps.hs
@@ -172,9 +172,8 @@ typeclassIdentifier ::
   (MonadState ResolveState m) =>
   Identifier ->
   m (ResolvedDep Identifier)
-typeclassIdentifier ident = do
-  i <- freshInt
-  pure (TypeclassCall ident i)
+typeclassIdentifier ident =
+  TypeclassCall ident <$> freshInt
 
 withNewIdentifier ::
   (MonadReader ResolveEnv m) =>

--- a/smol-core/src/Smol/Core/Modules/ResolveDeps.hs
+++ b/smol-core/src/Smol/Core/Modules/ResolveDeps.hs
@@ -32,9 +32,10 @@ resolveExprDeps ::
   (Show ann, MonadError ResolveDepsError m) =>
   Expr ParseDep ann ->
   Set Identifier ->
+  Set DefIdentifier ->
   m (Expr ResolvedDep ann)
-resolveExprDeps expr typeclassMethods =
-  evalStateT (resolveExpr expr typeclassMethods mempty mempty) (ResolveState 0)
+resolveExprDeps expr typeclassMethods localDefs =
+  evalStateT (resolveExpr expr typeclassMethods localDefs mempty) (ResolveState 0)
 
 resolveExpr ::
   (Show ann, MonadError ResolveDepsError m, MonadState ResolveState m) =>

--- a/smol-core/src/Smol/Core/Modules/ResolveDeps.hs
+++ b/smol-core/src/Smol/Core/Modules/ResolveDeps.hs
@@ -96,7 +96,8 @@ resolveModuleDeps typeclassMethods parsedModule = do
         ( parsedModule
             { moExpressions = resolvedExpressions,
               moDataTypes = resolvedDataTypes,
-              moInstances = resolvedInstances
+              moInstances = resolvedInstances,
+              moClasses = moClasses parsedModule
             },
           dependencies
         )

--- a/smol-core/src/Smol/Core/Modules/Typecheck.hs
+++ b/smol-core/src/Smol/Core/Modules/Typecheck.hs
@@ -3,13 +3,13 @@
 
 module Smol.Core.Modules.Typecheck (typecheckModule) where
 
-import Data.List (nub)
 import qualified Builder as Build
 import Control.Monad.Except
 import Control.Monad.Identity
 import Data.Bifunctor (first)
 import Data.Foldable (traverse_)
 import Data.Functor (($>))
+import Data.List (nub)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, mapMaybe)
@@ -70,7 +70,8 @@ moduleFromDepTypes oldModule definitions =
    in -- replace input module with typechecked versions
       oldModule
         { moExpressions = newExpressions,
-          moDataTypes = mapKeyMaybe getTypeName (filterDataTypes definitions)
+          moDataTypes = mapKeyMaybe getTypeName (filterDataTypes definitions),
+          moInstances = mempty -- well this is wrong
         }
 
 --- typecheck a single module

--- a/smol-core/src/Smol/Core/Modules/Typecheck.hs
+++ b/smol-core/src/Smol/Core/Modules/Typecheck.hs
@@ -254,7 +254,4 @@ typecheckOneExprDef input _inputModule deps (def, tle) = do
             tleType = typedType
           }
 
-  tracePrettyM "tle con" constraints
-  tracePrettyM "tle expr" typedExpr
-
   pure typedTle

--- a/smol-core/src/Smol/Core/Modules/Typecheck.hs
+++ b/smol-core/src/Smol/Core/Modules/Typecheck.hs
@@ -3,6 +3,7 @@
 
 module Smol.Core.Modules.Typecheck (typecheckModule) where
 
+import Data.List (nub)
 import qualified Builder as Build
 import Control.Monad.Except
 import Control.Monad.Identity
@@ -247,9 +248,12 @@ typecheckOneExprDef input _inputModule deps (def, tle) = do
         (EAnn _ ty expr) -> (Just ty, expr)
         other -> (Nothing, other)
 
+  -- add supplied constraints to any we discovered in typechecking
+  let allConstraints = nub (fmap resolveConstraint $ constraints <> tleConstraints tle)
+
   let typedTle =
         TopLevelExpression
-          { tleConstraints = fmap resolveConstraint constraints,
+          { tleConstraints = allConstraints,
             tleExpr = typedExpr,
             tleType = typedType
           }

--- a/smol-core/src/Smol/Core/Modules/Typecheck.hs
+++ b/smol-core/src/Smol/Core/Modules/Typecheck.hs
@@ -3,7 +3,6 @@
 
 module Smol.Core.Modules.Typecheck (typecheckModule) where
 
-import Smol.Core.Typecheck.Typeclass (checkInstance, lookupTypeclass)
 import qualified Builder as Build
 import Control.Monad.Except
 import Control.Monad.Identity
@@ -24,8 +23,11 @@ import Smol.Core.Modules.Types
 import Smol.Core.Modules.Types.DepType
 import Smol.Core.Modules.Types.ModuleError
 import Smol.Core.Typecheck.Typecheck (typecheck)
+import Smol.Core.Typecheck.Typeclass (checkInstance, lookupTypeclass, resolveType, toIdentityExpr)
 import Smol.Core.Typecheck.Typeclass.BuiltIns
 
+-- go through the module, and wrap all the items in DefIdentifier keys and
+-- DepType for items
 getModuleDefIdentifiers ::
   Map DefIdentifier (Set DefIdentifier) ->
   Module dep ann ->
@@ -46,7 +48,14 @@ getModuleDefIdentifiers depMap inputModule =
                in (defId, (defId, DTData dt, getDeps defId))
           )
             <$> M.elems (moDataTypes inputModule)
-   in exprs <> dataTypes
+      instances =
+        M.fromList $
+          ( \(constraint, inst) ->
+              let defId = DIInstance constraint
+               in (defId, (defId, DTInstance inst, getDeps defId))
+          )
+            <$> M.toList (moInstances inputModule)
+   in exprs <> dataTypes <> instances
 
 moduleFromDepTypes ::
   Module ResolvedDep ann ->
@@ -63,7 +72,7 @@ moduleFromDepTypes oldModule definitions =
       getTypeName (DIType tn) = Just tn
       getTypeName _ = Nothing
 
-      newExpressions =
+      typedExpressions =
         M.fromList $
           mapMaybe
             ( \(k, a) -> case (k, a) of
@@ -71,11 +80,21 @@ moduleFromDepTypes oldModule definitions =
                 _ -> Nothing
             )
             (M.toList $ filterExprs definitions)
+
+      typedInstances =
+        M.fromList $
+          mapMaybe
+            ( \(k, a) -> case (k, a) of
+                (DIInstance constraint, DTInstance inst) -> Just (constraint, inst)
+                _ -> Nothing
+            )
+            (M.toList definitions)
    in -- replace input module with typechecked versions
+
       oldModule
-        { moExpressions = newExpressions,
+        { moExpressions = typedExpressions,
           moDataTypes = mapKeyMaybe getTypeName (filterDataTypes definitions),
-          moInstances = mempty, -- well this is wrong
+          moInstances = typedInstances,
           moClasses = mempty
         }
 
@@ -107,7 +126,7 @@ typecheckModule input inputModule depMap = do
   -- go!
   typecheckedDefs <-
     Build.stOutputs
-      <$> Build.doJobs (typecheckOneDef input inputModule) state
+      <$> Build.doJobs (typecheckDef input inputModule) state
 
   -- check all tests make sense
   traverse_ (typecheckTest typecheckedDefs) (moTests inputModule)
@@ -141,18 +160,18 @@ typecheckTest defs (UnitTest testName ident) = do
     _ -> throwError (ErrorInResolveDeps $ VarNotFound ident)
 
 -- given types for other required definition, typecheck a definition
-typecheckOneDef ::
+typecheckDef ::
   (MonadError (ModuleError Annotation) m) =>
   Text ->
   Module ResolvedDep Annotation ->
   Map DefIdentifier (DepType ResolvedDep (Type ResolvedDep Annotation)) ->
   (DefIdentifier, DepType ResolvedDep Annotation) ->
   m (DepType ResolvedDep (Type ResolvedDep Annotation))
-typecheckOneDef input inputModule deps (def, dep) =
+typecheckDef input inputModule deps (def, dep) =
   case dep of
     DTExpr expr ->
       DTExpr
-        <$> typecheckOneExprDef
+        <$> typecheckExprDef
           input
           inputModule
           deps
@@ -161,7 +180,7 @@ typecheckOneDef input inputModule deps (def, dep) =
       DTInstance <$> typecheckInstance input inputModule deps def inst
     DTData dt ->
       DTData
-        <$> typecheckOneTypeDef
+        <$> typecheckTypeDef
           input
           inputModule
           (filterDataTypes deps)
@@ -175,7 +194,7 @@ typecheckInstance ::
   DefIdentifier ->
   Instance Annotation ->
   m (Instance (Type ResolvedDep Annotation))
-typecheckInstance _input _inputModule deps def inst = do
+typecheckInstance input inputModule deps def inst = do
   -- where are we getting constraints from?
   let exprTypeMap =
         mapKey LocalDefinition $
@@ -183,9 +202,11 @@ typecheckInstance _input _inputModule deps def inst = do
             <$> filterNameDefs (filterExprs deps)
 
   let constraint = case def of
-                     DIInstance c -> c
-                     _ -> error "def is not constraint, yikes"
+        DIInstance c -> c
+        _ -> error "def is not constraint, yikes"
 
+  let instances :: Map (Constraint Annotation) (Instance Annotation)
+      instances = mapKey (fmap (const mempty)) (moInstances inputModule)
 
   -- initial typechecking environment
   let env =
@@ -193,25 +214,34 @@ typecheckInstance _input _inputModule deps def inst = do
           { tceVars = exprTypeMap,
             tceDataTypes = getDataTypeMap deps,
             tceClasses = builtInClasses,
-            tceInstances = builtInInstances,
-            tceConstraints = mempty --tleConstraints tle
+            tceInstances = builtInInstances <> instances,
+            tceConstraints = mempty -- tleConstraints tle
           }
 
-  typeclass <- mapError _ (lookupTypeclass env (conTypeclass constraint))
+  typeclass <-
+    modifyError
+      (DefDoesNotTypeCheck input def)
+      (lookupTypeclass env (conTypeclass constraint))
 
-  mapError _ (checkInstance env typeclass (constraint $> mempty) inst)
+  (_fnName, constraints, typedExpr) <-
+    modifyError (DefDoesNotTypeCheck input def) (checkInstance env typeclass (constraint $> mempty) inst)
 
+  pure $
+    Instance
+      { inExpr = toIdentityExpr typedExpr,
+        inConstraints = typeForConstraint <$> constraints
+      }
 
 -- typechecking in this context means "does this data type make sense"
 -- and "do we know about all external datatypes it mentions"
-typecheckOneTypeDef ::
+typecheckTypeDef ::
   (MonadError (ModuleError Annotation) m) =>
   Text ->
   Module ResolvedDep Annotation ->
   Map DefIdentifier (DataType ResolvedDep (Type ResolvedDep Annotation)) ->
   (DefIdentifier, DataType ResolvedDep Annotation) ->
   m (DataType ResolvedDep (Type ResolvedDep Annotation))
-typecheckOneTypeDef _input _inputModule _typeDeps (_def, dt) = do
+typecheckTypeDef _input _inputModule _typeDeps (_def, dt) = do
   -- just put a bullshit type in for now
   pure $ (`TPrim` TPBool) <$> dt
 
@@ -249,20 +279,27 @@ resolveConstraint (Constraint tcn tys) =
     resolveTy ty = ty $> toResolvedDep ty
     toResolvedDep = mapTypeDep (LocalDefinition . runIdentity)
 
+typeForConstraint :: Constraint ann -> Constraint (Type ResolvedDep ann)
+typeForConstraint (Constraint tc tys) =
+  Constraint tc $ fmap (\ty -> ty $> resolveType ty) tys
+
 -- given types for other required definition, typecheck a definition
-typecheckOneExprDef ::
+typecheckExprDef ::
   (MonadError (ModuleError Annotation) m) =>
   Text ->
   Module ResolvedDep Annotation ->
   Map DefIdentifier (DepType ResolvedDep (Type ResolvedDep Annotation)) ->
   (DefIdentifier, TopLevelExpression ResolvedDep Annotation) ->
   m (TopLevelExpression ResolvedDep (Type ResolvedDep Annotation))
-typecheckOneExprDef input _inputModule deps (def, tle) = do
+typecheckExprDef input inputModule deps (def, tle) = do
   -- where are we getting constraints from?
   let exprTypeMap =
         mapKey LocalDefinition $
           (\depTLE -> ((fmap . fmap) getTypeAnnotation (tleConstraints depTLE), getExprAnnotation (tleExpr depTLE)))
             <$> filterNameDefs (filterExprs deps)
+
+  let instances :: Map (Constraint Annotation) (Instance Annotation)
+      instances = mapKey (fmap (const mempty)) (moInstances inputModule)
 
   -- initial typechecking environment
   let env =
@@ -270,7 +307,7 @@ typecheckOneExprDef input _inputModule deps (def, tle) = do
           { tceVars = exprTypeMap,
             tceDataTypes = getDataTypeMap deps,
             tceClasses = builtInClasses,
-            tceInstances = builtInInstances,
+            tceInstances = builtInInstances <> instances,
             tceConstraints = tleConstraints tle
           }
 

--- a/smol-core/src/Smol/Core/Modules/Typecheck.hs
+++ b/smol-core/src/Smol/Core/Modules/Typecheck.hs
@@ -210,7 +210,9 @@ typecheckOneExprDef input _inputModule deps (def, tle) = do
         TCEnv
           { tceVars = exprTypeMap,
             tceDataTypes = getDataTypeMap deps,
-            tceGlobals = mempty
+            tceGlobals = mempty,
+            tceClasses = mempty,
+            tceInstances = mempty
           }
 
   -- if we have a type, add an annotation

--- a/smol-core/src/Smol/Core/Modules/Typecheck.hs
+++ b/smol-core/src/Smol/Core/Modules/Typecheck.hs
@@ -3,9 +3,9 @@
 
 module Smol.Core.Modules.Typecheck (typecheckModule) where
 
-import Control.Monad.Identity
 import qualified Builder as Build
 import Control.Monad.Except
+import Control.Monad.Identity
 import Data.Bifunctor (first)
 import Data.Foldable (traverse_)
 import Data.Functor (($>))
@@ -198,11 +198,11 @@ getDataTypeMap =
     . filterDataTypes
 
 resolveConstraint :: Constraint ann -> Constraint (Type ResolvedDep ann)
-resolveConstraint (Constraint tcn tys)
-  = Constraint tcn (resolveTy  <$> tys)
-    where
-      resolveTy ty = ty $> toResolvedDep ty
-      toResolvedDep = mapTypeDep (LocalDefinition . runIdentity)
+resolveConstraint (Constraint tcn tys) =
+  Constraint tcn (resolveTy <$> tys)
+  where
+    resolveTy ty = ty $> toResolvedDep ty
+    toResolvedDep = mapTypeDep (LocalDefinition . runIdentity)
 
 -- given types for other required definition, typecheck a definition
 typecheckOneExprDef ::

--- a/smol-core/src/Smol/Core/Modules/Typecheck.hs
+++ b/smol-core/src/Smol/Core/Modules/Typecheck.hs
@@ -221,7 +221,7 @@ typecheckOneExprDef input _inputModule deps (def, tle) = do
         Just ty -> EAnn (getTypeAnnotation ty) ty (tleExpr tle)
 
   -- typecheck it
-  newExpr <-
+  (newExpr, _typeclassUses) <-
     liftEither $
       first
         (DefDoesNotTypeCheck input def)

--- a/smol-core/src/Smol/Core/Modules/Typecheck.hs
+++ b/smol-core/src/Smol/Core/Modules/Typecheck.hs
@@ -127,7 +127,7 @@ typecheckTest defs (UnitTest testName ident) = do
                     (TCTypeMismatch other (TPrim (getTypeAnnotation other) TPBool))
                 )
             )
-    _ -> throwError (VarNotFound ident)
+    _ -> throwError (ErrorInResolveDeps $ VarNotFound ident)
 
 -- given types for other required definition, typecheck a definition
 typecheckOneDef ::
@@ -212,7 +212,8 @@ typecheckOneExprDef input _inputModule deps (def, tle) = do
             tceDataTypes = getDataTypeMap deps,
             tceGlobals = mempty,
             tceClasses = mempty,
-            tceInstances = mempty
+            tceInstances = mempty,
+            tceConstraints = mempty -- we'll get these from the type
           }
 
   -- if we have a type, add an annotation

--- a/smol-core/src/Smol/Core/Modules/Types/DefIdentifier.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/DefIdentifier.hs
@@ -14,13 +14,14 @@ import Smol.Core.Modules.Types.TestName
 import Smol.Core.Printer
 import Smol.Core.Types.Identifier
 import Smol.Core.Types.TypeName
+import Smol.Core.Typecheck.Typeclass.Types
 
 -- | different kinds of top-level definitions
 data DefIdentifier
   = DIName Identifier
-  | --  | DIInfix InfixOp
-    DIType TypeName
+  | DIType TypeName
   | DITest TestName
+  | DIInstance (Constraint ())
   deriving stock (Eq, Ord, Show, Generic)
   deriving anyclass
     ( JSON.ToJSON,
@@ -34,3 +35,5 @@ instance Printer DefIdentifier where
   -- prettyDoc (DIInfix infixOp) = prettyDoc infixOp
   prettyDoc (DIType typeName) = prettyDoc typeName
   prettyDoc (DITest testName) = "\"" <> prettyDoc testName <> "\""
+  prettyDoc (DIInstance constraint)
+    = prettyDoc constraint

--- a/smol-core/src/Smol/Core/Modules/Types/DefIdentifier.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/DefIdentifier.hs
@@ -12,9 +12,9 @@ import qualified Data.Aeson as JSON
 import GHC.Generics
 import Smol.Core.Modules.Types.TestName
 import Smol.Core.Printer
+import Smol.Core.Typecheck.Typeclass.Types
 import Smol.Core.Types.Identifier
 import Smol.Core.Types.TypeName
-import Smol.Core.Typecheck.Typeclass.Types
 
 -- | different kinds of top-level definitions
 data DefIdentifier
@@ -35,5 +35,5 @@ instance Printer DefIdentifier where
   -- prettyDoc (DIInfix infixOp) = prettyDoc infixOp
   prettyDoc (DIType typeName) = prettyDoc typeName
   prettyDoc (DITest testName) = "\"" <> prettyDoc testName <> "\""
-  prettyDoc (DIInstance constraint)
-    = prettyDoc constraint
+  prettyDoc (DIInstance constraint) =
+    prettyDoc constraint

--- a/smol-core/src/Smol/Core/Modules/Types/DepType.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/DepType.hs
@@ -12,6 +12,7 @@ import Smol.Core.Modules.Types.TopLevelExpression
 
 data DepType dep ann
   = DTExpr (TopLevelExpression dep ann)
+  | DTInstance (Instance ann)
   | DTData (DataType dep ann)
 
 deriving stock instance

--- a/smol-core/src/Smol/Core/Modules/Types/Module.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/Module.hs
@@ -41,7 +41,9 @@ data Module dep ann = Module
   { moExpressions :: Map Identifier (TopLevelExpression dep ann),
     moDataTypes :: Map TypeName (DataType dep ann),
     moTests :: [Test],
-    moInstances :: Map (Constraint ()) (Instance ann)
+    moInstances :: Map (Constraint ()) (Instance ann),
+    moClasses :: Map TypeclassName (Typeclass ann)
+
   }
   deriving stock (Functor, Generic)
 
@@ -132,12 +134,13 @@ printDefinition name (TopLevelExpression {tleType, tleExpr}) =
    in prettyType <> prettyExpr
 
 instance Semigroup (Module dep ann) where
-  (Module a b c d) <> (Module a' b' c' d') =
-    Module (a <> a') (b <> b') (c <> c') (d <> d')
+  (Module a b c d e) <> (Module a' b' c' d' e') =
+    Module (a <> a') (b <> b') (c <> c') (d <> d') (e <> e')
 
 instance Monoid (Module dep ann) where
   mempty =
     Module
+      mempty
       mempty
       mempty
       mempty

--- a/smol-core/src/Smol/Core/Modules/Types/Module.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/Module.hs
@@ -116,16 +116,16 @@ printDefinition name (TopLevelExpression {tleType, tleExpr}) =
         "def"
           <+> prettyDoc name
           <+> "="
-            <> line
-            <> indentMulti 2 (prettyDoc tleExpr)
+          <> line
+          <> indentMulti 2 (prettyDoc tleExpr)
       prettyType = case tleType of
         Just ty ->
           "def"
             <+> prettyDoc name
             <+> ":"
-              <> line
-              <> indentMulti 2 (prettyDoc ty)
-              <> "\n"
+            <> line
+            <> indentMulti 2 (prettyDoc ty)
+            <> "\n"
         Nothing -> ""
    in prettyType <> prettyExpr
 

--- a/smol-core/src/Smol/Core/Modules/Types/Module.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/Module.hs
@@ -43,7 +43,6 @@ data Module dep ann = Module
     moTests :: [Test],
     moInstances :: Map (Constraint ()) (Instance ann),
     moClasses :: Map TypeclassName (Typeclass ann)
-
   }
   deriving stock (Functor, Generic)
 

--- a/smol-core/src/Smol/Core/Modules/Types/Module.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/Module.hs
@@ -23,6 +23,7 @@ import Prettyprinter
 import Smol.Core.Modules.Types.Test
 import Smol.Core.Modules.Types.TopLevelExpression
 import Smol.Core.Printer
+import Smol.Core.Typecheck.Typeclass.Types
 import Smol.Core.Types.Constructor
 import Smol.Core.Types.DataType
 import Smol.Core.Types.Identifier
@@ -39,7 +40,8 @@ import Smol.Core.Types.TypeName
 data Module dep ann = Module
   { moExpressions :: Map Identifier (TopLevelExpression dep ann),
     moDataTypes :: Map TypeName (DataType dep ann),
-    moTests :: [Test]
+    moTests :: [Test],
+    moInstances :: Map (Constraint ()) (Instance ann)
   }
   deriving stock (Functor, Generic)
 
@@ -130,12 +132,13 @@ printDefinition name (TopLevelExpression {tleType, tleExpr}) =
    in prettyType <> prettyExpr
 
 instance Semigroup (Module dep ann) where
-  (Module a b c) <> (Module a' b' c') =
-    Module (a <> a') (b <> b') (c <> c')
+  (Module a b c d) <> (Module a' b' c' d') =
+    Module (a <> a') (b <> b') (c <> c') (d <> d')
 
 instance Monoid (Module dep ann) where
   mempty =
     Module
+      mempty
       mempty
       mempty
       mempty

--- a/smol-core/src/Smol/Core/Modules/Types/Module.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/Module.hs
@@ -116,16 +116,16 @@ printDefinition name (TopLevelExpression {tleType, tleExpr}) =
         "def"
           <+> prettyDoc name
           <+> "="
-          <> line
-          <> indentMulti 2 (prettyDoc tleExpr)
+            <> line
+            <> indentMulti 2 (prettyDoc tleExpr)
       prettyType = case tleType of
         Just ty ->
           "def"
             <+> prettyDoc name
             <+> ":"
-            <> line
-            <> indentMulti 2 (prettyDoc ty)
-            <> "\n"
+              <> line
+              <> indentMulti 2 (prettyDoc ty)
+              <> "\n"
         Nothing -> ""
    in prettyType <> prettyExpr
 

--- a/smol-core/src/Smol/Core/Modules/Types/ModuleItem.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/ModuleItem.hs
@@ -46,6 +46,7 @@ data ModuleItem ann
   | ModuleExpressionType Identifier [Constraint ann] (Type ParseDep ann)
   | ModuleDataType (DataType ParseDep ann)
   | ModuleTest TestName Identifier
+  | ModuleInstance (Constraint ann) Identifier
   deriving stock (Eq, Ord, Functor)
 
 deriving stock instance

--- a/smol-core/src/Smol/Core/Modules/Types/ModuleItem.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/ModuleItem.hs
@@ -135,16 +135,16 @@ printDefinition name (TopLevelExpression {tleType, tleExpr}) =
         "def"
           <+> prettyDoc name
           <+> "="
-            <> line
-            <> indentMulti 2 (prettyDoc tleExpr)
+          <> line
+          <> indentMulti 2 (prettyDoc tleExpr)
       prettyType = case tleType of
         Just ty ->
           "def"
             <+> prettyDoc name
             <+> ":"
-              <> line
-              <> indentMulti 2 (prettyDoc ty)
-              <> "\n"
+            <> line
+            <> indentMulti 2 (prettyDoc ty)
+            <> "\n"
         Nothing -> ""
    in prettyType <> prettyExpr
 

--- a/smol-core/src/Smol/Core/Modules/Types/ModuleItem.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/ModuleItem.hs
@@ -46,7 +46,8 @@ data ModuleItem ann
   | ModuleExpressionType Identifier [Constraint ann] (Type ParseDep ann)
   | ModuleDataType (DataType ParseDep ann)
   | ModuleTest TestName Identifier
-  | ModuleInstance (Constraint ann) Identifier
+  | ModuleInstance (Constraint ann) (ParsedExpr ann)
+  | ModuleClass (Typeclass ann)
   deriving stock (Eq, Ord, Functor)
 
 deriving stock instance

--- a/smol-core/src/Smol/Core/Modules/Types/ModuleItem.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/ModuleItem.hs
@@ -23,6 +23,7 @@ import Prettyprinter
 import Smol.Core.Modules.Types.TestName
 import Smol.Core.Modules.Types.TopLevelExpression
 import Smol.Core.Printer
+import Smol.Core.Typecheck.Typeclass.Types
 import Smol.Core.Types.Constructor
 import Smol.Core.Types.DataType
 import Smol.Core.Types.Expr
@@ -42,7 +43,7 @@ import Smol.Core.Types.TypeName
 -- when things don't make sense (duplicate defs etc)
 data ModuleItem ann
   = ModuleExpression Identifier [Identifier] (ParsedExpr ann)
-  | ModuleExpressionType Identifier (Type ParseDep ann)
+  | ModuleExpressionType Identifier [Constraint ann] (Type ParseDep ann)
   | ModuleDataType (DataType ParseDep ann)
   | ModuleTest TestName Identifier
   deriving stock (Eq, Ord, Functor)

--- a/smol-core/src/Smol/Core/Modules/Types/ModuleItem.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/ModuleItem.hs
@@ -135,16 +135,16 @@ printDefinition name (TopLevelExpression {tleType, tleExpr}) =
         "def"
           <+> prettyDoc name
           <+> "="
-          <> line
-          <> indentMulti 2 (prettyDoc tleExpr)
+            <> line
+            <> indentMulti 2 (prettyDoc tleExpr)
       prettyType = case tleType of
         Just ty ->
           "def"
             <+> prettyDoc name
             <+> ":"
-            <> line
-            <> indentMulti 2 (prettyDoc ty)
-            <> "\n"
+              <> line
+              <> indentMulti 2 (prettyDoc ty)
+              <> "\n"
         Nothing -> ""
    in prettyType <> prettyExpr
 

--- a/smol-core/src/Smol/Core/Modules/Types/TopLevelExpression.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/TopLevelExpression.hs
@@ -28,7 +28,7 @@ import Smol.Core.Types.TypeName
 
 -- a single expression of zero or more exprs and an optional type
 data TopLevelExpression dep ann = TopLevelExpression
-  { tleConstraints :: [Constraint ()],
+  { tleConstraints :: [Constraint ann],
     tleExpr :: Expr dep ann,
     tleType :: Maybe (Type dep ann)
   }

--- a/smol-core/src/Smol/Core/Modules/Types/TopLevelExpression.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/TopLevelExpression.hs
@@ -15,6 +15,7 @@ where
 
 import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import GHC.Generics (Generic)
+import Smol.Core.Typecheck.Types
 import Smol.Core.Types.Constructor
 import Smol.Core.Types.Expr
 import Smol.Core.Types.Identifier
@@ -27,7 +28,8 @@ import Smol.Core.Types.TypeName
 
 -- a single expression of zero or more exprs and an optional type
 data TopLevelExpression dep ann = TopLevelExpression
-  { tleExpr :: Expr dep ann,
+  { tleConstraints :: [Constraint ()],
+    tleExpr :: Expr dep ann,
     tleType :: Maybe (Type dep ann)
   }
   deriving stock (Functor, Generic)

--- a/smol-core/src/Smol/Core/Parser.hs
+++ b/smol-core/src/Smol/Core/Parser.hs
@@ -7,8 +7,10 @@ module Smol.Core.Parser
     parseTypeAndFormatError,
     parseType,
     parseModule,
+    parseConstraint,
     parseModuleAndFormatError,
     parseDataTypeAndFormatError,
+    parseConstraintAndFormatError,
     ParseErrorType,
   )
 where
@@ -22,6 +24,8 @@ import Smol.Core.Parser.DataType (dataTypeParser)
 import Smol.Core.Parser.Expr
 import Smol.Core.Parser.Module
 import Smol.Core.Parser.Type
+import Smol.Core.Parser.Typeclass
+import Smol.Core.Typecheck.Types
 import Smol.Core.Types
 import Text.Megaparsec
 import Text.Megaparsec.Char
@@ -45,8 +49,14 @@ parseExprAndFormatError = parseAndFormat (space *> expressionParser <* eof)
 parseModule :: Text -> Either ParseErrorType [ModuleItem Annotation]
 parseModule = parse (space *> moduleParser <* eof) "repl"
 
+parseConstraint :: Text -> Either ParseErrorType (Constraint Annotation)
+parseConstraint = parse (space *> constraintParser <* eof) "repl"
+
 parseModuleAndFormatError :: Text -> Either Text [ModuleItem Annotation]
 parseModuleAndFormatError = parseAndFormat (space *> moduleParser <* eof)
 
 parseDataTypeAndFormatError :: Text -> Either Text (DataType ParseDep Annotation)
 parseDataTypeAndFormatError = parseAndFormat (space *> dataTypeParser <* eof)
+
+parseConstraintAndFormatError :: Text -> Either Text (Constraint Annotation)
+parseConstraintAndFormatError = parseAndFormat (space *> constraintParser <* eof)

--- a/smol-core/src/Smol/Core/Parser/Expr.hs
+++ b/smol-core/src/Smol/Core/Parser/Expr.hs
@@ -286,7 +286,7 @@ patternMatchParser = addLocation $ do
   patterns <-
     try patternMatchesParser
       <|> pure
-        <$> patternCaseParser
+      <$> patternCaseParser
   case NE.nonEmpty patterns of
     (Just nePatterns) -> pure $ EPatternMatch mempty matchExpr nePatterns
     _ -> error "need at least one pattern"

--- a/smol-core/src/Smol/Core/Parser/Expr.hs
+++ b/smol-core/src/Smol/Core/Parser/Expr.hs
@@ -286,7 +286,7 @@ patternMatchParser = addLocation $ do
   patterns <-
     try patternMatchesParser
       <|> pure
-      <$> patternCaseParser
+        <$> patternCaseParser
   case NE.nonEmpty patterns of
     (Just nePatterns) -> pure $ EPatternMatch mempty matchExpr nePatterns
     _ -> error "need at least one pattern"

--- a/smol-core/src/Smol/Core/Parser/Expr.hs
+++ b/smol-core/src/Smol/Core/Parser/Expr.hs
@@ -285,7 +285,8 @@ patternMatchParser = addLocation $ do
   matchExpr <- matchExprWithParser
   patterns <-
     try patternMatchesParser
-      <|> pure <$> patternCaseParser
+      <|> pure
+      <$> patternCaseParser
   case NE.nonEmpty patterns of
     (Just nePatterns) -> pure $ EPatternMatch mempty matchExpr nePatterns
     _ -> error "need at least one pattern"

--- a/smol-core/src/Smol/Core/Parser/Identifiers.hs
+++ b/smol-core/src/Smol/Core/Parser/Identifiers.hs
@@ -50,9 +50,8 @@ protectedNames =
       "Nat",
       "Unit",
       "def",
-      "export",
-      "import",
-      "test"
+      "test",
+      "instance"
     ]
 
 filterProtectedNames :: Text -> Maybe Text

--- a/smol-core/src/Smol/Core/Parser/Identifiers.hs
+++ b/smol-core/src/Smol/Core/Parser/Identifiers.hs
@@ -9,10 +9,12 @@ module Smol.Core.Parser.Identifiers
     moduleNameParser,
     typeNameParser,
     plainTypeNameParser,
+    typeclassNameParser,
     testNameParser,
   )
 where
 
+import Smol.Core.Typecheck.Typeclass.Types
 import Control.Monad
 import qualified Data.Char as Char
 import Data.Set (Set)
@@ -169,6 +171,19 @@ moduleNameParser =
     maybePred
       moduleName
       (filterProtectedNames >=> safeMkModuleName)
+
+----
+
+typeclassName :: Parser Text
+typeclassName = takeWhile1P (Just "constructor") Char.isAlphaNum
+
+typeclassNameParser :: Parser TypeclassName
+typeclassNameParser =
+  myLexeme $
+    maybePred
+      typeclassName
+      (filterProtectedNames >=> safeMkTypeclassName)
+
 
 --------
 

--- a/smol-core/src/Smol/Core/Parser/Identifiers.hs
+++ b/smol-core/src/Smol/Core/Parser/Identifiers.hs
@@ -14,7 +14,6 @@ module Smol.Core.Parser.Identifiers
   )
 where
 
-import Smol.Core.Typecheck.Typeclass.Types
 import Control.Monad
 import qualified Data.Char as Char
 import Data.Set (Set)
@@ -25,6 +24,7 @@ import Smol.Core.Modules.Types.ModuleName
 import Smol.Core.Modules.Types.TestName
 import Smol.Core.Parser.Primitives (textPrim)
 import Smol.Core.Parser.Shared
+import Smol.Core.Typecheck.Typeclass.Types
 import Smol.Core.Types
 import Text.Megaparsec
 
@@ -183,7 +183,6 @@ typeclassNameParser =
     maybePred
       typeclassName
       (filterProtectedNames >=> safeMkTypeclassName)
-
 
 --------
 

--- a/smol-core/src/Smol/Core/Parser/Module.hs
+++ b/smol-core/src/Smol/Core/Parser/Module.hs
@@ -41,8 +41,7 @@ parseModuleItem =
     <|> try moduleDefinitionParser
     <|> try moduleTypeDeclarationParser
     <|> parseTest
-
---    <|> parseInfix
+    <|> parseInstance
 
 -------
 
@@ -96,3 +95,11 @@ parseTest = do
   testName <- testNameParser
   myString "using"
   ModuleTest testName <$> identifierParser
+
+-- `instance Eq Int using eqInt`
+parseInstance :: Parser (ModuleItem Annotation)
+parseInstance = do
+  myString "instance"
+  constraint <- constraintParser
+  myString "using"
+  ModuleInstance constraint <$> identifierParser

--- a/smol-core/src/Smol/Core/Parser/Module.hs
+++ b/smol-core/src/Smol/Core/Parser/Module.hs
@@ -6,6 +6,7 @@ module Smol.Core.Parser.Module
   )
 where
 
+import qualified Data.List.NonEmpty as NE
 import Data.Text (Text)
 import Data.Void
 import Smol.Core.Modules.Types.ModuleItem
@@ -14,6 +15,8 @@ import Smol.Core.Parser.Expr
 import Smol.Core.Parser.Identifiers
 import Smol.Core.Parser.Shared
 import Smol.Core.Parser.Type
+import Smol.Core.Parser.Typeclass
+import Smol.Core.Typecheck.Typeclass.Types
 import Smol.Core.Types
 import Text.Megaparsec hiding (parseTest)
 
@@ -75,7 +78,16 @@ moduleTypeDefinitionParser = do
   myString "def"
   name <- identifierParser
   myString ":"
-  ModuleExpressionType name <$> typeParser
+  constraints <- try typeConstraintParser <|> pure mempty
+  ModuleExpressionType name constraints <$> typeParser
+
+typeConstraintParser :: Parser [Constraint Annotation]
+typeConstraintParser = do
+  myString "("
+  constraints <- commaSep constraintParser
+  myString ")"
+  myString "=>"
+  pure (NE.toList constraints)
 
 -- `test "everything is fine" with myFunctionName`
 parseTest :: Parser (ModuleItem Annotation)

--- a/smol-core/src/Smol/Core/Parser/Module.hs
+++ b/smol-core/src/Smol/Core/Parser/Module.hs
@@ -7,10 +7,10 @@ module Smol.Core.Parser.Module
 where
 
 import Control.Monad.Identity
-import Smol.Core.ExprUtils
 import qualified Data.List.NonEmpty as NE
 import Data.Text (Text)
 import Data.Void
+import Smol.Core.ExprUtils
 import Smol.Core.Modules.Types.ModuleItem
 import Smol.Core.Parser.DataType (dataTypeParser)
 import Smol.Core.Parser.Expr
@@ -112,8 +112,8 @@ parseClass = do
   myString "class"
   typeclassName <- typeclassNameParser
   parts <-
-      chainl1 ((: []) <$> identifierParser) (pure (<>))
-        <|> pure mempty
+    chainl1 ((: []) <$> identifierParser) (pure (<>))
+      <|> pure mempty
   myString "{"
   fnName <- identifierParser
   myString ":"
@@ -121,10 +121,12 @@ parseClass = do
   ty <- mapTypeDep resolve <$> typeParser
   myString "}"
 
-  pure $ ModuleClass (Typeclass {
-          tcName  =typeclassName,
-          tcArgs = parts,
-          tcFuncName = fnName,
-          tcFuncType = ty
-
-                                })
+  pure $
+    ModuleClass
+      ( Typeclass
+          { tcName = typeclassName,
+            tcArgs = parts,
+            tcFuncName = fnName,
+            tcFuncType = ty
+          }
+      )

--- a/smol-core/src/Smol/Core/Parser/Primitives.hs
+++ b/smol-core/src/Smol/Core/Parser/Primitives.hs
@@ -33,8 +33,8 @@ primParser =
         <|> truePrimParser
         <|> falsePrimParser
         <|> PUnit
-        <$ unitParser
-          <|> stringPrimParser
+          <$ unitParser
+        <|> stringPrimParser
     )
 
 typeLiteralParser :: Parser TypeLiteral
@@ -42,14 +42,14 @@ typeLiteralParser =
   myLexeme
     ( TLInt
         <$> multiIntParser
-          <|> TLBool
-        <$> trueParser
-          <|> TLBool
-        <$> falseParser
-          <|> TLUnit
-        <$ unitParser
-          <|> TLString
-        <$> multiStringParser
+        <|> TLBool
+          <$> trueParser
+        <|> TLBool
+          <$> falseParser
+        <|> TLUnit
+          <$ unitParser
+        <|> TLString
+          <$> multiStringParser
     )
 
 -- 2, -2, +2

--- a/smol-core/src/Smol/Core/Parser/Primitives.hs
+++ b/smol-core/src/Smol/Core/Parser/Primitives.hs
@@ -33,8 +33,8 @@ primParser =
         <|> truePrimParser
         <|> falsePrimParser
         <|> PUnit
-          <$ unitParser
-        <|> stringPrimParser
+        <$ unitParser
+          <|> stringPrimParser
     )
 
 typeLiteralParser :: Parser TypeLiteral
@@ -42,14 +42,14 @@ typeLiteralParser =
   myLexeme
     ( TLInt
         <$> multiIntParser
-        <|> TLBool
-          <$> trueParser
-        <|> TLBool
-          <$> falseParser
-        <|> TLUnit
-          <$ unitParser
-        <|> TLString
-          <$> multiStringParser
+          <|> TLBool
+        <$> trueParser
+          <|> TLBool
+        <$> falseParser
+          <|> TLUnit
+        <$ unitParser
+          <|> TLString
+        <$> multiStringParser
     )
 
 -- 2, -2, +2

--- a/smol-core/src/Smol/Core/Parser/Primitives.hs
+++ b/smol-core/src/Smol/Core/Parser/Primitives.hs
@@ -32,18 +32,24 @@ primParser =
     ( intPrimParser
         <|> truePrimParser
         <|> falsePrimParser
-        <|> PUnit <$ unitParser
-        <|> stringPrimParser
+        <|> PUnit
+        <$ unitParser
+          <|> stringPrimParser
     )
 
 typeLiteralParser :: Parser TypeLiteral
 typeLiteralParser =
   myLexeme
-    ( TLInt <$> multiIntParser
-        <|> TLBool <$> trueParser
-        <|> TLBool <$> falseParser
-        <|> TLUnit <$ unitParser
-        <|> TLString <$> multiStringParser
+    ( TLInt
+        <$> multiIntParser
+          <|> TLBool
+        <$> trueParser
+          <|> TLBool
+        <$> falseParser
+          <|> TLUnit
+        <$ unitParser
+          <|> TLString
+        <$> multiStringParser
     )
 
 -- 2, -2, +2

--- a/smol-core/src/Smol/Core/Parser/Type.hs
+++ b/smol-core/src/Smol/Core/Parser/Type.hs
@@ -208,8 +208,8 @@ protectedTypeNames =
       "type",
       "infix",
       "test",
-      "import",
-      "export"
+      "using",
+      "instance"
     ]
 
 tyVarParser :: Parser Identifier

--- a/smol-core/src/Smol/Core/Parser/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Parser/Typeclass.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 module Smol.Core.Parser.Typeclass
   ( constraintParser,
   )

--- a/smol-core/src/Smol/Core/Parser/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Parser/Typeclass.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Smol.Core.Parser.Typeclass
+  ( constraintParser
+  )
+where
+
+import Data.Text (Text)
+import Data.Void
+import Smol.Core.Types
+import Text.Megaparsec hiding (parseTest)
+import Smol.Core.Typecheck.Types
+
+type Parser = Parsec Void Text
+
+constraintParser :: Parser (Constraint Annotation)
+constraintParser =
+  fail "sdf"

--- a/smol-core/src/Smol/Core/Parser/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Parser/Typeclass.hs
@@ -1,18 +1,30 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Smol.Core.Parser.Typeclass
-  ( constraintParser
+  ( constraintParser,
   )
 where
 
+import Control.Monad.Identity
 import Data.Text (Text)
 import Data.Void
+import Smol.Core.ExprUtils
+import Smol.Core.Parser.Identifiers
+import Smol.Core.Parser.Type
+import Smol.Core.Typecheck.Types
 import Smol.Core.Types
 import Text.Megaparsec hiding (parseTest)
-import Smol.Core.Typecheck.Types
 
 type Parser = Parsec Void Text
 
+toIdentity :: Type ParseDep ann -> Type Identity ann
+toIdentity = mapTypeDep resolve
+  where
+    resolve (ParseDep ident _) = Identity ident
+
 constraintParser :: Parser (Constraint Annotation)
-constraintParser =
-  fail "sdf"
+constraintParser = do
+  tcn <- typeclassNameParser
+  tys <- many typeParser
+
+  pure $ Constraint tcn (toIdentity <$> tys)

--- a/smol-core/src/Smol/Core/Printer.hs
+++ b/smol-core/src/Smol/Core/Printer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Smol.Core.Printer
@@ -41,6 +42,9 @@ instance Printer () where
 instance (Printer a) => Printer (Maybe a) where
   prettyDoc (Just a) = prettyDoc a
   prettyDoc _ = mempty
+
+instance {-# OVERLAPPING #-} Printer [Char] where
+  prettyDoc = pretty
 
 instance Printer Text where
   prettyDoc = pretty

--- a/smol-core/src/Smol/Core/Printer.hs
+++ b/smol-core/src/Smol/Core/Printer.hs
@@ -9,6 +9,7 @@ where
 -- the Printer type class is used for internal debugging
 -- prettyDoc returns a Prettyprinter doc for nicer output
 
+import Control.Monad.Identity
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Set (Set)
@@ -26,6 +27,9 @@ renderWithWidth w doc = renderStrict (layoutPretty layoutOptions (unAnnotate doc
 
 class Printer a where
   prettyDoc :: a -> Doc ann
+
+instance (Printer a) => Printer (Identity a) where
+  prettyDoc (Identity a) = prettyDoc a
 
 instance (Printer e, Printer a) => Printer (Either e a) where
   prettyDoc (Left e) = prettyDoc e

--- a/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
@@ -16,7 +16,7 @@ import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Trans.Writer.CPS (runWriterT)
 import Control.Monad.Writer.CPS
-import Data.Foldable (toList)
+import Data.Foldable (toList, traverse_)
 import Data.Functor
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
@@ -28,28 +28,34 @@ import Smol.Core.Typecheck.Shared
 import Smol.Core.Typecheck.Simplify
 import Smol.Core.Typecheck.Substitute
 import Smol.Core.Typecheck.Subtype
+import Smol.Core.Typecheck.Typeclass.Helpers
 import Smol.Core.Typecheck.Types
 import Smol.Core.Types
 
 elaborate ::
   ( Ord ann,
     Show ann,
+    Monoid ann,
     MonadError (TCError ann) m
   ) =>
   TCEnv ann ->
   ResolvedExpr ann ->
   m (ResolvedExpr (ResolvedType ann))
-elaborate env expr = do
-  (typedExpr, subs) <-
-    runReaderT
-      ( runWriterT
-          ( evalStateT
-              (infer expr)
-              (TCState mempty 0 mempty)
-          )
-      )
-      env
-  pure (simplifyType . substituteMany subs <$> typedExpr)
+elaborate env expr =
+  runReaderT
+    ( runWriterT
+        ( evalStateT
+            (infer expr)
+            (TCState mempty 0 mempty)
+        )
+    )
+    env
+    >>= \(typedExpr, events) -> do
+      -- lookup typeclasses we need, explode if they're missing
+      traverse_ (lookupTypeclassHead env) (recoverTypeclassUses events)
+      -- we may want to think of a way of raising a legitimate polymorphic
+      -- constraint, ie `Eq a`
+      pure (simplifyType . substituteMany (filterSubstitutions events) <$> typedExpr)
 
 inferInfix ::
   ( Ord ann,
@@ -57,7 +63,7 @@ inferInfix ::
     MonadState (TCState ann) m,
     MonadReader (TCEnv ann) m,
     MonadError (TCError ann) m,
-    MonadWriter [Substitution ResolvedDep ann] m
+    MonadWriter [TCWrite ann] m
   ) =>
   ann ->
   Op ->
@@ -108,7 +114,7 @@ infer ::
     MonadError (TCError ann) m,
     MonadReader (TCEnv ann) m,
     MonadState (TCState ann) m,
-    MonadWriter [Substitution ResolvedDep ann] m
+    MonadWriter [TCWrite ann] m
   ) =>
   ResolvedExpr ann ->
   m (ResolvedExpr (ResolvedType ann))
@@ -200,7 +206,7 @@ inferApplication ::
     MonadError (TCError ann) m,
     MonadReader (TCEnv ann) m,
     MonadState (TCState ann) m,
-    MonadWriter [Substitution ResolvedDep ann] m
+    MonadWriter [TCWrite ann] m
   ) =>
   ann ->
   Maybe (ResolvedType ann) ->
@@ -231,7 +237,7 @@ inferApplication ann maybeCheckType fn arg = withRecursiveFn fn arg $ do
                 -- unknowns unnecessarily
                 let realType =
                       substituteMany
-                        (subs <> undoSubs)
+                        (filterSubstitutions subs <> undoSubs)
                         (TFunc tAnn tClosure tyArg tBody)
 
                 pure (mapOuterExprAnnotation (const realType) typedFn) -- replace type with clever one
@@ -268,7 +274,7 @@ withRecursiveFn _ _ = id
 
 checkLambda ::
   ( MonadState (TCState ann) m,
-    MonadWriter [Substitution ResolvedDep ann] m,
+    MonadWriter [TCWrite ann] m,
     MonadError (TCError ann) m,
     MonadReader (TCEnv ann) m,
     Show ann,
@@ -289,7 +295,7 @@ checkLambda (TFunc tAnn _ tFrom tTo) ident body = do
     pure (tBody, tClosure, subs)
   let lambdaType =
         substituteMany
-          subs
+          (filterSubstitutions subs)
           ( TFunc
               tAnn
               typedClosure
@@ -307,7 +313,7 @@ checkLambda other@(TUnknown {}) ident body = do
     pure (tBody, tClosure, subs)
   let lambdaType =
         substituteMany
-          subs
+          (filterSubstitutions subs)
           ( TFunc
               tAnn
               typedClosure
@@ -323,7 +329,7 @@ inferLambda ::
     MonadError (TCError ann) m,
     MonadReader (TCEnv ann) m,
     MonadState (TCState ann) m,
-    MonadWriter [Substitution ResolvedDep ann] m
+    MonadWriter [TCWrite ann] m
   ) =>
   ann ->
   ResolvedDep Identifier ->
@@ -340,7 +346,7 @@ inferLambda ann ident body = do
     pure (tBody, tClosure, subs)
   let lambdaType =
         substituteMany
-          subs
+          (filterSubstitutions subs)
           (TFunc ann typedClosure tyArg (getExprAnnotation typedBody))
   pure (ELambda lambdaType ident typedBody)
 
@@ -352,7 +358,7 @@ check ::
     MonadError (TCError ann) m,
     MonadReader (TCEnv ann) m,
     MonadState (TCState ann) m,
-    MonadWriter [Substitution ResolvedDep ann] m
+    MonadWriter [TCWrite ann] m
   ) =>
   ResolvedType ann ->
   ResolvedExpr ann ->
@@ -395,4 +401,4 @@ check typ expr = do
     other -> do
       inferredExpr <- infer other
       (realType, subs) <- listen (getExprAnnotation inferredExpr `isSubtypeOf` typ)
-      pure $ inferredExpr $> substituteMany subs realType
+      pure $ inferredExpr $> substituteMany (filterSubstitutions subs) realType

--- a/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
@@ -40,7 +40,7 @@ elaborate ::
   ) =>
   TCEnv ann ->
   ResolvedExpr ann ->
-  m (ResolvedExpr (ResolvedType ann), M.Map (ResolvedDep Identifier) (TypeclassHead ann))
+  m (ResolvedExpr (ResolvedType ann), M.Map (ResolvedDep Identifier) (Constraint ann))
 elaborate env expr =
   runReaderT
     ( runWriterT

--- a/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
@@ -53,7 +53,7 @@ elaborate env expr =
     >>= \(typedExpr, events) -> do
       let typeclassUses = recoverTypeclassUses events
       -- lookup typeclasses we need, explode if they're missing
-      traverse_ (lookupTypeclassHead env) (M.elems typeclassUses)
+      traverse_ (lookupTypeclassConstraint env) (M.elems typeclassUses)
       -- we may want to think of a way of raising a legitimate polymorphic
       -- constraint, ie `Eq a`
       pure (simplifyType . substituteMany (filterSubstitutions events) <$> typedExpr, typeclassUses)

--- a/smol-core/src/Smol/Core/Typecheck/Pattern.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Pattern.hs
@@ -31,7 +31,7 @@ checkPattern ::
     MonadError (TCError ann) m,
     MonadReader (TCEnv ann) m,
     MonadState (TCState ann) m,
-    MonadWriter [Substitution ResolvedDep ann] m
+    MonadWriter [TCWrite ann] m
   ) =>
   ResolvedType ann ->
   Pattern ResolvedDep ann ->
@@ -56,7 +56,7 @@ checkPattern checkTy checkPat =
           env = envA <> mconcat (NE.toList envRest)
       -- we have learned that our unknown type equals the tuple of new unknowns
       -- we have created
-      tell [Substitution (SubUnknown a) ty]
+      tell [TCWSubstitution $ Substitution (SubUnknown a) ty]
       pure (PTuple ty patA patRest, env)
     (ty, PVar _ ident) ->
       pure (PVar ty ident, M.singleton ident ty)

--- a/smol-core/src/Smol/Core/Typecheck/Shared.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Shared.hs
@@ -227,7 +227,9 @@ lookupVar ::
 lookupVar ann ident = do
   maybeVar <- asks (M.lookup ident . tceVars)
   case maybeVar of
-    Just expr -> pure expr
+    Just (_constraints, expr) ->
+      -- TODO: raise constraints used maybe?
+      pure expr
     Nothing -> do
       classes <- asks tceClasses
 
@@ -266,7 +268,7 @@ withVar ::
 withVar ident expr =
   local
     ( \env ->
-        env {tceVars = M.singleton ident expr <> tceVars env}
+        env {tceVars = M.singleton ident (mempty, expr) <> tceVars env}
     )
 
 pushArg ::
@@ -352,7 +354,7 @@ withNewVars ::
   m a ->
   m a
 withNewVars vars =
-  local (\env -> env {tceVars = vars <> tceVars env})
+  local (\env -> env {tceVars = ((,) mempty <$> vars) <> tceVars env})
 
 typeLiteralFromPrim :: Prim -> TypeLiteral
 typeLiteralFromPrim (PBool b) = TLBool b

--- a/smol-core/src/Smol/Core/Typecheck/Shared.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Shared.hs
@@ -20,7 +20,6 @@ module Smol.Core.Typecheck.Shared
     withNewVars,
     pushArg,
     getApplyReturnType,
-    withGlobal,
     lookupConstructor,
     lookupTypeName,
     typeForConstructor,
@@ -268,18 +267,6 @@ withVar ident expr =
   local
     ( \env ->
         env {tceVars = M.singleton ident expr <> tceVars env}
-    )
-
-withGlobal ::
-  (MonadReader (TCEnv ann) m) =>
-  Identifier ->
-  ResolvedType ann ->
-  m a ->
-  m a
-withGlobal ident expr =
-  local
-    ( \env ->
-        env {tceGlobals = M.singleton ident expr <> tceGlobals env}
     )
 
 pushArg ::

--- a/smol-core/src/Smol/Core/Typecheck/Shared.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Shared.hs
@@ -239,7 +239,7 @@ lookupVar ann ident = do
         -- need to turn Type Identity ann into Type ResolvedDep ann
         Just tc -> do
           (newType, undoSubs) <- freshen (resolve $ tcFuncType tc)
-          tell [TCWTypeclassUse (tcName tc) (pairFromSubs undoSubs)]
+          tell [TCWTypeclassUse ident (tcName tc) (pairFromSubs undoSubs)]
           pure newType
         Nothing -> throwError (TCCouldNotFindVar ann ident)
 

--- a/smol-core/src/Smol/Core/Typecheck/Substitute.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Substitute.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Smol.Core.Typecheck.Substitute
   ( Substitution (..),

--- a/smol-core/src/Smol/Core/Typecheck/Substitute.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Substitute.hs
@@ -11,53 +11,8 @@ module Smol.Core.Typecheck.Substitute
   )
 where
 
-import qualified Prettyprinter as PP
-import Smol.Core.Printer
+import Smol.Core.Typecheck.Types.Substitution
 import Smol.Core.Types
-
-data SubstitutionMatcher dep ann
-  = SubId (dep Identifier)
-  | SubUnknown Integer
-  | SubType (Type dep ann)
-
-deriving stock instance
-  ( Eq ann,
-    Eq (dep Identifier),
-    Eq (dep TypeName)
-  ) =>
-  Eq (SubstitutionMatcher dep ann)
-
-deriving stock instance
-  ( Ord ann,
-    Ord (dep Identifier),
-    Ord (dep TypeName)
-  ) =>
-  Ord (SubstitutionMatcher dep ann)
-
-deriving stock instance
-  ( Show ann,
-    Show (dep Identifier),
-    Show (dep TypeName)
-  ) =>
-  Show (SubstitutionMatcher dep ann)
-
-data Substitution dep ann
-  = Substitution (SubstitutionMatcher dep ann) (Type dep ann)
-
-instance (Show ann, Show (dep Identifier), Show (dep TypeName)) => Printer (Substitution dep ann) where
-  prettyDoc a = PP.pretty (show a)
-
-deriving stock instance
-  (Eq ann, Eq (dep Identifier), Eq (dep TypeName)) =>
-  Eq (Substitution dep ann)
-
-deriving stock instance
-  (Ord ann, Ord (dep Identifier), Ord (dep TypeName)) =>
-  Ord (Substitution dep ann)
-
-deriving stock instance
-  (Show ann, Show (dep Identifier), Show (dep TypeName)) =>
-  Show (Substitution dep ann)
 
 getSubId :: SubstitutionMatcher dep ann -> Maybe (dep Identifier)
 getSubId (SubId subId) = Just subId

--- a/smol-core/src/Smol/Core/Typecheck/Subtype.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Subtype.hs
@@ -72,7 +72,6 @@ combineMany types =
 -- | when calculating type for addition, we try and do the actual sum,
 -- otherwise treat literals as their more generic types (int, nat, etc) and
 -- then subtype as usual to check for errors
--- TODO: make this function part of `Type` so we can defer calculating it
 typeAddition ::
   ( Eq ann,
     Show ann,

--- a/smol-core/src/Smol/Core/Typecheck/Subtype.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Subtype.hs
@@ -33,7 +33,7 @@ combineTypeMaps ::
   ( Eq ann,
     Show ann,
     MonadError (TCError ann) m,
-    MonadWriter [Substitution ResolvedDep ann] m
+    MonadWriter [TCWrite ann] m
   ) =>
   GlobalMap ann ->
   GlobalMap ann ->
@@ -60,7 +60,7 @@ generaliseLiteral a = a
 -- | used to combine branches of if or case matches
 combineMany ::
   ( MonadError (TCError ann) m,
-    MonadWriter [Substitution ResolvedDep ann] m,
+    MonadWriter [TCWrite ann] m,
     Show ann,
     Eq ann
   ) =>
@@ -76,7 +76,7 @@ typeAddition ::
   ( Eq ann,
     Show ann,
     MonadError (TCError ann) m,
-    MonadWriter [Substitution ResolvedDep ann] m
+    MonadWriter [TCWrite ann] m
   ) =>
   ResolvedType ann ->
   ResolvedType ann ->
@@ -114,7 +114,7 @@ combine ::
   ( Eq ann,
     Show ann,
     MonadError (TCError ann) m,
-    MonadWriter [Substitution ResolvedDep ann] m
+    MonadWriter [TCWrite ann] m
   ) =>
   ResolvedType ann ->
   ResolvedType ann ->
@@ -149,7 +149,7 @@ isLiteralSubtypeOf union (TPrim _ TPInt) | isIntLiteral union = True
 isLiteralSubtypeOf _ _ = False
 
 isSubtypeOf ::
-  ( MonadWriter [Substitution ResolvedDep ann] m,
+  ( MonadWriter [TCWrite ann] m,
     MonadError (TCError ann) m,
     Eq ann,
     Show ann
@@ -165,7 +165,7 @@ isSubtypeOf a b = isSubtypeInner (simplifyType a) (simplifyType b)
 -- 1 | 2 is a subtype of Nat
 -- Nat is a subtype of Int
 isSubtypeInner ::
-  ( MonadWriter [Substitution ResolvedDep ann] m,
+  ( MonadWriter [TCWrite ann] m,
     MonadError (TCError ann) m,
     Eq ann,
     Show ann
@@ -187,16 +187,16 @@ isSubtypeInner (TVar ann a) (TVar ann' b) =
     else throwError (TCTypeMismatch (TVar ann a) (TVar ann' b))
 -- unknowns go before vars because they are weaker, as such
 isSubtypeInner (TUnknown _ i) b =
-  tell [Substitution (SubUnknown i) b]
+  tell [TCWSubstitution $ Substitution (SubUnknown i) b]
     >> pure b
 isSubtypeInner a (TUnknown _ i) =
-  tell [Substitution (SubUnknown i) a]
+  tell [TCWSubstitution $ Substitution (SubUnknown i) a]
     >> pure a
 isSubtypeInner (TVar _ ident) b =
-  tell [Substitution (SubId ident) b]
+  tell [TCWSubstitution $ Substitution (SubId ident) b]
     >> pure b
 isSubtypeInner a (TVar _ ident) =
-  tell [Substitution (SubId ident) a]
+  tell [TCWSubstitution $ Substitution (SubId ident) a]
     >> pure a
 isSubtypeInner (TInfix ann op a b) c =
   TInfix ann op <$> isSubtypeInner a c <*> isSubtypeInner b c

--- a/smol-core/src/Smol/Core/Typecheck/Typecheck.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typecheck.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
 
 module Smol.Core.Typecheck.Typecheck
   ( typecheck,

--- a/smol-core/src/Smol/Core/Typecheck/Typecheck.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typecheck.hs
@@ -10,7 +10,7 @@ where
 
 import Control.Monad.Except
 import Smol.Core.Typecheck.Elaborate (elaborate)
-import Smol.Core.Typecheck.Typeclass (convertExprToUseTypeclassDictionary)
+import Smol.Core.Typecheck.Typeclass.Deduplicate (deduplicateConstraints)
 import Smol.Core.Typecheck.Types
 import Smol.Core.Types
 
@@ -24,5 +24,5 @@ typecheck ::
 typecheck env expr = do
   (typedExpr, typeclassUses) <- elaborate env expr
 
-  -- inline those functions
-  convertExprToUseTypeclassDictionary env typeclassUses typedExpr
+  -- deduplicate constraints, and match them to the variables that use them
+  pure (deduplicateConstraints typeclassUses typedExpr)

--- a/smol-core/src/Smol/Core/Typecheck/Typecheck.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typecheck.hs
@@ -1,27 +1,28 @@
-
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Smol.Core.Typecheck.Typecheck
-  ( typecheck
+  ( typecheck,
   )
 where
 
 import Control.Monad.Except
-import Smol.Core.Typecheck.Types
-import Smol.Core.Types
 import Smol.Core.Typecheck.Elaborate (elaborate)
 import Smol.Core.Typecheck.Typeclass (convertExprToUseTypeclassDictionary)
+import Smol.Core.Typecheck.Types
+import Smol.Core.Types
 
 -- elaborate an expression, returning it along with constraints,
 -- with `\instances -> ...` where there are constraints
-typecheck :: (MonadError (TCError ann) m, Monoid ann, Show ann, Ord ann) =>
-    TCEnv ann -> ResolvedExpr ann -> m ([Constraint ann], ResolvedExpr (ResolvedType ann))
+typecheck ::
+  (MonadError (TCError ann) m, Monoid ann, Show ann, Ord ann) =>
+  TCEnv ann ->
+  ResolvedExpr ann ->
+  m ([Constraint ann], ResolvedExpr (ResolvedType ann))
 typecheck env expr = do
   (typedExpr, typeclassUses) <- elaborate env expr
 
   -- inline those functions
   convertExprToUseTypeclassDictionary env typeclassUses typedExpr
-

--- a/smol-core/src/Smol/Core/Typecheck/Typecheck.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typecheck.hs
@@ -1,0 +1,27 @@
+
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Smol.Core.Typecheck.Typecheck
+  ( typecheck
+  )
+where
+
+import Control.Monad.Except
+import Smol.Core.Typecheck.Types
+import Smol.Core.Types
+import Smol.Core.Typecheck.Elaborate (elaborate)
+import Smol.Core.Typecheck.Typeclass (convertExprToUseTypeclassDictionary)
+
+-- elaborate an expression, returning it along with constraints,
+-- with `\instances -> ...` where there are constraints
+typecheck :: (MonadError (TCError ann) m, Monoid ann, Show ann, Ord ann) =>
+    TCEnv ann -> ResolvedExpr ann -> m ([Constraint ann], ResolvedExpr (ResolvedType ann))
+typecheck env expr = do
+  (typedExpr, typeclassUses) <- elaborate env expr
+
+  -- inline those functions
+  convertExprToUseTypeclassDictionary env typeclassUses typedExpr
+

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -174,7 +174,7 @@ convertExprToUseTypeclassDictionary ::
 convertExprToUseTypeclassDictionary env constraints expr = do
   maybePattern <- getTypeForDictionary env (filterNotConcrete constraints)
 
-  newExpr <- case maybePattern of
+  case maybePattern of
     Just pat -> do
       let dictType = getPatternAnnotation pat
           exprType = getExprAnnotation expr
@@ -188,8 +188,6 @@ convertExprToUseTypeclassDictionary env constraints expr = do
               (NE.fromList [(pat, expr)])
           )
     Nothing -> pure expr
-
-  pure newExpr
 
 -- | create a typeclass dictionary
 -- return either solid instances or use vars from constraints if not available
@@ -275,9 +273,6 @@ toDictionaryPassing varsInScope instances constraints expr = do
             tceConstraints = constraints
           }
 
-  newExpr <-
-    passDictionaries env
-      <=< convertExprToUseTypeclassDictionary env constraints
-      $ expr
-
-  pure newExpr
+  passDictionaries env
+    <=< convertExprToUseTypeclassDictionary env constraints
+    $ expr

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -33,9 +33,9 @@ resolveExpr = mapExprDep resolve
 lookupInstanceAndCheck ::
   (Ord ann, Monoid ann, Show ann, MonadError (TCError ann) m) =>
   TCEnv ann ->
-  TypeclassHead ann ->
+  Constraint ann ->
   m (Identifier, Expr ResolvedDep (Type ResolvedDep ann))
-lookupInstanceAndCheck env tch@(TypeclassHead typeclassName _) = do
+lookupInstanceAndCheck env tch@(Constraint typeclassName _) = do
   tcInstance <- lookupTypeclassInstance env tch
   typeclass <- case M.lookup typeclassName (tceClasses env) of
     Just tc -> pure tc
@@ -46,10 +46,10 @@ checkInstance ::
   (MonadError (TCError ann) m, Ord ann, Show ann, Monoid ann) =>
   TCEnv ann ->
   Typeclass ann ->
-  TypeclassHead ann ->
+  Constraint ann ->
   Instance ann ->
   m (Identifier, Expr ResolvedDep (Type ResolvedDep ann))
-checkInstance tcEnv (Typeclass _ args funcName ty) (TypeclassHead _ tys) (Instance constraints expr) =
+checkInstance tcEnv (Typeclass _ args funcName ty) (Constraint _ tys) (Instance constraints expr) =
   do
     let subs =
           ( \(ident, tySub) ->
@@ -69,7 +69,7 @@ checkInstance tcEnv (Typeclass _ args funcName ty) (TypeclassHead _ tys) (Instan
         typeclassMethodNames =
           S.fromList $
             mapMaybe
-              ( \(TypeclassHead tcn _) -> case M.lookup tcn (tceClasses tcEnv) of
+              ( \(Constraint tcn _) -> case M.lookup tcn (tceClasses tcEnv) of
                   Just (Typeclass {tcFuncName}) -> Just tcFuncName
                   _ -> Nothing
               )
@@ -88,7 +88,7 @@ checkInstance tcEnv (Typeclass _ args funcName ty) (TypeclassHead _ tys) (Instan
 inlineTypeclassFunctions ::
   (MonadError (TCError ann) m, Ord ann, Show ann, Monoid ann) =>
   TCEnv ann ->
-  M.Map (ResolvedDep Identifier) (TypeclassHead ann) ->
+  M.Map (ResolvedDep Identifier) (Constraint ann) ->
   Expr ResolvedDep (Type ResolvedDep ann) ->
   m (Expr ResolvedDep (Type ResolvedDep ann))
 inlineTypeclassFunctions env tcs expr =

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -44,7 +44,7 @@ checkInstance ::
   TypeclassHead ann ->
   Instance ann ->
   m (Identifier, Expr ResolvedDep (Type ResolvedDep ann))
-checkInstance (Typeclass _ args funcName ty) (TypeclassHead _ tys) (Instance expr) =
+checkInstance (Typeclass _ args funcName ty) (TypeclassHead _ tys) (Instance _ expr) =
   do
     let subs =
           ( \(ident, tySub) ->

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -25,7 +25,6 @@ import Data.Maybe (fromMaybe, mapMaybe)
 import qualified Data.Set as S
 import Data.Tuple (swap)
 import Smol.Core.ExprUtils
-import Smol.Core.Helpers
 import Smol.Core.Modules.ResolveDeps
 import Smol.Core.Typecheck.Elaborate (elaborate)
 import Smol.Core.Typecheck.Shared
@@ -209,10 +208,10 @@ convertExprToUseTypeclassDictionary env constraints expr = do
   newExpr <- case maybePattern of
     Just pat -> do
       let dictType = getPatternAnnotation pat
-          wholeType = TFunc mempty mempty dictType (getExprAnnotation expr)
+          exprType = getExprAnnotation expr
       pure $
         ELambda
-          wholeType
+          exprType -- we want the overall expression to have the same type so we can still typecheck and ignore the constraints
           "instances"
           ( EPatternMatch
               (getExprAnnotation tidyExpr)
@@ -264,7 +263,6 @@ passOuterDictionaries ::
   m (Expr ResolvedDep (Type ResolvedDep ann))
 passOuterDictionaries _ [] expr = pure expr
 passOuterDictionaries env constraints expr = do
-  tracePrettyM "passOuterDictionaries" constraints
   dict <- createTypeclassDict env constraints
   let ann = getExprAnnotation expr
   pure (EApp ann expr dict)

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -10,6 +10,7 @@ module Smol.Core.Typecheck.Typeclass
     getTypeclassMethodNames,
     createTypeclassDict,
     passDictionaries,
+    passOuterDictionaries,
     module Smol.Core.Typecheck.Typeclass.Helpers,
   )
 where
@@ -252,3 +253,16 @@ passDictionaries env =
           pure (EApp ann (EVar ann ident) dict)
         Nothing -> pure (EVar ann ident)
     go other = bindExpr go other
+
+-- pass dictionaries to the current expression
+passOuterDictionaries ::
+  (Monoid ann, Ord ann, Show ann, MonadError (TCError ann) m) =>
+  TCEnv ann ->
+  [Constraint ann] ->
+  Expr ResolvedDep (Type ResolvedDep ann) ->
+  m (Expr ResolvedDep (Type ResolvedDep ann))
+passOuterDictionaries _ [] expr = pure expr
+passOuterDictionaries env constraints expr = do
+          dict <- createTypeclassDict env constraints
+          let ann = getExprAnnotation expr
+          pure (EApp ann expr dict)

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -4,6 +4,7 @@
 
 module Smol.Core.Typecheck.Typeclass
   ( checkInstance,
+    dedupeConstraints,
     lookupInstanceAndCheck,
     inlineTypeclassFunctions,
     getTypeclassMethodNames,
@@ -13,10 +14,12 @@ where
 
 import Control.Monad.Except
 import Control.Monad.Identity
-import Data.Foldable (foldrM)
+import Data.Functor
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import Data.Maybe (mapMaybe)
 import qualified Data.Set as S
+import Data.Tuple (swap)
 import Smol.Core.ExprUtils
 import Smol.Core.Modules.ResolveDeps
 import Smol.Core.Typecheck.Elaborate (elaborate)
@@ -90,6 +93,71 @@ getTypeclassMethodNames tcEnv =
   S.fromList $
     tcFuncName <$> M.elems (tceClasses tcEnv)
 
+-- just because we use a method twice doesn't mean we want to pass it in twice
+-- returns a new ordered set of constraints with fresh names,
+-- and a list of substitutions to change in the expression to make everything
+-- work
+dedupeConstraints ::
+  (Ord ann) =>
+  M.Map (ResolvedDep Identifier) (Constraint ann) ->
+  ([(ResolvedDep Identifier, Constraint ann)], M.Map (ResolvedDep Identifier) (ResolvedDep Identifier))
+dedupeConstraints dupes =
+  let initial = (mempty, mempty, 0)
+      deduped =
+        foldr
+          ( \(ident, constraint) (found, swaps, count) ->
+              case M.lookup constraint found of
+                Just foundIdent ->
+                  ( found,
+                    swaps <> M.singleton ident foundIdent,
+                    count
+                  )
+                Nothing ->
+                  let newCount = count + 1
+                      newIdent = TypeclassCall "newname" newCount
+                   in ( found <> M.singleton constraint newIdent,
+                        swaps <> M.singleton ident newIdent,
+                        newCount
+                      )
+          )
+          initial
+          (M.toList dupes)
+      (finalFound, finalSwaps, _) = deduped
+   in (swap <$> M.toList finalFound, finalSwaps)
+
+-- | swap var names of typeclass calls for their new deduped ones
+swapExprVarnames :: M.Map (ResolvedDep Identifier) (ResolvedDep Identifier) -> Expr ResolvedDep ann -> Expr ResolvedDep ann
+swapExprVarnames swappies expr =
+  go expr
+  where
+    go (EVar ann ident) = case M.lookup ident swappies of
+      Just newIdent -> EVar ann newIdent
+      Nothing -> EVar ann ident
+    go other = mapExpr go other
+
+getTypeForDictionary ::
+  ( MonadError (TCError ann) m,
+    Ord ann,
+    Show ann,
+    Monoid ann
+  ) =>
+  TCEnv ann ->
+  [(ResolvedDep Identifier, Constraint ann)] ->
+  m (Maybe (Pattern ResolvedDep (Type ResolvedDep ann)))
+getTypeForDictionary env constraints = do
+  let getConstraintPattern (ident, constraint) = do
+        (_, instanceExpr) <- lookupInstanceAndCheck env constraint
+        let ty = getExprAnnotation instanceExpr
+        pure (PVar ty ident)
+  case constraints of
+    [] -> pure Nothing
+    [one] -> Just <$> getConstraintPattern one
+    (one : rest) -> do
+      pOne <- getConstraintPattern one
+      pRest <- traverse getConstraintPattern (NE.fromList rest)
+      let ty = TTuple mempty (getPatternAnnotation pOne) (getPatternAnnotation <$> pRest)
+      pure $ Just $ PTuple ty pOne pRest
+
 -- | 10x typeclasses implementation - given an `expr` that calls typeclass
 -- methods, we inline all the instances as Let bindings
 -- `let equals_1 = \a -> \b -> a == b in equals_1 10 11`
@@ -99,10 +167,20 @@ inlineTypeclassFunctions ::
   M.Map (ResolvedDep Identifier) (Constraint ann) ->
   Expr ResolvedDep (Type ResolvedDep ann) ->
   m (Expr ResolvedDep (Type ResolvedDep ann))
-inlineTypeclassFunctions env tcs expr =
-  foldrM tcHeadToLet expr (M.toList tcs)
-  where
-    tcHeadToLet (ident, typeclassHead) rest = do
-      (_, instanceExpr) <- lookupInstanceAndCheck env typeclassHead
-      let ty = getExprAnnotation rest
-       in pure $ ELet ty ident instanceExpr rest
+inlineTypeclassFunctions env constraints expr = do
+  let (dedupedConstraints, nameSwaps) = dedupeConstraints constraints
+      tidyExpr = swapExprVarnames nameSwaps expr
+  maybePattern <- getTypeForDictionary env dedupedConstraints
+  case maybePattern of
+    Just pat -> do
+      let wholeType = TFunc mempty mempty (getPatternAnnotation pat) (getExprAnnotation expr)
+      pure $
+        ELambda
+          wholeType
+          "instances"
+          ( EPatternMatch
+              (getExprAnnotation expr)
+              (EAnn wholeType (wholeType $> wholeType) (EVar wholeType "instances"))
+              (NE.fromList [(pat, tidyExpr)])
+          )
+    Nothing -> pure expr

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -6,6 +6,7 @@ module Smol.Core.Typecheck.Typeclass
   ( checkInstance,
     lookupInstanceAndCheck,
     inlineTypeclassFunctions,
+  getTypeclassMethodNames,
     module Smol.Core.Typecheck.Typeclass.Helpers,
   )
 where
@@ -81,6 +82,14 @@ checkInstance tcEnv (Typeclass _ args funcName ty) (Constraint _ tys) (Instance 
         (typedExpr, _typeclassUses) <- elaborate typecheckEnv resolvedExpr
 
         pure (funcName, typedExpr)
+
+-- let's get all the method names from the Typeclasses
+-- mentioned in the instance constraints
+getTypeclassMethodNames :: TCEnv ann -> S.Set Identifier
+getTypeclassMethodNames tcEnv =
+          S.fromList $
+            tcFuncName <$> M.elems (tceClasses tcEnv)
+
 
 -- | 10x typeclasses implementation - we inline all the instances as Let
 -- bindings

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Smol.Core.Typecheck.Typeclass (checkInstance) where
+
+import Control.Monad.Except
+import Control.Monad.Identity
+import Smol.Core.ExprUtils (mapExprDep)
+import Smol.Core.Typecheck.Elaborate (elaborate, getExprAnnotation)
+import Smol.Core.Typecheck.Substitute
+import Smol.Core.Typecheck.Types
+import Smol.Core.Types.Expr
+import Smol.Core.Types.ResolvedDep
+import Smol.Core.Types.Type
+
+resolveExpr :: Expr Identity ann -> Expr ResolvedDep ann
+resolveExpr = mapExprDep resolve
+  where
+    resolve (Identity a) = emptyResolvedDep a
+
+checkInstance ::
+  (MonadError (TCError ann) m, Ord ann, Show ann) =>
+  Typeclass ann ->
+  TypeclassHead ann ->
+  Instance ann ->
+  m (String, Expr ResolvedDep (Type ResolvedDep ann))
+checkInstance (Typeclass args name ty) (TypeclassHead _ tys) (Instance expr) =
+  do
+    let subs =
+          ( \(ident, tySub) ->
+              Substitution (SubId $ Identity ident) tySub
+          )
+            <$> zip args tys
+
+    let subbedType = substituteMany subs ty
+
+    let tcEnv =
+          TCEnv
+            { tceVars = mempty,
+              tceGlobals = mempty,
+              tceDataTypes = mempty,
+              tceClasses = mempty,
+              tceInstances = mempty
+            }
+
+    let annotatedExpr = EAnn (getExprAnnotation expr) subbedType expr
+
+    typedExpr <- elaborate tcEnv (resolveExpr annotatedExpr)
+
+    pure (name,typedExpr)

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -6,7 +6,7 @@ module Smol.Core.Typecheck.Typeclass
   ( checkInstance,
     lookupInstanceAndCheck,
     inlineTypeclassFunctions,
-  getTypeclassMethodNames,
+    getTypeclassMethodNames,
     module Smol.Core.Typecheck.Typeclass.Helpers,
   )
 where
@@ -87,12 +87,11 @@ checkInstance tcEnv (Typeclass _ args funcName ty) (Constraint _ tys) (Instance 
 -- mentioned in the instance constraints
 getTypeclassMethodNames :: TCEnv ann -> S.Set Identifier
 getTypeclassMethodNames tcEnv =
-          S.fromList $
-            tcFuncName <$> M.elems (tceClasses tcEnv)
+  S.fromList $
+    tcFuncName <$> M.elems (tceClasses tcEnv)
 
-
--- | 10x typeclasses implementation - we inline all the instances as Let
--- bindings
+-- | 10x typeclasses implementation - given an `expr` that calls typeclass
+-- methods, we inline all the instances as Let bindings
 -- `let equals_1 = \a -> \b -> a == b in equals_1 10 11`
 inlineTypeclassFunctions ::
   (MonadError (TCError ann) m, Ord ann, Show ann, Monoid ann) =>

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -9,6 +9,7 @@ import Smol.Core.Typecheck.Elaborate (elaborate, getExprAnnotation)
 import Smol.Core.Typecheck.Substitute
 import Smol.Core.Typecheck.Types
 import Smol.Core.Types.Expr
+import Smol.Core.Types.Identifier
 import Smol.Core.Types.ResolvedDep
 import Smol.Core.Types.Type
 
@@ -22,8 +23,8 @@ checkInstance ::
   Typeclass ann ->
   TypeclassHead ann ->
   Instance ann ->
-  m (String, Expr ResolvedDep (Type ResolvedDep ann))
-checkInstance (Typeclass args funcName ty) (TypeclassHead _ tys) (Instance expr) =
+  m (Identifier, Expr ResolvedDep (Type ResolvedDep ann))
+checkInstance (Typeclass _ args funcName ty) (TypeclassHead _ tys) (Instance expr) =
   do
     let subs =
           ( \(ident, tySub) ->
@@ -46,4 +47,4 @@ checkInstance (Typeclass args funcName ty) (TypeclassHead _ tys) (Instance expr)
 
     typedExpr <- elaborate tcEnv (resolveExpr annotatedExpr)
 
-    pure (funcName,typedExpr)
+    pure (funcName, typedExpr)

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -23,7 +23,7 @@ checkInstance ::
   TypeclassHead ann ->
   Instance ann ->
   m (String, Expr ResolvedDep (Type ResolvedDep ann))
-checkInstance (Typeclass args name ty) (TypeclassHead _ tys) (Instance expr) =
+checkInstance (Typeclass args funcName ty) (TypeclassHead _ tys) (Instance expr) =
   do
     let subs =
           ( \(ident, tySub) ->
@@ -46,4 +46,4 @@ checkInstance (Typeclass args name ty) (TypeclassHead _ tys) (Instance expr) =
 
     typedExpr <- elaborate tcEnv (resolveExpr annotatedExpr)
 
-    pure (name,typedExpr)
+    pure (funcName,typedExpr)

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -12,7 +12,7 @@ module Smol.Core.Typecheck.Typeclass
   )
 where
 
-import Debug.Trace
+import Smol.Core.Helpers
 import Control.Monad.Except
 import Control.Monad.Identity
 import Data.Functor
@@ -81,8 +81,9 @@ checkInstance tcEnv (Typeclass _ args funcName ty) (Constraint _ tys) (Instance 
               constraints
 
     case resolveExprDeps (resolveExpr annotatedExpr) typeclassMethodNames of
-      Left resolveErr -> error (show resolveErr)
+      Left resolveErr -> error $ "Resolve error: " <> show resolveErr
       Right resolvedExpr -> do
+        tracePrettyM "resolved" resolvedExpr
         (typedExpr, _typeclassUses) <- elaborate typecheckEnv resolvedExpr
 
         pure (funcName, typedExpr)
@@ -131,7 +132,7 @@ swapExprVarnames :: M.Map (ResolvedDep Identifier) (ResolvedDep Identifier) -> E
 swapExprVarnames swappies expr =
   go expr
   where
-    go (EVar ann ident) = case M.lookup (traceShowId ident) (traceShowId swappies) of
+    go (EVar ann ident) = case M.lookup ident swappies of
       Just newIdent -> EVar ann newIdent
       Nothing -> EVar ann ident
     go other = mapExpr go other

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -25,6 +25,7 @@ import Data.Maybe (fromMaybe, mapMaybe)
 import qualified Data.Set as S
 import Data.Tuple (swap)
 import Smol.Core.ExprUtils
+import Smol.Core.Helpers
 import Smol.Core.Modules.ResolveDeps
 import Smol.Core.Typecheck.Elaborate (elaborate)
 import Smol.Core.Typecheck.Shared
@@ -263,6 +264,7 @@ passOuterDictionaries ::
   m (Expr ResolvedDep (Type ResolvedDep ann))
 passOuterDictionaries _ [] expr = pure expr
 passOuterDictionaries env constraints expr = do
-          dict <- createTypeclassDict env constraints
-          let ann = getExprAnnotation expr
-          pure (EApp ann expr dict)
+  tracePrettyM "passOuterDictionaries" constraints
+  dict <- createTypeclassDict env constraints
+  let ann = getExprAnnotation expr
+  pure (EApp ann expr dict)

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -45,7 +45,7 @@ resolveType = mapTypeDep resolve
 lookupInstanceAndCheck ::
   (Ord ann, Monoid ann, Show ann, MonadError (TCError ann) m) =>
   TCEnv ann ->
-  Constraint () ->
+  Constraint ann ->
   m (Identifier, Expr ResolvedDep (Type ResolvedDep ann))
 lookupInstanceAndCheck env tch@(Constraint typeclassName _) = do
   tcInstance <- lookupTypeclassInstance env tch
@@ -224,7 +224,7 @@ convertExprToUseTypeclassDictionary env constraints expr = do
 createTypeclassDict ::
   (Show ann, Ord ann, Monoid ann, MonadError (TCError ann) m) =>
   TCEnv ann ->
-  [Constraint ()] ->
+  [Constraint ann] ->
   m (Expr ResolvedDep (Type ResolvedDep ann))
 createTypeclassDict env constraints = do
   instances <- traverse (fmap snd . lookupInstanceAndCheck env) constraints

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/BuiltIns.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/BuiltIns.hs
@@ -45,7 +45,7 @@ builtInInstances =
   M.fromList
     [ ( Constraint "Eq" [TPrim mempty TPInt],
         Instance
-          { inExpr = ELambda mempty "a" (ELambda mempty "b" (EInfix mempty OpAdd (EVar mempty "a") (EVar mempty "b"))),
+          { inExpr = ELambda mempty "a" (ELambda mempty "b" (EInfix mempty OpEquals (EVar mempty "a") (EVar mempty "b"))),
             inConstraints = []
           }
       )

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/BuiltIns.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/BuiltIns.hs
@@ -2,9 +2,16 @@
 
 module Smol.Core.Typecheck.Typeclass.BuiltIns (builtInClasses, builtInInstances) where
 
+
+import Data.Functor
+import Smol.Core.ExprUtils
+import Smol.Core.Parser
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import Smol.Core.Typecheck.Typeclass.Types
 import Smol.Core.Types
+import qualified Data.Text as T
+import Control.Monad.Identity
 
 showTypeclass :: (Monoid ann) => Typeclass ann
 showTypeclass =
@@ -38,15 +45,54 @@ builtInClasses =
 
 -----
 
--- we should get rid of this once we can parse these in modules
+unsafeParseExpr :: T.Text -> Expr ParseDep ()
+unsafeParseExpr input = case parseExprAndFormatError input of
+  Right expr -> expr $> ()
+  Left e -> error (show e)
 
+
+identityFromParsedExpr :: Expr ParseDep ann -> Expr Identity ann
+identityFromParsedExpr = mapExprDep resolve
+  where
+    resolve (ParseDep a _) = Identity a
+
+unsafeParseInstanceExpr :: (Monoid ann) => T.Text -> Expr Identity ann
+unsafeParseInstanceExpr =
+  fmap (const mempty) . identityFromParsedExpr . unsafeParseExpr
+
+
+tyInt :: (Monoid ann) => Type dep ann
+tyInt = TPrim mempty TPInt
+
+tcVar :: (Monoid ann) => Identifier -> Type Identity ann
+tcVar = TVar mempty . Identity
+
+
+tyTuple ::
+  (Monoid ann) =>
+  Type dep ann ->
+  [Type dep ann] ->
+  Type dep ann
+tyTuple a as = TTuple mempty a (NE.fromList as)
+
+-- we should get rid of this once we can parse these in modules
 builtInInstances :: (Ord ann, Monoid ann) => M.Map (Constraint ann) (Instance ann)
 builtInInstances =
   M.fromList
-    [ ( Constraint "Eq" [TPrim mempty TPInt],
+    [ ( Constraint "Eq" [tyInt],
+        Instance {inExpr = unsafeParseInstanceExpr "\\a -> \\b -> a == b", inConstraints = []}
+      ),
+      ( Constraint "Eq" [tyTuple (tcVar "a") [tcVar "b"]],
         Instance
-          { inExpr = ELambda mempty "a" (ELambda mempty "b" (EInfix mempty OpEquals (EVar mempty "a") (EVar mempty "b"))),
-            inConstraints = []
+          { inExpr =
+              unsafeParseInstanceExpr "\\a -> \\b -> case (a,b) of ((a1, a2), (b1, b2)) -> if equals a1 b1 then equals a2 b2 else False",
+            inConstraints =
+              [ Constraint "Eq" [tcVar "a"],
+                Constraint "Eq" [tcVar "b"]
+              ]
           }
       )
     ]
+
+
+

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/BuiltIns.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/BuiltIns.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Smol.Core.Typecheck.Typeclass.BuiltIns (builtInClasses, builtInInstances) where
+
+import qualified Data.Map.Strict as M
+import Smol.Core.Typecheck.Typeclass.Types
+import Smol.Core.Types
+
+showTypeclass :: (Monoid ann) => Typeclass ann
+showTypeclass =
+  Typeclass
+    { tcName = "Show",
+      tcArgs = ["a"],
+      tcFuncName = "show",
+      tcFuncType = TFunc mempty mempty (TVar mempty "a") (TPrim mempty TPString)
+    }
+
+eqTypeclass :: (Monoid ann) => Typeclass ann
+eqTypeclass =
+  Typeclass
+    { tcName = "Eq",
+      tcArgs = ["a"],
+      tcFuncName = "equals",
+      tcFuncType =
+        TFunc
+          mempty
+          mempty
+          (TVar mempty "a")
+          (TFunc mempty mempty (TVar mempty "a") (TPrim mempty TPBool))
+    }
+
+builtInClasses :: (Monoid ann) => M.Map TypeclassName (Typeclass ann)
+builtInClasses =
+  M.fromList
+    [ ("Eq", eqTypeclass),
+      ("Show", showTypeclass)
+    ]
+
+-----
+
+-- we should get rid of this once we can parse these in modules
+
+builtInInstances :: (Ord ann, Monoid ann) => M.Map (Constraint ann) (Instance ann)
+builtInInstances =
+  M.fromList
+    [ ( Constraint "Eq" [TPrim mempty TPInt],
+        Instance
+          { inExpr = ELambda mempty "a" (ELambda mempty "b" (EInfix mempty OpAdd (EVar mempty "a") (EVar mempty "b"))),
+            inConstraints = []
+          }
+      )
+    ]

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/BuiltIns.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/BuiltIns.hs
@@ -2,16 +2,15 @@
 
 module Smol.Core.Typecheck.Typeclass.BuiltIns (builtInClasses, builtInInstances) where
 
-
+import Control.Monad.Identity
 import Data.Functor
-import Smol.Core.ExprUtils
-import Smol.Core.Parser
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
+import qualified Data.Text as T
+import Smol.Core.ExprUtils
+import Smol.Core.Parser
 import Smol.Core.Typecheck.Typeclass.Types
 import Smol.Core.Types
-import qualified Data.Text as T
-import Control.Monad.Identity
 
 showTypeclass :: (Monoid ann) => Typeclass ann
 showTypeclass =
@@ -50,7 +49,6 @@ unsafeParseExpr input = case parseExprAndFormatError input of
   Right expr -> expr $> ()
   Left e -> error (show e)
 
-
 identityFromParsedExpr :: Expr ParseDep ann -> Expr Identity ann
 identityFromParsedExpr = mapExprDep resolve
   where
@@ -60,13 +58,11 @@ unsafeParseInstanceExpr :: (Monoid ann) => T.Text -> Expr Identity ann
 unsafeParseInstanceExpr =
   fmap (const mempty) . identityFromParsedExpr . unsafeParseExpr
 
-
 tyInt :: (Monoid ann) => Type dep ann
 tyInt = TPrim mempty TPInt
 
 tcVar :: (Monoid ann) => Identifier -> Type Identity ann
 tcVar = TVar mempty . Identity
-
 
 tyTuple ::
   (Monoid ann) =>
@@ -93,6 +89,3 @@ builtInInstances =
           }
       )
     ]
-
-
-

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Deduplicate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Deduplicate.hs
@@ -1,0 +1,80 @@
+
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Smol.Core.Typecheck.Typeclass.Deduplicate
+  ( deduplicateConstraints,
+    findDedupedConstraints,
+    identForConstraint
+  )
+where
+
+import Data.Foldable (foldl')
+import qualified Data.Map.Strict as M
+import Data.Maybe (fromMaybe )
+import Smol.Core.ExprUtils
+import Smol.Core.Typecheck.Types
+import Smol.Core.Types
+
+-- | find deduplicated constraints and apply them to expr
+deduplicateConstraints ::
+  ( Ord ann ) =>
+  M.Map (ResolvedDep Identifier) (Constraint ann) ->
+  Expr ResolvedDep (Type ResolvedDep ann) ->
+  ([Constraint ann], Expr ResolvedDep (Type ResolvedDep ann))
+deduplicateConstraints constraints expr = do
+  let (dedupedConstraints, nameSwaps) = findDedupedConstraints constraints
+   in (dedupedConstraints, swapExprVarnames nameSwaps expr)
+
+identForConstraint :: Integer -> ResolvedDep Identifier
+identForConstraint = TypeclassCall "value_from_dictionary" . fromIntegral
+
+-- just because we use a method twice doesn't mean we want to pass it in twice
+-- returns a new ordered set of constraints with fresh names,
+-- and a list of substitutions to change in the expression to make everything
+-- work
+findDedupedConstraints ::
+  (Ord ann) =>
+  M.Map (ResolvedDep Identifier) (Constraint ann) ->
+  ([Constraint ann], M.Map (ResolvedDep Identifier) (ResolvedDep Identifier))
+findDedupedConstraints dupes =
+  let initial = (mempty, mempty, 0)
+      deduped =
+        foldl'
+          ( \(found, swaps, count) (ident, constraint) ->
+              case M.lookup constraint found of
+                Just foundIdent ->
+                  ( found,
+                    swaps <> M.singleton ident foundIdent,
+                    count
+                  )
+                Nothing ->
+                  let newCount = count + 0
+                      newIdent = TypeclassCall "value_from_dictionary" newCount
+                   in ( found <> M.singleton constraint newIdent,
+                        swaps <> M.singleton ident newIdent,
+                        newCount
+                      )
+          )
+          initial
+          (M.toList dupes)
+      (finalFound, finalSwaps, _) = deduped
+   in (fst <$> M.toList finalFound, finalSwaps)
+
+-- | swap var names of typeclass calls for their new deduped ones
+swapExprVarnames ::
+  M.Map (ResolvedDep Identifier) (ResolvedDep Identifier) ->
+  Expr ResolvedDep ann ->
+  Expr ResolvedDep ann
+swapExprVarnames swappies expr =
+  go expr
+  where
+    newIdent ident = fromMaybe ident (M.lookup ident swappies)
+
+    go (EVar ann ident) =
+      EVar ann (newIdent ident)
+    go (ELambda ann ident body) =
+      ELambda ann (newIdent ident) (go body)
+    go other = mapExpr go other
+

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Deduplicate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Deduplicate.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Smol.Core.Typecheck.Typeclass.Deduplicate
@@ -69,8 +68,8 @@ swapExprVarnames ::
   M.Map (ResolvedDep Identifier) (ResolvedDep Identifier) ->
   Expr ResolvedDep ann ->
   Expr ResolvedDep ann
-swapExprVarnames swappies expr =
-  go expr
+swapExprVarnames swappies =
+  go
   where
     newIdent ident = fromMaybe ident (M.lookup ident swappies)
 

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Deduplicate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Deduplicate.hs
@@ -1,4 +1,3 @@
-
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -6,20 +5,20 @@
 module Smol.Core.Typecheck.Typeclass.Deduplicate
   ( deduplicateConstraints,
     findDedupedConstraints,
-    identForConstraint
+    identForConstraint,
   )
 where
 
 import Data.Foldable (foldl')
 import qualified Data.Map.Strict as M
-import Data.Maybe (fromMaybe )
+import Data.Maybe (fromMaybe)
 import Smol.Core.ExprUtils
 import Smol.Core.Typecheck.Types
 import Smol.Core.Types
 
 -- | find deduplicated constraints and apply them to expr
 deduplicateConstraints ::
-  ( Ord ann ) =>
+  (Ord ann) =>
   M.Map (ResolvedDep Identifier) (Constraint ann) ->
   Expr ResolvedDep (Type ResolvedDep ann) ->
   ([Constraint ann], Expr ResolvedDep (Type ResolvedDep ann))
@@ -77,4 +76,3 @@ swapExprVarnames swappies expr =
     go (ELambda ann ident body) =
       ELambda ann (newIdent ident) (go body)
     go other = mapExpr go other
-

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Deduplicate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Deduplicate.hs
@@ -27,7 +27,7 @@ deduplicateConstraints constraints expr = do
    in (dedupedConstraints, swapExprVarnames nameSwaps expr)
 
 identForConstraint :: Integer -> ResolvedDep Identifier
-identForConstraint = TypeclassCall "value_from_dictionary" . fromIntegral
+identForConstraint = TypeclassCall "valuefromdictionary" . fromIntegral
 
 -- just because we use a method twice doesn't mean we want to pass it in twice
 -- returns a new ordered set of constraints with fresh names,
@@ -49,8 +49,8 @@ findDedupedConstraints dupes =
                     count
                   )
                 Nothing ->
-                  let newCount = count + 0
-                      newIdent = TypeclassCall "value_from_dictionary" newCount
+                  let newCount = count + 1
+                      newIdent = identForConstraint count
                    in ( found <> M.singleton constraint newIdent,
                         swaps <> M.singleton ident newIdent,
                         newCount

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Deduplicate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Deduplicate.hs
@@ -9,11 +9,11 @@ module Smol.Core.Typecheck.Typeclass.Deduplicate
   )
 where
 
-import Smol.Core.Typecheck.Typeclass.Helpers (isConcrete)
 import Data.Foldable (foldl')
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
 import Smol.Core.ExprUtils
+import Smol.Core.Typecheck.Typeclass.Helpers (isConcrete)
 import Smol.Core.Typecheck.Types
 import Smol.Core.Types
 
@@ -44,21 +44,20 @@ findDedupedConstraints dupes =
         foldl'
           ( \(found, swaps, count) (ident, constraint) ->
               if isConcrete constraint
-                 then (found, swaps, count)
-                 else
-                    case M.lookup constraint found of
-                      Just foundIdent ->
-                        ( found,
-                          swaps <> M.singleton ident foundIdent,
-                          count
+                then (found, swaps, count)
+                else case M.lookup constraint found of
+                  Just foundIdent ->
+                    ( found,
+                      swaps <> M.singleton ident foundIdent,
+                      count
+                    )
+                  Nothing ->
+                    let newCount = count + 1
+                        newIdent = identForConstraint count
+                     in ( found <> M.singleton constraint newIdent,
+                          swaps <> M.singleton ident newIdent,
+                          newCount
                         )
-                      Nothing ->
-                        let newCount = count + 1
-                            newIdent = identForConstraint count
-                         in ( found <> M.singleton constraint newIdent,
-                              swaps <> M.singleton ident newIdent,
-                              newCount
-                            )
           )
           initial
           (M.toList dupes)

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
@@ -6,13 +6,10 @@ module Smol.Core.Typecheck.Typeclass.Helpers
     lookupTypeclassConstraint,
     lookupTypeclassInstance,
     instanceMatchesType,
-    isConcrete
+    isConcrete,
   )
 where
 
-import Smol.Core.Helpers
-import Data.Monoid
-import Smol.Core.TypeUtils
 import Control.Monad (unless, void, zipWithM)
 import Control.Monad.Except
 import Control.Monad.Identity
@@ -21,7 +18,10 @@ import Data.Functor (($>))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import Data.Maybe (mapMaybe)
+import Data.Monoid
 import Smol.Core.ExprUtils
+import Smol.Core.Helpers
+import Smol.Core.TypeUtils
 import Smol.Core.Typecheck.Substitute
 import Smol.Core.Typecheck.Types
 import Smol.Core.Types
@@ -147,8 +147,8 @@ lookupTypeclassConstraint env constraint@(Constraint name tys) = do
 
 -- look for vars, if no, then it's concrete
 isConcrete :: Constraint ann -> Bool
-isConcrete (Constraint _ tys)
-  = not $ getAny $ foldMap containsVars tys
+isConcrete (Constraint _ tys) =
+  not $ getAny $ foldMap containsVars tys
   where
     containsVars (TVar {}) = Any True
     containsVars other = monoidType containsVars other

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
@@ -20,7 +20,6 @@ import qualified Data.Map.Strict as M
 import Data.Maybe (mapMaybe)
 import Data.Monoid
 import Smol.Core.ExprUtils
-import Smol.Core.Helpers
 import Smol.Core.TypeUtils
 import Smol.Core.Typecheck.Substitute
 import Smol.Core.Typecheck.Types
@@ -87,8 +86,6 @@ lookupTypeclassInstance ::
   Constraint ann ->
   m (Instance ann)
 lookupTypeclassInstance env constraint@(Constraint name tys) = do
-  tracePrettyM "lookupTypeclassInstance" constraint
-
   -- first, do we have a concrete instance?
   case lookupConcreteInstance env constraint of
     Just tcInstance -> pure tcInstance
@@ -135,7 +132,6 @@ lookupTypeclassConstraint ::
   Constraint ann ->
   m ()
 lookupTypeclassConstraint env constraint@(Constraint name tys) = do
-  tracePrettyM "lookupTypeclassConstraint" constraint
   -- see if this is a valid instance first?
   _ <-
     void (lookupTypeclassInstance env constraint) `catchError` \_ -> do

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
@@ -8,9 +8,7 @@ module Smol.Core.Typecheck.Typeclass.Helpers
     instanceMatchesType,
   )
 where
-import Smol.Core.Helpers
 
-import Debug.Trace
 import Control.Monad (unless, void, zipWithM)
 import Control.Monad.Except
 import Control.Monad.Identity
@@ -79,16 +77,14 @@ lookupTypeclassInstance ::
   TCEnv ann ->
   Constraint ann ->
   m (Instance ann)
-lookupTypeclassInstance env tch@(Constraint name tys) = do
-  traceShowM tch
-  tracePrettyM "env" (tceInstances env)
+lookupTypeclassInstance env tch@(Constraint name tys) =
   -- first, do we have a concrete instance?
   case M.lookup tch (tceInstances env) of
     Just tcInstance -> pure tcInstance
     Nothing -> do
-      case traceShowId $ mapMaybe
+      case mapMaybe
         ( \(Constraint innerName innerTys) ->
-            case traceShowId (innerName == name, instanceMatchesType tys innerTys) of
+            case (innerName == name, instanceMatchesType tys innerTys) of
               (True, Right matches) -> Just (Constraint innerName innerTys, matches)
               _ -> Nothing
         )

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
@@ -66,8 +66,8 @@ instanceMatchesType ::
 instanceMatchesType needleTys haystackTys =
   fmap mconcat $ zipWithM matchType needleTys haystackTys
 
---lookupConcreteInstance :: TCEnv ann -> Constraint ann -> Maybe (Instance ann)
---lookupConcreteInstance
+-- lookupConcreteInstance :: TCEnv ann -> Constraint ann -> Maybe (Instance ann)
+-- lookupConcreteInstance
 
 -- | do we have a matching instance? if we're looking for a concrete type and
 -- it's not there, explode (ie, there is no `Eq Bool`)
@@ -75,7 +75,7 @@ instanceMatchesType needleTys haystackTys =
 lookupTypeclassInstance ::
   (MonadError (TCError ann) m, Ord ann, Show ann) =>
   TCEnv ann ->
-  Constraint ann ->
+  Constraint () ->
   m (Instance ann)
 lookupTypeclassInstance env tch@(Constraint name tys) =
   -- first, do we have a concrete instance?

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
@@ -75,7 +75,7 @@ instanceMatchesType needleTys haystackTys =
 lookupTypeclassInstance ::
   (MonadError (TCError ann) m, Ord ann, Show ann) =>
   TCEnv ann ->
-  Constraint () ->
+  Constraint ann ->
   m (Instance ann)
 lookupTypeclassInstance env tch@(Constraint name tys) =
   -- first, do we have a concrete instance?

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
@@ -1,0 +1,37 @@
+
+{-# LANGUAGE FlexibleContexts #-}
+
+module Smol.Core.Typecheck.Typeclass.Helpers ( recoverTypeclassUses, lookupTypeclassHead) where
+
+import Control.Monad.Except
+import qualified Data.Map.Strict as M
+import Control.Monad.Identity
+import Smol.Core.ExprUtils
+import Smol.Core.Typecheck.Substitute
+import Smol.Core.Typecheck.Types
+import Smol.Core.Types
+
+unresolveType :: Type ResolvedDep ann -> Type Identity ann
+unresolveType = mapTypeDep resolve
+  where
+    resolve (LocalDefinition a) = Identity a
+    resolve (UniqueDefinition a _) = Identity a
+
+-- this just chucks types in any order and will break on multi-parameter type
+-- classes
+recoverTypeclassUses :: (Monoid ann) => [TCWrite ann] -> [TypeclassHead ann]
+recoverTypeclassUses events =
+  let allSubs = filterSubstitutions events
+      allTCs = filterTypeclassUses events
+      substituteMatch (ident, unknownId) = (ident, unresolveType $ substituteMany allSubs (TUnknown mempty unknownId))
+      fixTC (name, matches) = (name, substituteMatch <$> matches)
+      toTypeclassHead (name, fixedMatches) =
+        TypeclassHead name (snd <$> fixedMatches)
+   in toTypeclassHead . fixTC <$> allTCs
+
+-- | do we have a matching instance? explode if not
+lookupTypeclassHead :: (MonadError (TCError ann) m, Ord ann) => TCEnv ann -> TypeclassHead ann -> m ()
+lookupTypeclassHead env tch@(TypeclassHead name tys)
+  = case M.lookup tch (tceInstances env) of
+      Just _ -> pure ()
+      Nothing -> throwError (TCTypeclassInstanceNotFound name tys)

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
@@ -10,6 +10,7 @@ module Smol.Core.Typecheck.Typeclass.Helpers
   )
 where
 
+import Smol.Core.Helpers
 import Data.Monoid
 import Smol.Core.TypeUtils
 import Control.Monad (unless, void, zipWithM)
@@ -85,7 +86,9 @@ lookupTypeclassInstance ::
   TCEnv ann ->
   Constraint ann ->
   m (Instance ann)
-lookupTypeclassInstance env constraint@(Constraint name tys) =
+lookupTypeclassInstance env constraint@(Constraint name tys) = do
+  tracePrettyM "lookupTypeclassInstance" constraint
+
   -- first, do we have a concrete instance?
   case lookupConcreteInstance env constraint of
     Just tcInstance -> pure tcInstance
@@ -131,13 +134,14 @@ lookupTypeclassConstraint ::
   TCEnv ann ->
   Constraint ann ->
   m ()
-lookupTypeclassConstraint env tch@(Constraint name tys) = do
+lookupTypeclassConstraint env constraint@(Constraint name tys) = do
+  tracePrettyM "lookupTypeclassConstraint" constraint
   -- see if this is a valid instance first?
   _ <-
-    void (lookupTypeclassInstance env tch) `catchError` \_ -> do
+    void (lookupTypeclassInstance env constraint) `catchError` \_ -> do
       -- maybe it's a constraint, look there
       unless
-        (elem tch (tceConstraints env))
+        (elem constraint (tceConstraints env))
         (throwError (TCTypeclassInstanceNotFound name tys))
   pure ()
 

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
@@ -73,7 +73,7 @@ instanceMatchesType ::
     (Type Identity ann, Type Identity ann)
     [Substitution Identity ann]
 instanceMatchesType needleTys haystackTys =
-  fmap mconcat $ zipWithM matchType needleTys haystackTys
+  mconcat <$> zipWithM matchType needleTys haystackTys
 
 -- | wipe out annotations when looking for instances
 -- this is fragile and depends on us manually creating instances with `mempty`
@@ -142,7 +142,7 @@ lookupTypeclassConstraint env constraint@(Constraint name tys) = do
     void (lookupTypeclassInstance env constraint) `catchError` \_ -> do
       -- maybe it's a constraint, look there
       unless
-        (elem constraint (tceConstraints env))
+        (constraint `elem` tceConstraints env)
         (throwError (TCTypeclassInstanceNotFound name tys (M.keys $ tceInstances env)))
   pure ()
 

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Smol.Core.Typecheck.Typeclass.Helpers
   ( recoverTypeclassUses,

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
@@ -5,6 +5,7 @@ module Smol.Core.Typecheck.Typeclass.Helpers
   ( recoverTypeclassUses,
     lookupTypeclassConstraint,
     lookupTypeclassInstance,
+    lookupTypeclass,
     instanceMatchesType,
     isConcrete,
     recoverInstance,

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
@@ -1,6 +1,11 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 
-module Smol.Core.Typecheck.Typeclass.Helpers (recoverTypeclassUses, lookupTypeclassHead) where
+module Smol.Core.Typecheck.Typeclass.Helpers
+  ( recoverTypeclassUses,
+    lookupTypeclassHead,
+  )
+where
 
 import Control.Monad.Except
 import Control.Monad.Identity
@@ -30,8 +35,12 @@ recoverTypeclassUses events =
    in mconcat $ toTypeclassHead . fixTC <$> allTCs
 
 -- | do we have a matching instance? explode if not
-lookupTypeclassHead :: (MonadError (TCError ann) m, Ord ann) => TCEnv ann -> TypeclassHead ann -> m ()
+lookupTypeclassHead ::
+  (MonadError (TCError ann) m, Ord ann) =>
+  TCEnv ann ->
+  TypeclassHead ann ->
+  m (Instance ann)
 lookupTypeclassHead env tch@(TypeclassHead name tys) =
   case M.lookup tch (tceInstances env) of
-    Just _ -> pure ()
+    Just tcInstance -> pure tcInstance
     Nothing -> throwError (TCTypeclassInstanceNotFound name tys)

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
@@ -1,11 +1,10 @@
-
 {-# LANGUAGE FlexibleContexts #-}
 
-module Smol.Core.Typecheck.Typeclass.Helpers ( recoverTypeclassUses, lookupTypeclassHead) where
+module Smol.Core.Typecheck.Typeclass.Helpers (recoverTypeclassUses, lookupTypeclassHead) where
 
 import Control.Monad.Except
-import qualified Data.Map.Strict as M
 import Control.Monad.Identity
+import qualified Data.Map.Strict as M
 import Smol.Core.ExprUtils
 import Smol.Core.Typecheck.Substitute
 import Smol.Core.Typecheck.Types
@@ -31,7 +30,7 @@ recoverTypeclassUses events =
 
 -- | do we have a matching instance? explode if not
 lookupTypeclassHead :: (MonadError (TCError ann) m, Ord ann) => TCEnv ann -> TypeclassHead ann -> m ()
-lookupTypeclassHead env tch@(TypeclassHead name tys)
-  = case M.lookup tch (tceInstances env) of
-      Just _ -> pure ()
-      Nothing -> throwError (TCTypeclassInstanceNotFound name tys)
+lookupTypeclassHead env tch@(TypeclassHead name tys) =
+  case M.lookup tch (tceInstances env) of
+    Just _ -> pure ()
+    Nothing -> throwError (TCTypeclassInstanceNotFound name tys)

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
@@ -66,8 +66,9 @@ instanceMatchesType ::
 instanceMatchesType needleTys haystackTys =
   fmap mconcat $ zipWithM matchType needleTys haystackTys
 
--- lookupConcreteInstance :: TCEnv ann -> Constraint ann -> Maybe (Instance ann)
--- lookupConcreteInstance
+lookupConcreteInstance :: (Ord ann) => TCEnv ann -> Constraint ann -> Maybe (Instance ann)
+lookupConcreteInstance env constraint =
+  M.lookup constraint (tceInstances env)
 
 -- | do we have a matching instance? if we're looking for a concrete type and
 -- it's not there, explode (ie, there is no `Eq Bool`)
@@ -77,9 +78,9 @@ lookupTypeclassInstance ::
   TCEnv ann ->
   Constraint ann ->
   m (Instance ann)
-lookupTypeclassInstance env tch@(Constraint name tys) =
+lookupTypeclassInstance env constraint@(Constraint name tys) =
   -- first, do we have a concrete instance?
-  case M.lookup tch (tceInstances env) of
+  case lookupConcreteInstance env constraint of
     Just tcInstance -> pure tcInstance
     Nothing -> do
       case mapMaybe

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
@@ -33,7 +33,9 @@ recoverTypeclassUses events =
         M.singleton identifier (TypeclassHead name (snd <$> fixedMatches))
    in mconcat $ toTypeclassHead . fixTC <$> allTCs
 
--- | do we have a matching instance? explode if not
+-- | do we have a matching instance? if we're looking for a concrete type and
+-- it's not there, explode (ie, there is no `Eq Bool`)
+-- if we're looking up `Eq a` though, raise a constraint.
 lookupTypeclassHead ::
   (MonadError (TCError ann) m, Ord ann) =>
   TCEnv ann ->

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Smol.Core.Typecheck.Typeclass.Types

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -33,7 +34,7 @@ data Typeclass ann = Typeclass
 
 data Constraint ann
   = Constraint TypeclassName [Type Identity ann]
-  deriving stock (Eq, Ord, Show, Functor, Generic)
+  deriving stock (Eq, Ord, Show, Functor, Foldable, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
 instance Printer (Constraint ann) where

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
@@ -15,7 +15,7 @@ module Smol.Core.Typecheck.Typeclass.Types
 where
 
 import Control.Monad.Identity
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import GHC.Generics
 import qualified Prettyprinter as PP
 import Smol.Core.Printer
@@ -35,7 +35,7 @@ data Typeclass ann = Typeclass
 data Constraint ann
   = Constraint TypeclassName [Type Identity ann]
   deriving stock (Eq, Ord, Show, Functor, Foldable, Generic)
-  deriving anyclass (ToJSON, FromJSON)
+  deriving anyclass (ToJSON, ToJSONKey, FromJSON, FromJSONKey)
 
 instance Printer (Constraint ann) where
   prettyDoc (Constraint tcn tys) =
@@ -48,7 +48,8 @@ data Instance ann = Instance
   { inConstraints :: [Constraint ann],
     inExpr :: Expr Identity ann
   }
-  deriving stock (Eq, Ord, Show, Functor)
+  deriving stock (Eq, Ord, Show, Functor, Generic)
+  deriving anyclass (ToJSON, FromJSON)
 
 instance Printer (Instance ann) where
   prettyDoc (Instance [] expr) = prettyDoc expr

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
@@ -33,8 +33,7 @@ data Typeclass ann = Typeclass
   deriving stock (Eq, Ord, Show, Functor, Generic)
   deriving anyclass (ToJSON, FromJSON)
 
-data Constraint ann
-  = Constraint { conTypeclass :: TypeclassName, conType :: [Type Identity ann] }
+data Constraint ann = Constraint {conTypeclass :: TypeclassName, conType :: [Type Identity ann]}
   deriving stock (Eq, Ord, Show, Functor, Foldable, Generic)
   deriving anyclass (ToJSON, ToJSONKey, FromJSON, FromJSONKey)
 

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings #-}
+  {-# LANGUAGE GeneralisedNewtypeDeriving #-}
+module Smol.Core.Typecheck.Typeclass.Types
+  (
+    Typeclass (..),
+    Constraint (..),
+    Instance (..),
+    module Smol.Core.Typecheck.Typeclass.Types.TypeclassName
+  )
+where
+
+import Smol.Core.Typecheck.Typeclass.Types.TypeclassName
+import Control.Monad.Identity
+import Data.Aeson (FromJSON, ToJSON)
+import GHC.Generics
+import qualified Prettyprinter as PP
+import Smol.Core.Printer
+import Smol.Core.Types
+
+-- | the typeclass described in it's most general form, ie
+-- class Show a where show :: a -> String
+data Typeclass ann = Typeclass
+  { tcName :: TypeclassName,
+    tcArgs :: [Identifier],
+    tcFuncName :: Identifier,
+    tcFuncType :: Type Identity ann
+  }
+  deriving stock (Eq, Ord, Show, Functor)
+
+data Constraint ann
+  = Constraint TypeclassName [Type Identity ann]
+  deriving stock (Eq, Ord, Show, Functor, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+instance Printer (Constraint ann) where
+  prettyDoc (Constraint tcn tys) =
+    prettyDoc tcn
+      PP.<+> PP.concatWith
+        (\a b -> a <> " " <> b)
+        (prettyDoc <$> tys)
+
+data Instance ann = Instance
+  { inConstraints :: [Constraint ann],
+    inExpr :: Expr Identity ann
+  }
+  deriving stock (Eq, Ord, Show, Functor)
+
+instance Printer (Instance ann) where
+  prettyDoc (Instance [] expr) = prettyDoc expr
+  prettyDoc (Instance constraints expr) =
+    "(" <> PP.concatWith (\a b -> a <> ", " <> b) (prettyDoc <$> constraints) <> ") => " <> prettyDoc expr

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
@@ -30,10 +30,11 @@ data Typeclass ann = Typeclass
     tcFuncName :: Identifier,
     tcFuncType :: Type Identity ann
   }
-  deriving stock (Eq, Ord, Show, Functor)
+  deriving stock (Eq, Ord, Show, Functor, Generic)
+  deriving anyclass (ToJSON, FromJSON)
 
 data Constraint ann
-  = Constraint TypeclassName [Type Identity ann]
+  = Constraint { conTypeclass :: TypeclassName, conType :: [Type Identity ann] }
   deriving stock (Eq, Ord, Show, Functor, Foldable, Generic)
   deriving anyclass (ToJSON, ToJSONKey, FromJSON, FromJSONKey)
 

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
@@ -2,23 +2,23 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
-  {-# LANGUAGE GeneralisedNewtypeDeriving #-}
+
 module Smol.Core.Typecheck.Typeclass.Types
-  (
-    Typeclass (..),
+  ( Typeclass (..),
     Constraint (..),
     Instance (..),
-    module Smol.Core.Typecheck.Typeclass.Types.TypeclassName
+    module Smol.Core.Typecheck.Typeclass.Types.TypeclassName,
   )
 where
 
-import Smol.Core.Typecheck.Typeclass.Types.TypeclassName
 import Control.Monad.Identity
 import Data.Aeson (FromJSON, ToJSON)
 import GHC.Generics
 import qualified Prettyprinter as PP
 import Smol.Core.Printer
+import Smol.Core.Typecheck.Typeclass.Types.TypeclassName
 import Smol.Core.Types
 
 -- | the typeclass described in it's most general form, ie

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Types/TypeclassName.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Types/TypeclassName.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Smol.Core.Typecheck.Typeclass.Types.TypeclassName
+  ( TypeclassName (..),
+    getTypeclassName,
+    validTypeclassName,
+    safeMkTypeclassName,
+  )
+where
+
+import qualified Data.Aeson as JSON
+import qualified Data.Char as Ch
+import Data.String
+import Data.Text (Text)
+import qualified Data.Text as T
+import GHC.Generics
+import Prettyprinter
+import Smol.Core.Printer
+
+-- | A TypeclassName is like `Either` or `Maybe`.
+-- It must start with a capital letter.
+newtype TypeclassName = TypeclassName Text
+  deriving stock (Eq, Ord, Generic)
+  deriving newtype
+    ( Show,
+      JSON.FromJSONKey,
+      JSON.ToJSON,
+      JSON.ToJSONKey
+    )
+
+instance JSON.FromJSON TypeclassName where
+  parseJSON json =
+    JSON.parseJSON json >>= \txt -> case safeMkTypeclassName txt of
+      Just tyCon' -> pure tyCon'
+      _ -> fail "Text is not a valid TypeclassName"
+
+instance IsString TypeclassName where
+  fromString = mkTypeclassName . T.pack
+
+getTypeclassName :: TypeclassName -> Text
+getTypeclassName (TypeclassName t) = t
+
+validTypeclassName :: Text -> Bool
+validTypeclassName a =
+  T.length a > 0
+    && T.filter Ch.isAlphaNum a == a
+    && not (Ch.isDigit (T.head a))
+    && Ch.isUpper (T.head a)
+
+mkTypeclassName :: Text -> TypeclassName
+mkTypeclassName a =
+  if validTypeclassName a
+    then TypeclassName a
+    else error $ T.unpack $ "TypeclassName validation fail for '" <> a <> "'"
+
+safeMkTypeclassName :: Text -> Maybe TypeclassName
+safeMkTypeclassName a =
+  if validTypeclassName a
+    then Just (TypeclassName a)
+    else Nothing
+
+instance Printer TypeclassName where
+  prettyDoc = pretty . getTypeclassName

--- a/smol-core/src/Smol/Core/Typecheck/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types.hs
@@ -8,6 +8,8 @@ module Smol.Core.Typecheck.Types
     TCError (..),
     GlobalMap (..),
     Typeclass (..),
+    TypeclassHead (..),
+    Instance (..),
     filterIdent,
     globalMapIsNull,
   )
@@ -56,12 +58,12 @@ data Typeclass ann = Typeclass
     tcFuncType :: Type Identity ann
   }
 
-data TypeclassHead ann =
-    TypeclassHead String [Type Identity ann]
-  deriving stock (Eq,Ord,Show)
+data TypeclassHead ann
+  = TypeclassHead String [Type Identity ann]
+  deriving stock (Eq, Ord, Show)
 
 data Instance ann = Instance
-  { inExpr :: Expr Identity ann }
+  {inExpr :: Expr Identity ann}
   deriving stock (Eq, Ord, Show)
 
 data TCEnv ann = TCEnv

--- a/smol-core/src/Smol/Core/Typecheck/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types.hs
@@ -31,8 +31,10 @@ data TypeclassHead ann
   = TypeclassHead String [Type Identity ann]
   deriving stock (Eq, Ord, Show)
 
-newtype Instance ann = Instance
-  {inExpr :: Expr Identity ann}
+data Instance ann = Instance
+  { inConstraints :: [TypeclassHead ann],
+    inExpr :: Expr Identity ann
+  }
   deriving stock (Eq, Ord, Show)
 
 data TCEnv ann = TCEnv

--- a/smol-core/src/Smol/Core/Typecheck/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types.hs
@@ -7,11 +7,13 @@ module Smol.Core.Typecheck.Types
     TCEnv (..),
     TCError (..),
     GlobalMap (..),
+    Typeclass (..),
     filterIdent,
     globalMapIsNull,
   )
 where
 
+import Control.Monad.Identity
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import Data.Set (Set)
@@ -48,10 +50,26 @@ data TCError ann
   | TCPatternMatchError (PatternMatchError (ResolvedType ann))
   deriving stock (Eq, Ord, Show, Foldable)
 
+data Typeclass ann = Typeclass
+  { tcArgs :: [Identifier],
+    tcFuncName :: String,
+    tcFuncType :: Type Identity ann
+  }
+
+data TypeclassHead ann =
+    TypeclassHead String [Type Identity ann]
+  deriving stock (Eq,Ord,Show)
+
+data Instance ann = Instance
+  { inExpr :: Expr Identity ann }
+  deriving stock (Eq, Ord, Show)
+
 data TCEnv ann = TCEnv
   { tceVars :: Map (ResolvedDep Identifier) (ResolvedType ann),
     tceGlobals :: Map Identifier (ResolvedType ann),
-    tceDataTypes :: Map (ResolvedDep TypeName) (DataType ResolvedDep ann)
+    tceDataTypes :: Map (ResolvedDep TypeName) (DataType ResolvedDep ann),
+    tceClasses :: Map String (Typeclass ann),
+    tceInstances :: Map (TypeclassHead ann) (Instance ann)
   }
 
 data TCState ann = TCState

--- a/smol-core/src/Smol/Core/Typecheck/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types.hs
@@ -9,6 +9,7 @@ module Smol.Core.Typecheck.Types
     Instance (..),
     module Smol.Core.Typecheck.Types.TCError,
     module Smol.Core.Typecheck.Types.TCState,
+    module Smol.Core.Typecheck.Types.TCWrite,
   )
 where
 
@@ -16,6 +17,7 @@ import Control.Monad.Identity
 import Data.Map.Strict (Map)
 import Smol.Core.Typecheck.Types.TCError
 import Smol.Core.Typecheck.Types.TCState
+import Smol.Core.Typecheck.Types.TCWrite
 import Smol.Core.Types
 
 data Typeclass ann = Typeclass

--- a/smol-core/src/Smol/Core/Typecheck/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types.hs
@@ -1,10 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings #-}
-
 module Smol.Core.Typecheck.Types
   ( TCEnv (..),
     module Smol.Core.Typecheck.Typeclass.Types,

--- a/smol-core/src/Smol/Core/Typecheck/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types.hs
@@ -3,54 +3,20 @@
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 
 module Smol.Core.Typecheck.Types
-  ( TCState (..),
-    TCEnv (..),
-    TCError (..),
-    GlobalMap (..),
+  ( TCEnv (..),
     Typeclass (..),
     TypeclassHead (..),
     Instance (..),
-    filterIdent,
-    globalMapIsNull,
+    module Smol.Core.Typecheck.Types.TCError,
+    module Smol.Core.Typecheck.Types.TCState,
   )
 where
 
 import Control.Monad.Identity
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as M
-import Data.Set (Set)
+import Smol.Core.Typecheck.Types.TCError
+import Smol.Core.Typecheck.Types.TCState
 import Smol.Core.Types
-import Smol.Core.Types.PatternMatchError (PatternMatchError)
-
-newtype GlobalMap ann = GlobalMap {getGlobalMap :: Map Identifier (ResolvedType ann)}
-  deriving newtype (Eq, Ord, Show, Semigroup, Monoid)
-
-globalMapIsNull :: GlobalMap ann -> Bool
-globalMapIsNull (GlobalMap m) = M.null m
-
-filterIdent :: Identifier -> GlobalMap ann -> GlobalMap ann
-filterIdent ident (GlobalMap m) =
-  GlobalMap $
-    M.delete ident m
-
-data TCError ann
-  = TCUnknownError
-  | TCCouldNotFindVar ann (ResolvedDep Identifier)
-  | TCCouldNotFindGlobal Identifier (Set Identifier)
-  | TCTypeMismatch (ResolvedType ann) (ResolvedType ann)
-  | TCTupleSizeMismatch Int (ResolvedType ann)
-  | TCExpectedTuple (ResolvedType ann)
-  | TCExpectedFunction (ResolvedType ann)
-  | TCRecordMissingItems (Set Identifier)
-  | TCExpectedRecord (ResolvedType ann)
-  | TCInfixMismatch Op (ResolvedType ann) (ResolvedType ann)
-  | TCPatternMismatch (Pattern ResolvedDep ann) (ResolvedType ann)
-  | TCUnknownConstructor (ResolvedDep Constructor) [Constructor]
-  | TCConstructorArgumentMismatch (ResolvedDep Constructor) Int Int -- expected, actual
-  | TCExpectedConstructorType (ResolvedType ann)
-  | TCCompoundTypeInEquality (ResolvedType ann) -- for now we only do primitive equality
-  | TCPatternMatchError (PatternMatchError (ResolvedType ann))
-  deriving stock (Eq, Ord, Show, Foldable)
 
 data Typeclass ann = Typeclass
   { tcName :: String,
@@ -73,10 +39,4 @@ data TCEnv ann = TCEnv
     tceDataTypes :: Map (ResolvedDep TypeName) (DataType ResolvedDep ann),
     tceClasses :: Map String (Typeclass ann),
     tceInstances :: Map (TypeclassHead ann) (Instance ann)
-  }
-
-data TCState ann = TCState
-  { tcsArgStack :: [ResolvedType ann],
-    tcsUnknown :: Integer,
-    tcsGlobals :: [GlobalMap ann]
   }

--- a/smol-core/src/Smol/Core/Typecheck/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types.hs
@@ -56,7 +56,7 @@ instance Printer (Instance ann) where
 
 data TCEnv ann = TCEnv
   { tceVars :: Map (ResolvedDep Identifier) (ResolvedType ann),
-    tceGlobals :: Map Identifier (ResolvedType ann),
+    tceGlobals :: Map Identifier ([Constraint ann], ResolvedType ann),
     tceDataTypes :: Map (ResolvedDep TypeName) (DataType ResolvedDep ann),
     tceClasses :: Map String (Typeclass ann),
     tceInstances :: Map (Constraint ann) (Instance ann),

--- a/smol-core/src/Smol/Core/Typecheck/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types.hs
@@ -4,7 +4,7 @@
 module Smol.Core.Typecheck.Types
   ( TCEnv (..),
     Typeclass (..),
-    TypeclassHead (..),
+    Constraint (..),
     Instance (..),
     module Smol.Core.Typecheck.Types.TCError,
     module Smol.Core.Typecheck.Types.TCState,
@@ -31,19 +31,19 @@ data Typeclass ann = Typeclass
   }
   deriving stock (Eq, Ord, Show)
 
-data TypeclassHead ann
-  = TypeclassHead String [Type Identity ann]
+data Constraint ann
+  = Constraint String [Type Identity ann]
   deriving stock (Eq, Ord, Show)
 
-instance Printer (TypeclassHead ann) where
-  prettyDoc (TypeclassHead tcn tys) =
+instance Printer (Constraint ann) where
+  prettyDoc (Constraint tcn tys) =
     PP.pretty tcn
       PP.<+> PP.concatWith
         (\a b -> a <> " " <> b)
         (prettyDoc <$> tys)
 
 data Instance ann = Instance
-  { inConstraints :: [TypeclassHead ann],
+  { inConstraints :: [Constraint ann],
     inExpr :: Expr Identity ann
   }
   deriving stock (Eq, Ord, Show)
@@ -58,6 +58,6 @@ data TCEnv ann = TCEnv
     tceGlobals :: Map Identifier (ResolvedType ann),
     tceDataTypes :: Map (ResolvedDep TypeName) (DataType ResolvedDep ann),
     tceClasses :: Map String (Typeclass ann),
-    tceInstances :: Map (TypeclassHead ann) (Instance ann),
-    tceConstraints :: [TypeclassHead ann]
+    tceInstances :: Map (Constraint ann) (Instance ann),
+    tceConstraints :: [Constraint ann]
   }

--- a/smol-core/src/Smol/Core/Typecheck/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types.hs
@@ -53,8 +53,9 @@ data TCError ann
   deriving stock (Eq, Ord, Show, Foldable)
 
 data Typeclass ann = Typeclass
-  { tcArgs :: [Identifier],
-    tcFuncName :: String,
+  { tcName :: String,
+    tcArgs :: [Identifier],
+    tcFuncName :: Identifier,
     tcFuncType :: Type Identity ann
   }
 

--- a/smol-core/src/Smol/Core/Typecheck/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types.hs
@@ -60,9 +60,9 @@ instance Printer (Instance ann) where
     "(" <> PP.concatWith (\a b -> a <> ", " <> b) (prettyDoc <$> constraints) <> ") => " <> prettyDoc expr
 
 data TCEnv ann = TCEnv
-  { tceVars :: Map (ResolvedDep Identifier) ([Constraint ()], ResolvedType ann),
+  { tceVars :: Map (ResolvedDep Identifier) ([Constraint ann], ResolvedType ann),
     tceDataTypes :: Map (ResolvedDep TypeName) (DataType ResolvedDep ann),
     tceClasses :: Map String (Typeclass ann),
-    tceInstances :: Map (Constraint ()) (Instance ann),
+    tceInstances :: Map (Constraint ann) (Instance ann),
     tceConstraints :: [Constraint ann]
   }

--- a/smol-core/src/Smol/Core/Typecheck/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types.hs
@@ -20,6 +20,8 @@ import Smol.Core.Typecheck.Types.TCState
 import Smol.Core.Typecheck.Types.TCWrite
 import Smol.Core.Types
 
+-- | the typeclass described in it's most general form, ie
+-- class Show a where show :: a -> String
 data Typeclass ann = Typeclass
   { tcName :: String,
     tcArgs :: [Identifier],

--- a/smol-core/src/Smol/Core/Typecheck/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types.hs
@@ -2,67 +2,29 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Smol.Core.Typecheck.Types
   ( TCEnv (..),
-    Typeclass (..),
-    Constraint (..),
-    Instance (..),
+    module Smol.Core.Typecheck.Typeclass.Types,
     module Smol.Core.Typecheck.Types.TCError,
     module Smol.Core.Typecheck.Types.TCState,
     module Smol.Core.Typecheck.Types.TCWrite,
   )
 where
 
-import Control.Monad.Identity
-import Data.Aeson (FromJSON, ToJSON)
 import Data.Map.Strict (Map)
-import GHC.Generics
-import qualified Prettyprinter as PP
-import Smol.Core.Printer
+import Smol.Core.Typecheck.Typeclass.Types
 import Smol.Core.Typecheck.Types.TCError
 import Smol.Core.Typecheck.Types.TCState
 import Smol.Core.Typecheck.Types.TCWrite
 import Smol.Core.Types
 
--- | the typeclass described in it's most general form, ie
--- class Show a where show :: a -> String
-data Typeclass ann = Typeclass
-  { tcName :: String,
-    tcArgs :: [Identifier],
-    tcFuncName :: Identifier,
-    tcFuncType :: Type Identity ann
-  }
-  deriving stock (Eq, Ord, Show, Functor)
-
-data Constraint ann
-  = Constraint String [Type Identity ann]
-  deriving stock (Eq, Ord, Show, Functor, Generic)
-  deriving anyclass (ToJSON, FromJSON)
-
-instance Printer (Constraint ann) where
-  prettyDoc (Constraint tcn tys) =
-    PP.pretty tcn
-      PP.<+> PP.concatWith
-        (\a b -> a <> " " <> b)
-        (prettyDoc <$> tys)
-
-data Instance ann = Instance
-  { inConstraints :: [Constraint ann],
-    inExpr :: Expr Identity ann
-  }
-  deriving stock (Eq, Ord, Show, Functor)
-
-instance Printer (Instance ann) where
-  prettyDoc (Instance [] expr) = prettyDoc expr
-  prettyDoc (Instance constraints expr) =
-    "(" <> PP.concatWith (\a b -> a <> ", " <> b) (prettyDoc <$> constraints) <> ") => " <> prettyDoc expr
-
 data TCEnv ann = TCEnv
   { tceVars :: Map (ResolvedDep Identifier) ([Constraint ann], ResolvedType ann),
     tceDataTypes :: Map (ResolvedDep TypeName) (DataType ResolvedDep ann),
-    tceClasses :: Map String (Typeclass ann),
+    tceClasses :: Map TypeclassName (Typeclass ann),
     tceInstances :: Map (Constraint ann) (Instance ann),
     tceConstraints :: [Constraint ann]
   }

--- a/smol-core/src/Smol/Core/Typecheck/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 
 module Smol.Core.Typecheck.Types
   ( TCEnv (..),
@@ -33,7 +31,7 @@ data TypeclassHead ann
   = TypeclassHead String [Type Identity ann]
   deriving stock (Eq, Ord, Show)
 
-data Instance ann = Instance
+newtype Instance ann = Instance
   {inExpr :: Expr Identity ann}
   deriving stock (Eq, Ord, Show)
 

--- a/smol-core/src/Smol/Core/Typecheck/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -29,11 +30,11 @@ data Typeclass ann = Typeclass
     tcFuncName :: Identifier,
     tcFuncType :: Type Identity ann
   }
-  deriving stock (Eq, Ord, Show)
+  deriving stock (Eq, Ord, Show, Functor)
 
 data Constraint ann
   = Constraint String [Type Identity ann]
-  deriving stock (Eq, Ord, Show)
+  deriving stock (Eq, Ord, Show, Functor)
 
 instance Printer (Constraint ann) where
   prettyDoc (Constraint tcn tys) =
@@ -46,7 +47,7 @@ data Instance ann = Instance
   { inConstraints :: [Constraint ann],
     inExpr :: Expr Identity ann
   }
-  deriving stock (Eq, Ord, Show)
+  deriving stock (Eq, Ord, Show, Functor)
 
 instance Printer (Instance ann) where
   prettyDoc (Instance [] expr) = prettyDoc expr

--- a/smol-core/src/Smol/Core/Typecheck/Types/Substitution.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types/Substitution.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Smol.Core.Typecheck.Types.Substitution
+  ( Substitution (..),
+    SubstitutionMatcher (..),
+  )
+where
+
+import qualified Prettyprinter as PP
+import Smol.Core.Printer
+import Smol.Core.Types
+
+data SubstitutionMatcher dep ann
+  = SubId (dep Identifier)
+  | SubUnknown Integer
+  | SubType (Type dep ann)
+
+deriving stock instance
+  ( Eq ann,
+    Eq (dep Identifier),
+    Eq (dep TypeName)
+  ) =>
+  Eq (SubstitutionMatcher dep ann)
+
+deriving stock instance
+  ( Ord ann,
+    Ord (dep Identifier),
+    Ord (dep TypeName)
+  ) =>
+  Ord (SubstitutionMatcher dep ann)
+
+deriving stock instance
+  ( Show ann,
+    Show (dep Identifier),
+    Show (dep TypeName)
+  ) =>
+  Show (SubstitutionMatcher dep ann)
+
+data Substitution dep ann
+  = Substitution (SubstitutionMatcher dep ann) (Type dep ann)
+
+instance (Show ann, Show (dep Identifier), Show (dep TypeName)) => Printer (Substitution dep ann) where
+  prettyDoc a = PP.pretty (show a)
+
+deriving stock instance
+  (Eq ann, Eq (dep Identifier), Eq (dep TypeName)) =>
+  Eq (Substitution dep ann)
+
+deriving stock instance
+  (Ord ann, Ord (dep Identifier), Ord (dep TypeName)) =>
+  Ord (Substitution dep ann)
+
+deriving stock instance
+  (Show ann, Show (dep Identifier), Show (dep TypeName)) =>
+  Show (Substitution dep ann)

--- a/smol-core/src/Smol/Core/Typecheck/Types/Substitution.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types/Substitution.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
 module Smol.Core.Typecheck.Types.Substitution

--- a/smol-core/src/Smol/Core/Typecheck/Types/TCError.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types/TCError.hs
@@ -2,10 +2,11 @@
 {-# LANGUAGE DerivingStrategies #-}
 
 module Smol.Core.Typecheck.Types.TCError
-  ( TCError(..),
+  ( TCError (..),
   )
 where
 
+import Control.Monad.Identity
 import Data.Set (Set)
 import Smol.Core.Types
 import Smol.Core.Types.PatternMatchError (PatternMatchError)
@@ -13,7 +14,6 @@ import Smol.Core.Types.PatternMatchError (PatternMatchError)
 data TCError ann
   = TCUnknownError
   | TCCouldNotFindVar ann (ResolvedDep Identifier)
-  | TCCouldNotFindGlobal Identifier (Set Identifier)
   | TCTypeMismatch (ResolvedType ann) (ResolvedType ann)
   | TCTupleSizeMismatch Int (ResolvedType ann)
   | TCExpectedTuple (ResolvedType ann)
@@ -27,5 +27,5 @@ data TCError ann
   | TCExpectedConstructorType (ResolvedType ann)
   | TCCompoundTypeInEquality (ResolvedType ann) -- for now we only do primitive equality
   | TCPatternMatchError (PatternMatchError (ResolvedType ann))
+  | TCTypeclassInstanceNotFound String [Type Identity ann]
   deriving stock (Eq, Ord, Show, Foldable)
-

--- a/smol-core/src/Smol/Core/Typecheck/Types/TCError.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types/TCError.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+module Smol.Core.Typecheck.Types.TCError
+  ( TCError(..),
+  )
+where
+
+import Data.Set (Set)
+import Smol.Core.Types
+import Smol.Core.Types.PatternMatchError (PatternMatchError)
+
+data TCError ann
+  = TCUnknownError
+  | TCCouldNotFindVar ann (ResolvedDep Identifier)
+  | TCCouldNotFindGlobal Identifier (Set Identifier)
+  | TCTypeMismatch (ResolvedType ann) (ResolvedType ann)
+  | TCTupleSizeMismatch Int (ResolvedType ann)
+  | TCExpectedTuple (ResolvedType ann)
+  | TCExpectedFunction (ResolvedType ann)
+  | TCRecordMissingItems (Set Identifier)
+  | TCExpectedRecord (ResolvedType ann)
+  | TCInfixMismatch Op (ResolvedType ann) (ResolvedType ann)
+  | TCPatternMismatch (Pattern ResolvedDep ann) (ResolvedType ann)
+  | TCUnknownConstructor (ResolvedDep Constructor) [Constructor]
+  | TCConstructorArgumentMismatch (ResolvedDep Constructor) Int Int -- expected, actual
+  | TCExpectedConstructorType (ResolvedType ann)
+  | TCCompoundTypeInEquality (ResolvedType ann) -- for now we only do primitive equality
+  | TCPatternMatchError (PatternMatchError (ResolvedType ann))
+  deriving stock (Eq, Ord, Show, Foldable)
+

--- a/smol-core/src/Smol/Core/Typecheck/Types/TCError.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types/TCError.hs
@@ -29,6 +29,6 @@ data TCError ann
   | TCCompoundTypeInEquality (ResolvedType ann) -- for now we only do primitive equality
   | TCPatternMatchError (PatternMatchError (ResolvedType ann))
   | TCTypeclassNotFound TypeclassName
-  | TCTypeclassInstanceNotFound TypeclassName [Type Identity ann]
+  | TCTypeclassInstanceNotFound TypeclassName [Type Identity ann] [Constraint ann]
   | TCConflictingTypeclassInstancesFound [Constraint ann]
   deriving stock (Eq, Ord, Show, Foldable)

--- a/smol-core/src/Smol/Core/Typecheck/Types/TCError.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types/TCError.hs
@@ -29,4 +29,5 @@ data TCError ann
   | TCCompoundTypeInEquality (ResolvedType ann) -- for now we only do primitive equality
   | TCPatternMatchError (PatternMatchError (ResolvedType ann))
   | TCTypeclassInstanceNotFound TypeclassName [Type Identity ann]
+  | TCConflictingTypeclassInstancesFound [Constraint ann]
   deriving stock (Eq, Ord, Show, Foldable)

--- a/smol-core/src/Smol/Core/Typecheck/Types/TCError.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types/TCError.hs
@@ -28,6 +28,7 @@ data TCError ann
   | TCExpectedConstructorType (ResolvedType ann)
   | TCCompoundTypeInEquality (ResolvedType ann) -- for now we only do primitive equality
   | TCPatternMatchError (PatternMatchError (ResolvedType ann))
+  | TCTypeclassNotFound TypeclassName
   | TCTypeclassInstanceNotFound TypeclassName [Type Identity ann]
   | TCConflictingTypeclassInstancesFound [Constraint ann]
   deriving stock (Eq, Ord, Show, Foldable)

--- a/smol-core/src/Smol/Core/Typecheck/Types/TCError.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types/TCError.hs
@@ -8,6 +8,7 @@ where
 
 import Control.Monad.Identity
 import Data.Set (Set)
+import Smol.Core.Typecheck.Typeclass.Types
 import Smol.Core.Types
 import Smol.Core.Types.PatternMatchError (PatternMatchError)
 
@@ -27,5 +28,5 @@ data TCError ann
   | TCExpectedConstructorType (ResolvedType ann)
   | TCCompoundTypeInEquality (ResolvedType ann) -- for now we only do primitive equality
   | TCPatternMatchError (PatternMatchError (ResolvedType ann))
-  | TCTypeclassInstanceNotFound String [Type Identity ann]
+  | TCTypeclassInstanceNotFound TypeclassName [Type Identity ann]
   deriving stock (Eq, Ord, Show, Foldable)

--- a/smol-core/src/Smol/Core/Typecheck/Types/TCState.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types/TCState.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 

--- a/smol-core/src/Smol/Core/Typecheck/Types/TCState.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types/TCState.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+
+module Smol.Core.Typecheck.Types.TCState
+  ( TCState (..),
+    GlobalMap (..),
+    filterIdent,
+    globalMapIsNull,
+  )
+where
+
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import Smol.Core.Types
+
+newtype GlobalMap ann = GlobalMap {getGlobalMap :: Map Identifier (ResolvedType ann)}
+  deriving newtype (Eq, Ord, Show, Semigroup, Monoid)
+
+globalMapIsNull :: GlobalMap ann -> Bool
+globalMapIsNull (GlobalMap m) = M.null m
+
+filterIdent :: Identifier -> GlobalMap ann -> GlobalMap ann
+filterIdent ident (GlobalMap m) =
+  GlobalMap $
+    M.delete ident m
+
+data TCState ann = TCState
+  { tcsArgStack :: [ResolvedType ann],
+    tcsUnknown :: Integer,
+    tcsGlobals :: [GlobalMap ann]
+  }

--- a/smol-core/src/Smol/Core/Typecheck/Types/TCWrite.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types/TCWrite.hs
@@ -7,18 +7,24 @@ module Smol.Core.Typecheck.Types.TCWrite (TCWrite (..), filterSubstitutions, fil
 import Data.Maybe (mapMaybe)
 import Data.String
 import Smol.Core.Printer
+import Smol.Core.Typecheck.Typeclass.Types
 import Smol.Core.Typecheck.Types.Substitution
 import Smol.Core.Types.Identifier
 import Smol.Core.Types.ResolvedDep
 
 -- stuff emitted during typechecking
 data TCWrite ann
-  = TCWSubstitution (Substitution ResolvedDep ann)
-  | TCWTypeclassUse (ResolvedDep Identifier) String [(Identifier, Integer)]
+  = TCWSubstitution
+      (Substitution ResolvedDep ann)
+  | TCWTypeclassUse
+      (ResolvedDep Identifier)
+      TypeclassName
+      [(Identifier, Integer)]
   deriving stock (Eq, Ord, Show)
 
 instance (Show ann) => Printer (TCWrite ann) where
-  prettyDoc (TCWTypeclassUse _ tcName matches) = fromString tcName <> " : " <> fromString (show matches)
+  prettyDoc (TCWTypeclassUse _ tcn matches) =
+    prettyDoc tcn <> " : " <> fromString (show matches)
   prettyDoc (TCWSubstitution sub) = prettyDoc sub
 
 filterSubstitutions :: [TCWrite ann] -> [Substitution ResolvedDep ann]
@@ -29,7 +35,7 @@ filterSubstitutions =
         _ -> Nothing
     )
 
-filterTypeclassUses :: [TCWrite ann] -> [(ResolvedDep Identifier, String, [(Identifier, Integer)])]
+filterTypeclassUses :: [TCWrite ann] -> [(ResolvedDep Identifier, TypeclassName, [(Identifier, Integer)])]
 filterTypeclassUses =
   mapMaybe
     ( \case

--- a/smol-core/src/Smol/Core/Typecheck/Types/TCWrite.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types/TCWrite.hs
@@ -1,0 +1,9 @@
+module Smol.Core.Typecheck.Types.TCWrite (TCWrite(..)) where
+
+import Smol.Core.Typecheck.Types.Substitution
+import Smol.Core.Types.ResolvedDep
+
+-- stuff emitted during typechecking
+data TCWrite ann
+  = TCWSubstitution (Substitution ResolvedDep ann)
+

--- a/smol-core/src/Smol/Core/Typecheck/Types/TCWrite.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types/TCWrite.hs
@@ -14,11 +14,11 @@ import Smol.Core.Types.ResolvedDep
 -- stuff emitted during typechecking
 data TCWrite ann
   = TCWSubstitution (Substitution ResolvedDep ann)
-  | TCWTypeclassUse String [(Identifier, Integer)]
+  | TCWTypeclassUse (ResolvedDep Identifier) String [(Identifier, Integer)]
   deriving stock (Eq, Ord, Show)
 
 instance (Show ann) => Printer (TCWrite ann) where
-  prettyDoc (TCWTypeclassUse tcName matches) = fromString tcName <> " : " <> fromString (show matches)
+  prettyDoc (TCWTypeclassUse _ tcName matches) = fromString tcName <> " : " <> fromString (show matches)
   prettyDoc (TCWSubstitution sub) = prettyDoc sub
 
 filterSubstitutions :: [TCWrite ann] -> [Substitution ResolvedDep ann]
@@ -29,10 +29,10 @@ filterSubstitutions =
         _ -> Nothing
     )
 
-filterTypeclassUses :: [TCWrite ann] -> [(String, [(Identifier, Integer)])]
+filterTypeclassUses :: [TCWrite ann] -> [(ResolvedDep Identifier, String, [(Identifier, Integer)])]
 filterTypeclassUses =
   mapMaybe
     ( \case
-        TCWTypeclassUse s matches -> Just (s, matches)
+        TCWTypeclassUse ident s matches -> Just (ident, s, matches)
         _ -> Nothing
     )

--- a/smol-core/src/Smol/Core/Typecheck/Types/TCWrite.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types/TCWrite.hs
@@ -1,9 +1,38 @@
-module Smol.Core.Typecheck.Types.TCWrite (TCWrite(..)) where
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 
+module Smol.Core.Typecheck.Types.TCWrite (TCWrite (..), filterSubstitutions, filterTypeclassUses) where
+
+import Data.Maybe (mapMaybe)
+import Data.String
+import Smol.Core.Printer
 import Smol.Core.Typecheck.Types.Substitution
+import Smol.Core.Types.Identifier
 import Smol.Core.Types.ResolvedDep
 
 -- stuff emitted during typechecking
 data TCWrite ann
   = TCWSubstitution (Substitution ResolvedDep ann)
+  | TCWTypeclassUse String [(Identifier, Integer)]
+  deriving stock (Eq, Ord, Show)
 
+instance (Show ann) => Printer (TCWrite ann) where
+  prettyDoc (TCWTypeclassUse tcName matches) = fromString tcName <> " : " <> fromString (show matches)
+  prettyDoc (TCWSubstitution sub) = prettyDoc sub
+
+filterSubstitutions :: [TCWrite ann] -> [Substitution ResolvedDep ann]
+filterSubstitutions =
+  mapMaybe
+    ( \case
+        TCWSubstitution sub -> Just sub
+        _ -> Nothing
+    )
+
+filterTypeclassUses :: [TCWrite ann] -> [(String, [(Identifier, Integer)])]
+filterTypeclassUses =
+  mapMaybe
+    ( \case
+        TCWTypeclassUse s matches -> Just (s, matches)
+        _ -> Nothing
+    )

--- a/smol-core/src/Smol/Core/Types/DataType.hs
+++ b/smol-core/src/Smol/Core/Types/DataType.hs
@@ -84,7 +84,7 @@ renderDataType ::
 renderDataType (DataType tyCon vars' constructors') =
   "type"
     <+> prettyDoc tyCon
-      <> printVars vars'
+    <> printVars vars'
     <+> if M.null constructors'
       then mempty
       else

--- a/smol-core/src/Smol/Core/Types/DataType.hs
+++ b/smol-core/src/Smol/Core/Types/DataType.hs
@@ -84,7 +84,7 @@ renderDataType ::
 renderDataType (DataType tyCon vars' constructors') =
   "type"
     <+> prettyDoc tyCon
-    <> printVars vars'
+      <> printVars vars'
     <+> if M.null constructors'
       then mempty
       else

--- a/smol-core/src/Smol/Core/Types/Expr.hs
+++ b/smol-core/src/Smol/Core/Types/Expr.hs
@@ -179,12 +179,12 @@ prettyLet var expr1 expr2 =
    in PP.group
         ( "let"
             <+> prettyVar
-            <> prettyArgs args
+              <> prettyArgs args
             <+> "="
-            <> PP.line
-            <> indentMulti 2 (prettyDoc letExpr)
-            <> newlineOrIn
-            <> prettyDoc expr2
+              <> PP.line
+              <> indentMulti 2 (prettyDoc letExpr)
+              <> newlineOrIn
+              <> prettyDoc expr2
         )
   where
     prettyArgs [] = ""
@@ -298,22 +298,22 @@ prettyPatternMatch sumExpr matches =
     <+> printSubExpr sumExpr
     <+> "with"
     <+> PP.line
-    <> PP.indent
-      2
-      ( PP.align $
-          PP.vsep
-            ( zipWith
-                (<+>)
-                (" " : repeat "|")
-                (printMatch <$> NE.toList matches)
-            )
-      )
+      <> PP.indent
+        2
+        ( PP.align $
+            PP.vsep
+              ( zipWith
+                  (<+>)
+                  (" " : repeat "|")
+                  (printMatch <$> NE.toList matches)
+              )
+        )
   where
     printMatch (construct, expr') =
       printSubPattern construct
         <+> "->"
         <+> PP.line
-        <> indentMulti 4 (printSubExpr expr')
+          <> indentMulti 4 (printSubExpr expr')
 
 prettyArray ::
   ( Printer (dep Constructor),

--- a/smol-core/src/Smol/Core/Types/Expr.hs
+++ b/smol-core/src/Smol/Core/Types/Expr.hs
@@ -179,12 +179,12 @@ prettyLet var expr1 expr2 =
    in PP.group
         ( "let"
             <+> prettyVar
-              <> prettyArgs args
+            <> prettyArgs args
             <+> "="
-              <> PP.line
-              <> indentMulti 2 (prettyDoc letExpr)
-              <> newlineOrIn
-              <> prettyDoc expr2
+            <> PP.line
+            <> indentMulti 2 (prettyDoc letExpr)
+            <> newlineOrIn
+            <> prettyDoc expr2
         )
   where
     prettyArgs [] = ""
@@ -298,22 +298,22 @@ prettyPatternMatch sumExpr matches =
     <+> printSubExpr sumExpr
     <+> "with"
     <+> PP.line
-      <> PP.indent
-        2
-        ( PP.align $
-            PP.vsep
-              ( zipWith
-                  (<+>)
-                  (" " : repeat "|")
-                  (printMatch <$> NE.toList matches)
-              )
-        )
+    <> PP.indent
+      2
+      ( PP.align $
+          PP.vsep
+            ( zipWith
+                (<+>)
+                (" " : repeat "|")
+                (printMatch <$> NE.toList matches)
+            )
+      )
   where
     printMatch (construct, expr') =
       printSubPattern construct
         <+> "->"
         <+> PP.line
-          <> indentMulti 4 (printSubExpr expr')
+        <> indentMulti 4 (printSubExpr expr')
 
 prettyArray ::
   ( Printer (dep Constructor),

--- a/smol-core/src/Smol/Core/Types/Expr.hs
+++ b/smol-core/src/Smol/Core/Types/Expr.hs
@@ -178,12 +178,13 @@ prettyLet var expr1 expr2 =
           prettyDoc var
    in PP.group
         ( "let"
-            <+> prettyVar <> prettyArgs args
+            <+> prettyVar
+            <> prettyArgs args
             <+> "="
-              <> PP.line
-              <> indentMulti 2 (prettyDoc letExpr)
-              <> newlineOrIn
-              <> prettyDoc expr2
+            <> PP.line
+            <> indentMulti 2 (prettyDoc letExpr)
+            <> newlineOrIn
+            <> prettyDoc expr2
         )
   where
     prettyArgs [] = ""
@@ -297,22 +298,22 @@ prettyPatternMatch sumExpr matches =
     <+> printSubExpr sumExpr
     <+> "with"
     <+> PP.line
-      <> PP.indent
-        2
-        ( PP.align $
-            PP.vsep
-              ( zipWith
-                  (<+>)
-                  (" " : repeat "|")
-                  (printMatch <$> NE.toList matches)
-              )
-        )
+    <> PP.indent
+      2
+      ( PP.align $
+          PP.vsep
+            ( zipWith
+                (<+>)
+                (" " : repeat "|")
+                (printMatch <$> NE.toList matches)
+            )
+      )
   where
     printMatch (construct, expr') =
       printSubPattern construct
         <+> "->"
         <+> PP.line
-          <> indentMulti 4 (printSubExpr expr')
+        <> indentMulti 4 (printSubExpr expr')
 
 prettyArray ::
   ( Printer (dep Constructor),

--- a/smol-core/src/Smol/Core/Types/ResolvedDep.hs
+++ b/smol-core/src/Smol/Core/Types/ResolvedDep.hs
@@ -21,6 +21,10 @@ data ResolvedDep identifier
       { rdIdentifier :: identifier,
         rdUnique :: Int
       }
+  | TypeclassCall
+      { rdIdentifier :: identifier,
+        rdUnique :: Int
+      }
   deriving stock (Eq, Ord, Show, Generic)
 
 instance

--- a/smol-core/test/Main.hs
+++ b/smol-core/test/Main.hs
@@ -12,6 +12,7 @@ import qualified Test.Typecheck.ExhaustivenessSpec
 import qualified Test.Typecheck.NestingMonadSpec
 import qualified Test.Typecheck.PatternSpec
 import qualified Test.Typecheck.SubtypeSpec
+import qualified Test.Typecheck.TypeclassSpec
 import qualified Test.TypecheckSpec
 
 main :: IO ()
@@ -21,6 +22,7 @@ main = hspec $ do
   Test.Typecheck.NestingMonadSpec.spec
   Test.Typecheck.ExhaustivenessSpec.spec
   Test.Typecheck.PatternSpec.spec
+  Test.Typecheck.TypeclassSpec.spec
   Test.ParserSpec.spec
   Test.Interpreter.InterpreterSpec.spec
   Test.Modules.FromPartsSpec.spec

--- a/smol-core/test/Test/Helpers.hs
+++ b/smol-core/test/Test/Helpers.hs
@@ -37,10 +37,10 @@ module Test.Helpers
   )
 where
 
+import Control.Monad.Identity
 import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Writer
-import Control.Monad.Identity
 import Data.Foldable (foldl')
 import Data.Functor
 import qualified Data.List.NonEmpty as NE
@@ -177,7 +177,7 @@ joinText = T.intercalate "\n"
 runTypecheckM ::
   (Monad m) =>
   TCEnv ann ->
-  StateT (TCState ann) (WriterT [Substitution ResolvedDep ann] (ReaderT (TCEnv ann) m)) a ->
+  StateT (TCState ann) (WriterT [TCWrite ann] (ReaderT (TCEnv ann) m)) a ->
   m a
 runTypecheckM env action =
   fst

--- a/smol-core/test/Test/Helpers.hs
+++ b/smol-core/test/Test/Helpers.hs
@@ -252,7 +252,6 @@ typecheckEnv :: (Monoid ann, Ord ann) => TCEnv ann
 typecheckEnv =
   TCEnv
     mempty
-    mempty
     (builtInTypes emptyResolvedDep)
     classes
     instances

--- a/smol-core/test/Test/Helpers.hs
+++ b/smol-core/test/Test/Helpers.hs
@@ -34,7 +34,7 @@ module Test.Helpers
     eqTypeclass,
     unsafeParseInstanceExpr,
     tcVar,
-    typeForComparison
+    typeForComparison,
   )
 where
 
@@ -267,5 +267,3 @@ typeForComparison (TFunc ann _ fn arg) =
   TFunc ann mempty (typeForComparison fn) (typeForComparison arg)
 typeForComparison (TArray ann _ as) = TArray ann 0 (typeForComparison as)
 typeForComparison other = mapType typeForComparison other
-
-

--- a/smol-core/test/Test/Helpers.hs
+++ b/smol-core/test/Test/Helpers.hs
@@ -255,3 +255,4 @@ typecheckEnv =
     (builtInTypes emptyResolvedDep)
     classes
     instances
+    mempty

--- a/smol-core/test/Test/Helpers.hs
+++ b/smol-core/test/Test/Helpers.hs
@@ -34,6 +34,7 @@ module Test.Helpers
     eqTypeclass,
     unsafeParseInstanceExpr,
     tcVar,
+    typeForComparison
   )
 where
 
@@ -256,3 +257,15 @@ typecheckEnv =
     classes
     instances
     mempty
+
+----
+
+-- simplify type for equality check
+-- remove anything that can't be described in a type signature
+typeForComparison :: (Ord (dep Identifier)) => Type dep ann -> Type dep ann
+typeForComparison (TFunc ann _ fn arg) =
+  TFunc ann mempty (typeForComparison fn) (typeForComparison arg)
+typeForComparison (TArray ann _ as) = TArray ann 0 (typeForComparison as)
+typeForComparison other = mapType typeForComparison other
+
+

--- a/smol-core/test/Test/Helpers.hs
+++ b/smol-core/test/Test/Helpers.hs
@@ -6,6 +6,7 @@ module Test.Helpers
     tyInt,
     tyIntLit,
     tyStrLit,
+    tyUnit,
     tyVar,
     tyUnknown,
     tyTuple,
@@ -55,6 +56,9 @@ tyBoolLit = TLiteral mempty . TLBool
 
 tyInt :: (Monoid ann) => Type dep ann
 tyInt = TPrim mempty TPInt
+
+tyUnit :: (Monoid ann) => Type dep ann
+tyUnit = TLiteral mempty TLUnit
 
 tyString :: (Monoid ann) => Type dep ann
 tyString = TPrim mempty TPString

--- a/smol-core/test/Test/Helpers.hs
+++ b/smol-core/test/Test/Helpers.hs
@@ -219,7 +219,7 @@ eqTypeclass =
       tcFuncType = tyFunc (tcVar "a") (tyFunc (tcVar "a") tyBool)
     }
 
-classes :: (Monoid ann) => M.Map String (Typeclass ann)
+classes :: (Monoid ann) => M.Map TypeclassName (Typeclass ann)
 classes =
   M.fromList
     [ ("Eq", eqTypeclass),

--- a/smol-core/test/Test/Helpers.hs
+++ b/smol-core/test/Test/Helpers.hs
@@ -10,6 +10,8 @@ module Test.Helpers
     tyUnknown,
     tyTuple,
     tyCons,
+    tyFunc,
+    tyString,
     bool,
     int,
     var,
@@ -54,6 +56,9 @@ tyBoolLit = TLiteral mempty . TLBool
 tyInt :: (Monoid ann) => Type dep ann
 tyInt = TPrim mempty TPInt
 
+tyString :: (Monoid ann) => Type dep ann
+tyString = TPrim mempty TPString
+
 tyIntLit :: (Monoid ann) => [Integer] -> Type dep ann
 tyIntLit = TLiteral mempty . TLInt . NES.fromList . NE.fromList
 
@@ -80,6 +85,9 @@ tyCons ::
   Type ParseDep ann
 tyCons typeName =
   foldl' (TApp mempty) (TConstructor mempty (emptyParseDep typeName))
+
+tyFunc :: (Monoid ann, Ord (dep Identifier)) => Type dep ann -> Type dep ann -> Type dep ann
+tyFunc = TFunc mempty mempty
 
 unit :: (Monoid ann) => Expr dep ann
 unit = EPrim mempty PUnit

--- a/smol-core/test/Test/Helpers.hs
+++ b/smol-core/test/Test/Helpers.hs
@@ -229,19 +229,19 @@ unsafeParseInstanceExpr :: (Monoid ann) => Text -> Expr Identity ann
 unsafeParseInstanceExpr =
   fmap (const mempty) . identityFromParsedExpr . unsafeParseExpr
 
-instances :: (Ord ann, Monoid ann) => M.Map (TypeclassHead ann) (Instance ann)
+instances :: (Ord ann, Monoid ann) => M.Map (Constraint ann) (Instance ann)
 instances =
   M.fromList
-    [ ( TypeclassHead "Eq" [tyInt],
+    [ ( Constraint "Eq" [tyInt],
         Instance {inExpr = unsafeParseInstanceExpr "\\a -> \\b -> a == b", inConstraints = []}
       ),
-      ( TypeclassHead "Eq" [tyTuple (tcVar "a") [tcVar "b"]],
+      ( Constraint "Eq" [tyTuple (tcVar "a") [tcVar "b"]],
         Instance
           { inExpr =
               unsafeParseInstanceExpr "\\a -> \\b -> case (a,b) of ((a1, a2), (b1, b2)) -> if equals a1 b1 then equals a2 b2 else False",
             inConstraints =
-              [ TypeclassHead "Eq" [tcVar "a"],
-                TypeclassHead "Eq" [tcVar "b"]
+              [ Constraint "Eq" [tcVar "a"],
+                Constraint "Eq" [tcVar "b"]
               ]
           }
       )

--- a/smol-core/test/Test/Interpreter/InterpreterSpec.hs
+++ b/smol-core/test/Test/Interpreter/InterpreterSpec.hs
@@ -69,7 +69,7 @@ spec = do
         )
         cases
 
-    fdescribe "interpret with typeclasses" $ do
+    describe "interpret with typeclasses" $ do
       let cases =
             [ ("equals (1 : Int) (1 : Int)", "True"), -- use Eq Int
               ("equals (2 : Int) (1 : Int)", "False"), -- use Eq Int

--- a/smol-core/test/Test/Interpreter/InterpreterSpec.hs
+++ b/smol-core/test/Test/Interpreter/InterpreterSpec.hs
@@ -9,6 +9,7 @@ import Smol.Core
 import Smol.Core.Interpreter.Types.Stack
 import Smol.Core.Typecheck.FromParsedExpr
 import Smol.Core.Typecheck.Typecheck (typecheck)
+import Smol.Core.Typecheck.Typeclass
 import Test.Helpers
 import Test.Hspec
 
@@ -30,12 +31,14 @@ discardLeft (Right a) = a
 doInterpret :: Text -> Expr ResolvedDep ()
 doInterpret input =
   case typecheck typecheckEnv (fromParsedExpr (unsafeParseExpr input)) of
-    Right (_constraints, typedExpr ) ->
+    Right (_constraints, typedExpr) ->
       fmap edAnnotation
         . discardLeft
         . interpret mempty
         . addEmptyStackFrames
         . void
+        . discardLeft
+        . passDictionaries typecheckEnv
         $ typedExpr
     Left e -> error (show e)
 

--- a/smol-core/test/Test/Interpreter/InterpreterSpec.hs
+++ b/smol-core/test/Test/Interpreter/InterpreterSpec.hs
@@ -10,8 +10,9 @@ import Smol.Core.Typecheck.FromParsedExpr
 import Test.Helpers
 import Test.Hspec
 
-doInterpret :: Text -> Expr ResolvedDep ()
-doInterpret =
+-- | interpret without typechecking etc
+doBasicInterpret :: Text -> Expr ResolvedDep ()
+doBasicInterpret =
   fmap edAnnotation
     . discardLeft
     . interpret mempty
@@ -45,7 +46,20 @@ spec = do
       traverse_
         ( \(input, expect) ->
             it (show input <> " = " <> show expect) $ do
-              doInterpret input
+              doBasicInterpret input
+                `shouldBe` fromParsedExpr (unsafeParseExpr expect)
+        )
+        cases
+
+    describe "interpret with typeclasses" $ do
+      let cases =
+            [ ("equals 1 1", "True"), -- use Eq Int
+              ("equals (1,1) (1,2)", "False") -- use Eq (a,b) and Eq Int (advanced, not ready for this yet)
+            ]
+      traverse_
+        ( \(input, expect) ->
+            it (show input <> " = " <> show expect) $ do
+              doBasicInterpret input
                 `shouldBe` fromParsedExpr (unsafeParseExpr expect)
         )
         cases

--- a/smol-core/test/Test/Interpreter/InterpreterSpec.hs
+++ b/smol-core/test/Test/Interpreter/InterpreterSpec.hs
@@ -8,7 +8,7 @@ import Data.Text (Text)
 import Smol.Core
 import Smol.Core.Interpreter.Types.Stack
 import Smol.Core.Typecheck.FromParsedExpr
-import Smol.Core.Typecheck.Typeclass
+import Smol.Core.Typecheck.Typecheck (typecheck)
 import Test.Helpers
 import Test.Hspec
 
@@ -29,15 +29,13 @@ discardLeft (Right a) = a
 -- | typecheck, resolve typeclasses, interpret, profit
 doInterpret :: Text -> Expr ResolvedDep ()
 doInterpret input =
-  case elaborate typecheckEnv (fromParsedExpr (unsafeParseExpr input)) of
-    Right (typedExpr, typeclassUses) ->
+  case typecheck typecheckEnv (fromParsedExpr (unsafeParseExpr input)) of
+    Right (_constraints, typedExpr ) ->
       fmap edAnnotation
         . discardLeft
         . interpret mempty
         . addEmptyStackFrames
         . void
-        . discardLeft
-        . inlineTypeclassFunctions typecheckEnv typeclassUses
         $ typedExpr
     Left e -> error (show e)
 

--- a/smol-core/test/Test/Interpreter/InterpreterSpec.hs
+++ b/smol-core/test/Test/Interpreter/InterpreterSpec.hs
@@ -71,11 +71,11 @@ spec = do
         cases
 
     -- not sure this is the way
-    xdescribe "interpret with typeclasses" $ do
+    describe "interpret with typeclasses" $ do
       let cases =
             [ ("equals (1 : Int) (1 : Int)", "True"), -- use Eq Int
               ("equals (2 : Int) (1 : Int)", "False"), -- use Eq Int
-              ("equals ((1 : Int),(1 : Int)) ((1 : Int), (2 : Int))", "False") -- use Eq (a,b) and Eq Int (advanced, not ready for this yet)
+              ("equals ((1 : Int),(1 : Int)) ((1 : Int), (2 : Int))", "False") -- use Eq (a,b) and Eq Int
             ]
       traverse_
         ( \(input, expect) ->

--- a/smol-core/test/Test/Interpreter/InterpreterSpec.hs
+++ b/smol-core/test/Test/Interpreter/InterpreterSpec.hs
@@ -70,7 +70,8 @@ spec = do
         )
         cases
 
-    describe "interpret with typeclasses" $ do
+    -- not sure this is the way
+    xdescribe "interpret with typeclasses" $ do
       let cases =
             [ ("equals (1 : Int) (1 : Int)", "True"), -- use Eq Int
               ("equals (2 : Int) (1 : Int)", "False"), -- use Eq Int

--- a/smol-core/test/Test/Modules/FromPartsSpec.hs
+++ b/smol-core/test/Test/Modules/FromPartsSpec.hs
@@ -14,7 +14,7 @@ spec = do
     describe "FromParts" $ do
       it "Test that refers to non-existent identifier" $ do
         let modParts = unsafeParseModuleItems (joinText ["test \"horses\" using missing"])
-            expected = VarNotFound "missing"
+            expected = ErrorInResolveDeps $ VarNotFound "missing"
 
         moduleFromModuleParts modParts `shouldBe` Left expected
 

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -70,12 +70,6 @@ spec = do
                 ],
                 "False"
               ),
-              ( [ "def uselessConstraint : (Eq a) => Int -> Int",
-                  "def uselessConstraint a = a + 1",
-                  "def main = uselessConstraint 100"
-                ],
-                "101"
-              ),
               ( ["def main = equals ((1:Int), (2: Int)) ((1: Int), (2: Int))"],
                 "True"
               ),

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -28,7 +28,7 @@ testInterpret input =
 spec :: Spec
 spec = do
   describe "Module InterpreterSpec" $ do
-    describe "interpret" $ do
+    fdescribe "interpret" $ do
       let cases =
             [ (["def main = 1 + 1"], "2"),
               ( [ "def id a = a",
@@ -42,8 +42,7 @@ spec = do
                 ],
                 "100"
               ),
-              ( [ "def main = useEquals",
-                  "def useEquals = equals (1: Int) (2: Int)"
+              ( [ "def main = equals (1: Int) (2: Int)"
                 ],
                 "False"
               )

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -36,7 +36,17 @@ spec = do
                 ],
                 "-10"
               ),
-              (["def id a = a", "def useId a = id a", "def main = useId 100"], "100")
+              ( [ "def id a = a",
+                  "def useId a = id a",
+                  "def main = useId 100"
+                ],
+                "100"
+              ),
+              ( [ "def main = useEquals",
+                  "def useEquals = equals (1: Int) (2: Int)"
+                ],
+                "False"
+              )
             ]
       traverse_
         ( \(parts, expect) ->

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -94,6 +94,13 @@ spec = do
                   "def main = equals (\"cat\" : String) (\"cat\" : String)"
                 ],
                 "True"
+              ),
+              ( [ "class Semigroup a { mappend: a -> a -> a }",
+                  "instance Semigroup Int = \\a -> \\b -> a + b",
+                  "def main : Bool",
+                  "def main = equals (mappend (20 : Int) (22 : Int)) (42 : Int)"
+                ],
+                "True"
               )
               {-
                   -- next we need to work out the dependencies of our typeclass

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -78,6 +78,13 @@ spec = do
               ),
               ( ["def main = equals ((1:Int),(2: Int)) ((1: Int), (2: Int))"],
                 "True"
+              ),
+              ( [ "def main : Bool",
+                  "def main = equals (1: Int) (2: Int)",
+                  "def useEqualsA : (Eq a) => a -> a -> Bool",
+                  "def useEqualsA a b = equals a b"
+                ],
+                "False"
               )
             ]
       traverse_

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -79,17 +79,31 @@ spec = do
                   "def useEquals a b = equals a b"
                 ],
                 "False"
-              ) {-,
-                ( [ "def main : Bool",
-                    "def main = notEquals (1: Int) (2: Int)",
-                    "def notEquals : (Eq a) => a -> a -> Bool",
-                    "def notEquals a b = if isEquals a b then False else True",
-                    "def isEquals : (Eq a) => a -> a -> Bool",
-                    "def isEquals a b = equals a b"
-
-                  ],
+              ),
+              ( [ "def main : Bool",
+                  "def main = notEquals (1: Int) (2: Int)",
+                  "def notEquals : (Eq a) => a -> a -> Bool",
+                  "def notEquals a b = if isEquals a b then False else True",
+                  "def isEquals : (Eq a) => a -> a -> Bool",
+                  "def isEquals a b = equals a b"
+                ],
+                "True"
+              ),
+              ( [ "instance Eq String = \\a -> \\b -> a == b",
+                  "def main : Bool",
+                  "def main = equals (\"cat\" : String) (\"cat\" : String)"
+                ],
+                "True"
+              )
+              {-
+                  -- next we need dependencies
+              ( ["type Pet = Dog | Cat | Rat",
+                  "instance Eq Pet = \\a -> \\b -> case (a,b) of (Dog,Dog) -> True | (Cat, Cat) -> True | (Rat,Rat) -> True | _ -> False",
+                  "def main : Bool",
+                  "def main = equals Dog Cat"],
                   "False"
-                )-}
+
+              ) -}
             ]
       traverse_
         ( \(parts, expect) ->

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -32,7 +32,7 @@ testInterpret input =
 
 spec :: Spec
 spec = do
-  describe "Module InterpreterSpec" $ do
+  fdescribe "Module InterpreterSpec" $ do
     describe "interpret" $ do
       let cases =
             [ (["def main = 1 + 1"], "2"),

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -76,16 +76,27 @@ spec = do
                 ],
                 "101"
               ),
-              ( ["def main = equals ((1:Int),(2: Int)) ((1: Int), (2: Int))"],
+              ( ["def main = equals ((1:Int), (2: Int)) ((1: Int), (2: Int))"],
                 "True"
               ),
               ( [ "def main : Bool",
-                  "def main = equals (1: Int) (2: Int)",
-                  "def useEqualsA : (Eq a) => a -> a -> Bool",
-                  "def useEqualsA a b = equals a b"
+                  "def main = useEquals (1: Int) (2: Int)",
+                  "def useEquals : (Eq a) => a -> a -> Bool",
+                  "def useEquals a b = equals a b"
                 ],
                 "False"
-              )
+              ){-,
+              ( [ "def main : Bool",
+                  "def main = notEquals (1: Int) (2: Int)",
+                  "def notEquals : (Eq a) => a -> a -> Bool",
+                  "def notEquals a b = if isEquals a b then False else True",
+                  "def isEquals : (Eq a) => a -> a -> Bool",
+                  "def isEquals a b = equals a b"
+
+                ],
+                "False"
+              )-}
+
             ]
       traverse_
         ( \(parts, expect) ->

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Modules.InterpreterSpec (spec) where
-import Error.Diagnose (defaultStyle, printDiagnostic, stdout)
-import Smol.Core.Helpers
+
 import Control.Monad (void)
 import Data.Foldable (traverse_)
 import Data.Text (Text)
+import Error.Diagnose (defaultStyle, printDiagnostic, stdout)
 import Smol.Core
 import Smol.Core.Modules.Check
 import Smol.Core.Modules.Interpret
@@ -13,10 +13,9 @@ import Smol.Core.Modules.Types.ModuleError
 import Smol.Core.Typecheck.FromParsedExpr
 import Test.Helpers
 import Test.Hspec
-import Smol.Core.Modules.Types
 
-showModuleError :: ModuleError Annotation -> IO () 
-showModuleError modErr = 
+showModuleError :: ModuleError Annotation -> IO ()
+showModuleError modErr =
   printDiagnostic stdout True True 2 defaultStyle (moduleErrorDiagnostic modErr)
 
 testInterpret ::
@@ -28,7 +27,6 @@ testInterpret input =
   case parseModuleAndFormatError input of
     Right moduleParts -> do
       goodModule <- checkModule input moduleParts
-      tracePrettyM "checked module" (getExprAnnotation . tleExpr <$> moExpressions goodModule)
       fmap void (interpretModule "main" (fmap getTypeAnnotation goodModule))
     Left e -> error (show e)
 
@@ -58,6 +56,13 @@ spec = do
                 ],
                 "False"
               ),
+              ( [ "def useEquals : Int -> Bool",
+                  "def useEquals a = equals a (1: Int)",
+                  "def main : Bool",
+                  "def main = useEquals 2"
+                ],
+                "False"
+              ),
               ( [ "def useEquals : Bool -> Bool",
                   "def useEquals a = equals (2: Int) (1: Int)",
                   "def main : Bool",
@@ -65,10 +70,14 @@ spec = do
                 ],
                 "False"
               ),
-              (
-                ["def uselessConstraint : (Eq a) => Int -> Int",
-                "def uselessConstraint a = a + 1",
-                "def main = uselessConstraint 100"],"101")
+              ( [ "def uselessConstraint : (Eq a) => Int -> Int",
+                  "def uselessConstraint a = a + 1",
+                  "def main = uselessConstraint 100"
+                ],
+                "101"
+              ),
+              ( [ "def main = equals ((1:Int),(2: Int)) ((1: Int), (2: Int))" ],
+                "True")
             ]
       traverse_
         ( \(parts, expect) ->
@@ -76,7 +85,7 @@ spec = do
              in it (show input <> " = " <> show expect) $ do
                   let expected :: Expr ResolvedDep ()
                       expected = void (fromParsedExpr (unsafeParseExpr expect))
-                  
+
                   let result = testInterpret input
                   case result of
                     Left e -> showModuleError e

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -96,7 +96,8 @@ spec = do
                 "True"
               )
               {-
-                  -- next we need dependencies
+                  -- next we need to work out the dependencies of our typeclass
+                  -- functions
               ( ["type Pet = Dog | Cat | Rat",
                   "instance Eq Pet = \\a -> \\b -> case (a,b) of (Dog,Dog) -> True | (Cat, Cat) -> True | (Rat,Rat) -> True | _ -> False",
                   "def main : Bool",

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -33,7 +33,7 @@ testInterpret input =
 spec :: Spec
 spec = do
   describe "Module InterpreterSpec" $ do
-    fdescribe "interpret" $ do
+    describe "interpret" $ do
       let cases =
             [ (["def main = 1 + 1"], "2"),
               ( [ "def id a = a",

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -85,18 +85,17 @@ spec = do
                   "def useEquals a b = equals a b"
                 ],
                 "False"
-              ){-,
-              ( [ "def main : Bool",
-                  "def main = notEquals (1: Int) (2: Int)",
-                  "def notEquals : (Eq a) => a -> a -> Bool",
-                  "def notEquals a b = if isEquals a b then False else True",
-                  "def isEquals : (Eq a) => a -> a -> Bool",
-                  "def isEquals a b = equals a b"
+              ) {-,
+                ( [ "def main : Bool",
+                    "def main = notEquals (1: Int) (2: Int)",
+                    "def notEquals : (Eq a) => a -> a -> Bool",
+                    "def notEquals a b = if isEquals a b then False else True",
+                    "def isEquals : (Eq a) => a -> a -> Bool",
+                    "def isEquals a b = equals a b"
 
-                ],
-                "False"
-              )-}
-
+                  ],
+                  "False"
+                )-}
             ]
       traverse_
         ( \(parts, expect) ->

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -32,7 +32,7 @@ testInterpret input =
 
 spec :: Spec
 spec = do
-  fdescribe "Module InterpreterSpec" $ do
+  describe "Module InterpreterSpec" $ do
     describe "interpret" $ do
       let cases =
             [ (["def main = 1 + 1"], "2"),

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -76,8 +76,9 @@ spec = do
                 ],
                 "101"
               ),
-              ( [ "def main = equals ((1:Int),(2: Int)) ((1: Int), (2: Int))" ],
-                "True")
+              ( ["def main = equals ((1:Int),(2: Int)) ((1: Int), (2: Int))"],
+                "True"
+              )
             ]
       traverse_
         ( \(parts, expect) ->

--- a/smol-core/test/Test/Modules/ResolveDepsSpec.hs
+++ b/smol-core/test/Test/Modules/ResolveDepsSpec.hs
@@ -14,7 +14,7 @@ import Test.Hspec
 spec :: Spec
 spec = do
   describe "Modules" $ do
-    fdescribe "ResolvedDeps" $ do
+    describe "ResolvedDeps" $ do
       it "No deps, marks var as unique" $ do
         let mod' = unsafeParseModule "def main = let a = 123 in a"
             expr =

--- a/smol-core/test/Test/Modules/ResolveDepsSpec.hs
+++ b/smol-core/test/Test/Modules/ResolveDepsSpec.hs
@@ -26,7 +26,7 @@ spec = do
 
             expected =
               mempty
-                { moExpressions = M.singleton "main" (TopLevelExpression expr Nothing)
+                { moExpressions = M.singleton "main" (TopLevelExpression mempty expr Nothing)
                 }
 
         fst <$> resolveModuleDeps mempty mod' `shouldBe` Right expected
@@ -46,7 +46,7 @@ spec = do
             typeclassMethods = S.singleton "equals"
             expected =
               mempty
-                { moExpressions = M.singleton "main" (TopLevelExpression expr Nothing)
+                { moExpressions = M.singleton "main" (TopLevelExpression mempty expr Nothing)
                 }
 
         fst <$> resolveModuleDeps typeclassMethods mod' `shouldBe` Right expected
@@ -67,7 +67,7 @@ spec = do
 
             expected =
               mempty
-                { moExpressions = M.singleton "main" (TopLevelExpression expr Nothing)
+                { moExpressions = M.singleton "main" (TopLevelExpression mempty expr Nothing)
                 }
 
         fst <$> resolveModuleDeps mempty mod' `shouldBe` Right expected
@@ -78,7 +78,7 @@ spec = do
 
             expected =
               mempty
-                { moExpressions = M.singleton "main" (TopLevelExpression expr Nothing)
+                { moExpressions = M.singleton "main" (TopLevelExpression mempty expr Nothing)
                 }
 
         fst <$> resolveModuleDeps mempty mod' `shouldBe` Right expected
@@ -97,7 +97,7 @@ spec = do
                 )
             expected =
               mempty
-                { moExpressions = M.singleton "main" (TopLevelExpression expr Nothing)
+                { moExpressions = M.singleton "main" (TopLevelExpression mempty expr Nothing)
                 }
 
         fst <$> resolveModuleDeps mempty mod' `shouldBe` Right expected
@@ -121,8 +121,8 @@ spec = do
               mempty
                 { moExpressions =
                     M.fromList
-                      [ ("main", TopLevelExpression mainExpr Nothing),
-                        ("dep", TopLevelExpression depExpr Nothing)
+                      [ ("main", TopLevelExpression mempty mainExpr Nothing),
+                        ("dep", TopLevelExpression mempty depExpr Nothing)
                       ]
                 }
 
@@ -144,7 +144,7 @@ spec = do
             expected =
               mempty
                 { moExpressions =
-                    M.singleton "main" (TopLevelExpression mainExpr Nothing),
+                    M.singleton "main" (TopLevelExpression mempty mainExpr Nothing),
                   moDataTypes =
                     M.singleton
                       "Moybe"

--- a/smol-core/test/Test/Modules/TypecheckSpec.hs
+++ b/smol-core/test/Test/Modules/TypecheckSpec.hs
@@ -106,3 +106,6 @@ spec = do
 
       it "Typechecks State successfully" $ do
         testModuleTypecheck "State" `shouldSatisfy` isRight
+
+      it "Typechecks Eq successfully" $ do
+        testModuleTypecheck "Eq" `shouldSatisfy` isRight

--- a/smol-core/test/Test/Modules/TypecheckSpec.hs
+++ b/smol-core/test/Test/Modules/TypecheckSpec.hs
@@ -109,3 +109,6 @@ spec = do
 
       it "Typechecks Eq successfully" $ do
         testModuleTypecheck "Eq" `shouldSatisfy` isRight
+
+      it "Typechecks Semigroup successfully" $ do
+        testModuleTypecheck "Semigroup" `shouldSatisfy` isRight

--- a/smol-core/test/Test/ParserSpec.hs
+++ b/smol-core/test/Test/ParserSpec.hs
@@ -51,7 +51,9 @@ spec = do
               "def compose : (c -> b) -> (a -> b) -> (a -> c)",
               "def onePlusOneEqualsTwo = 1 + 1 == 2",
               "test \"one plus one equals two\" using onePlusOneEqualsTwo",
-              "def usesEquals : (Eq (a,b)) => (a,b) -> (a,b) -> Bool"
+              "def usesEquals : (Eq (a,b)) => (a,b) -> (a,b) -> Bool",
+              "class Eq a { equals: a -> a -> Bool }",
+              "instance Eq Int using eqInt"
             ]
 
       it "All defs" $ do

--- a/smol-core/test/Test/ParserSpec.hs
+++ b/smol-core/test/Test/ParserSpec.hs
@@ -53,7 +53,7 @@ spec = do
               "test \"one plus one equals two\" using onePlusOneEqualsTwo",
               "def usesEquals : (Eq (a,b)) => (a,b) -> (a,b) -> Bool",
               "class Eq a { equals: a -> a -> Bool }",
-              "instance Eq Int using eqInt"
+              "instance Eq Int = eqInt"
             ]
 
       it "All defs" $ do

--- a/smol-core/test/Test/ParserSpec.hs
+++ b/smol-core/test/Test/ParserSpec.hs
@@ -26,7 +26,7 @@ testInputs =
 spec :: Spec
 spec = do
   describe "Parser" $ do
-    describe "Module" $ do
+    fdescribe "Module" $ do
       let singleDefs =
             [ "type Dog a = Woof String | Other a",
               "def id : a -> a",
@@ -34,7 +34,8 @@ spec = do
               "def compose f g a = f (g a)",
               "def compose : (c -> b) -> (a -> b) -> (a -> c)",
               "def onePlusOneEqualsTwo = 1 + 1 == 2",
-              "test \"one plus one equals two\" using onePlusOneEqualsTwo"
+              "test \"one plus one equals two\" using onePlusOneEqualsTwo",
+              "def usesEquals : (Eq (a,b)) => (a,b) -> (a,b) -> Bool"
             ]
 
       it "All defs" $ do

--- a/smol-core/test/Test/ParserSpec.hs
+++ b/smol-core/test/Test/ParserSpec.hs
@@ -26,6 +26,13 @@ testInputs =
 spec :: Spec
 spec = do
   describe "Parser" $ do
+    fdescribe "Constraint" $ do
+      let inputs = [ ("Eq Int", Constraint "Eq" [tyInt]) ]
+      traverse_
+        (\(input, expected) ->
+          parseConstraintAndFormatError input `shouldBe` Right expected
+          ) inputs
+
     fdescribe "Module" $ do
       let singleDefs =
             [ "type Dog a = Woof String | Other a",

--- a/smol-core/test/Test/ParserSpec.hs
+++ b/smol-core/test/Test/ParserSpec.hs
@@ -27,11 +27,13 @@ spec :: Spec
 spec = do
   describe "Parser" $ do
     fdescribe "Constraint" $ do
-      let inputs = [ ("Eq Int", Constraint "Eq" [tyInt]) ]
+      let inputs = [("Eq Int", Constraint "Eq" [tyInt])]
       traverse_
-        (\(input, expected) ->
-          parseConstraintAndFormatError input `shouldBe` Right expected
-          ) inputs
+        ( \(input, expected) ->
+            it (T.unpack $ "Parses constraint: " <> input) $ do
+              parseConstraintAndFormatError input `shouldBe` Right expected
+        )
+        inputs
 
     fdescribe "Module" $ do
       let singleDefs =

--- a/smol-core/test/Test/ParserSpec.hs
+++ b/smol-core/test/Test/ParserSpec.hs
@@ -26,8 +26,15 @@ testInputs =
 spec :: Spec
 spec = do
   describe "Parser" $ do
-    fdescribe "Constraint" $ do
-      let inputs = [("Eq Int", Constraint "Eq" [tyInt])]
+    describe "Constraint" $ do
+      let inputs =
+            [ ( "Eq Int",
+                Constraint "Eq" [tyInt]
+              ),
+              ( "Eq (a,b)",
+                Constraint "Eq" [tyTuple (tcVar "a") [tcVar "b"]]
+              )
+            ]
       traverse_
         ( \(input, expected) ->
             it (T.unpack $ "Parses constraint: " <> input) $ do
@@ -35,7 +42,7 @@ spec = do
         )
         inputs
 
-    fdescribe "Module" $ do
+    describe "Module" $ do
       let singleDefs =
             [ "type Dog a = Woof String | Other a",
               "def id : a -> a",

--- a/smol-core/test/Test/Typecheck/ExhaustivenessSpec.hs
+++ b/smol-core/test/Test/Typecheck/ExhaustivenessSpec.hs
@@ -15,7 +15,7 @@ import Test.Helpers
 import Test.Hspec
 
 env :: (Monoid ann, Ord ann) => TCEnv ann
-env = TCEnv mempty mempty (builtInTypes emptyResolvedDep) mempty mempty
+env = TCEnv mempty mempty (builtInTypes emptyResolvedDep) mempty mempty mempty
 
 type PatternM = ExceptT (TCError Annotation) (Reader (TCEnv Annotation))
 

--- a/smol-core/test/Test/Typecheck/ExhaustivenessSpec.hs
+++ b/smol-core/test/Test/Typecheck/ExhaustivenessSpec.hs
@@ -15,7 +15,7 @@ import Test.Helpers
 import Test.Hspec
 
 env :: (Monoid ann, Ord ann) => TCEnv ann
-env = TCEnv mempty mempty (builtInTypes emptyResolvedDep) mempty mempty mempty
+env = TCEnv mempty (builtInTypes emptyResolvedDep) mempty mempty mempty
 
 type PatternM = ExceptT (TCError Annotation) (Reader (TCEnv Annotation))
 

--- a/smol-core/test/Test/Typecheck/ExhaustivenessSpec.hs
+++ b/smol-core/test/Test/Typecheck/ExhaustivenessSpec.hs
@@ -14,8 +14,8 @@ import Test.BuiltInTypes
 import Test.Helpers
 import Test.Hspec
 
-env :: (Monoid ann) => TCEnv ann
-env = TCEnv mempty mempty (builtInTypes emptyResolvedDep)
+env :: (Monoid ann, Ord ann) => TCEnv ann
+env = TCEnv mempty mempty (builtInTypes emptyResolvedDep) mempty mempty
 
 type PatternM = ExceptT (TCError Annotation) (Reader (TCEnv Annotation))
 

--- a/smol-core/test/Test/Typecheck/PatternSpec.hs
+++ b/smol-core/test/Test/Typecheck/PatternSpec.hs
@@ -11,7 +11,7 @@ import Test.Hspec
 spec :: Spec
 spec = do
   describe "checkPattern" $ do
-    let emptyEnv = TCEnv mempty mempty (builtInTypes emptyResolvedDep) mempty mempty
+    let emptyEnv = TCEnv mempty mempty (builtInTypes emptyResolvedDep) mempty mempty mempty
     it "PVar" $ do
       snd <$> runTypecheckM emptyEnv (checkPattern tyInt (PVar () "a"))
         `shouldBe` Right

--- a/smol-core/test/Test/Typecheck/PatternSpec.hs
+++ b/smol-core/test/Test/Typecheck/PatternSpec.hs
@@ -11,7 +11,7 @@ import Test.Hspec
 spec :: Spec
 spec = do
   describe "checkPattern" $ do
-    let emptyEnv = TCEnv mempty mempty (builtInTypes emptyResolvedDep)
+    let emptyEnv = TCEnv mempty mempty (builtInTypes emptyResolvedDep) mempty mempty
     it "PVar" $ do
       snd <$> runTypecheckM emptyEnv (checkPattern tyInt (PVar () "a"))
         `shouldBe` Right

--- a/smol-core/test/Test/Typecheck/PatternSpec.hs
+++ b/smol-core/test/Test/Typecheck/PatternSpec.hs
@@ -11,7 +11,7 @@ import Test.Hspec
 spec :: Spec
 spec = do
   describe "checkPattern" $ do
-    let emptyEnv = TCEnv mempty mempty (builtInTypes emptyResolvedDep) mempty mempty mempty
+    let emptyEnv = TCEnv mempty (builtInTypes emptyResolvedDep) mempty mempty mempty
     it "PVar" $ do
       snd <$> runTypecheckM emptyEnv (checkPattern tyInt (PVar () "a"))
         `shouldBe` Right

--- a/smol-core/test/Test/Typecheck/SubtypeSpec.hs
+++ b/smol-core/test/Test/Typecheck/SubtypeSpec.hs
@@ -152,7 +152,8 @@ spec = do
                 ("Maybe 1", "Maybe a"),
                 ("{ item: 1 }", "{}"),
                 ("[1 | 2]", "[Int]"),
-                ("1", "1 | 2")
+                ("1", "1 | 2"),
+                ("(Int,Int)", "(a,b)")
               ]
         traverse_
           ( \(lhs, rhs) -> it (show lhs <> " <: " <> show rhs) $ do

--- a/smol-core/test/Test/Typecheck/SubtypeSpec.hs
+++ b/smol-core/test/Test/Typecheck/SubtypeSpec.hs
@@ -40,7 +40,7 @@ spec = do
         it "Maybe Nat <: Maybe i1" $ do
           let one = fromParsedType $ tyCons "Maybe" [tyInt]
               two = fromParsedType $ tyCons "Maybe" [tyUnknown 1]
-              expected = (one, [Substitution (SubUnknown 1) (TPrim () TPInt)])
+              expected = (one, [TCWSubstitution $ Substitution (SubUnknown 1) (TPrim () TPInt)])
 
           runWriterT (one `isSubtypeOf` two)
             `shouldBe` Right expected
@@ -48,7 +48,7 @@ spec = do
         it "Maybe Nat <: i1" $ do
           let one = fromParsedType $ tyCons "Maybe" [tyInt]
               two = fromParsedType $ TUnknown () 1
-              expected = (one, [Substitution (SubUnknown 1) one])
+              expected = (one, [TCWSubstitution $ Substitution (SubUnknown 1) one])
 
           runWriterT (one `isSubtypeOf` two)
             `shouldBe` Right expected
@@ -58,8 +58,8 @@ spec = do
               two = fromParsedType $ TApp () (TVar () "a") (TVar () "b")
               expected =
                 ( one,
-                  [ Substitution (SubId "a") (TConstructor () "Maybe"),
-                    Substitution (SubId "b") (TPrim () TPInt)
+                  [ TCWSubstitution $ Substitution (SubId "a") (TConstructor () "Maybe"),
+                    TCWSubstitution $ Substitution (SubId "b") (TPrim () TPInt)
                   ]
                 )
 
@@ -71,8 +71,8 @@ spec = do
               two = fromParsedType $ TApp () (TUnknown () 1) (TUnknown () 2)
               expected =
                 ( one,
-                  [ Substitution (SubUnknown 1) (TConstructor () "Maybe"),
-                    Substitution (SubUnknown 2) (TPrim () TPInt)
+                  [ TCWSubstitution $ Substitution (SubUnknown 1) (TConstructor () "Maybe"),
+                    TCWSubstitution $ Substitution (SubUnknown 2) (TPrim () TPInt)
                   ]
                 )
 
@@ -83,7 +83,7 @@ spec = do
           let maybeNat = tyCons "Maybe" [tyInt]
               one = fromParsedType $ TFunc () mempty (tyVar "a") maybeNat
               two = fromParsedType $ TFunc () mempty (tyVar "a") (TUnknown () 1)
-              expected = (one, [Substitution (SubUnknown 1) (fromParsedType maybeNat)])
+              expected = (one, [TCWSubstitution $ Substitution (SubUnknown 1) (fromParsedType maybeNat)])
 
           runWriterT (one `isSubtypeOf` two)
             `shouldBe` Right expected

--- a/smol-core/test/Test/Typecheck/TypeclassSpec.hs
+++ b/smol-core/test/Test/Typecheck/TypeclassSpec.hs
@@ -7,6 +7,7 @@
 
 module Test.Typecheck.TypeclassSpec (spec) where
 
+import qualified Data.List.NonEmpty as NE
 import Control.Monad.Identity
 import Data.Bifunctor (bimap)
 import Data.Either
@@ -244,14 +245,14 @@ spec = do
 
   describe "Get dictionaries" $ do
     it "Single item dictionary for single constraint" $ do
-      let constraints = [Constraint "Eq" [tyInt]]
+      let constraints = NE.fromList [Constraint "Eq" [tyInt]]
           expected = evalExprUnsafe "(\\a1 -> \\b2 -> a1 == b2 : Int -> Int -> Bool)"
 
       fmap simplify (createTypeclassDict typecheckEnv constraints)
         `shouldBe` simplify <$> expected
 
     it "Tuple for two constraints" $ do
-      let constraints = [Constraint "Eq" [tyInt], Constraint "Eq" [tyInt]]
+      let constraints = NE.fromList [Constraint "Eq" [tyInt], Constraint "Eq" [tyInt]]
           expected = evalExprUnsafe "((\\a1 -> \\b2 -> a1 == b2 : Int -> Int -> Bool), (\\a1 -> \\b2 -> a1 == b2 : Int -> Int -> Bool))"
 
       fmap simplify (createTypeclassDict typecheckEnv constraints)

--- a/smol-core/test/Test/Typecheck/TypeclassSpec.hs
+++ b/smol-core/test/Test/Typecheck/TypeclassSpec.hs
@@ -336,11 +336,12 @@ spec = do
               expected = joinText expectedParts
            in it ("Successfully inlined " <> show input) $ do
                 let (expr, typeclassUses) = getRight $ evalExpr constraints varsInScope input
+                let env = typecheckEnv {tceVars = varsInScope}
 
                 let expectedExpr = getRight $ evalExprUnsafe varsInScope expected
                     (dedupedConstraints, tidyExpr) = deduplicateConstraints typeclassUses expr
                     allConstraints = nub (dedupedConstraints <> constraints) -- we lose outer constraints sometimes
-                    result = toDictionaryPassing varsInScope (tceInstances typecheckEnv) allConstraints tidyExpr
+                    result = toDictionaryPassing env allConstraints tidyExpr
 
                 simplify <$> result `shouldBe` Right (simplify expectedExpr)
       )

--- a/smol-core/test/Test/Typecheck/TypeclassSpec.hs
+++ b/smol-core/test/Test/Typecheck/TypeclassSpec.hs
@@ -7,6 +7,7 @@
 
 module Test.Typecheck.TypeclassSpec (spec) where
 
+import Smol.Core.Helpers
 import Control.Monad.Identity
 import qualified Data.Char as Char
 import Data.Either
@@ -249,14 +250,16 @@ spec = do
              in it ("Successfully inlined " <> show input) $ do
                   let expr = getRight $ evalExpr input
                       expectedExpr = getRight $ evalExprUnsafe expected
-                  simplify <$> (inlineTypeclassFunctions typecheckEnv typeclasses expr)
-                    `shouldBe` Right (simplify expectedExpr)
+                      result = inlineTypeclassFunctions typecheckEnv typeclasses expr
+                  tracePrettyM "expected" expectedExpr
+                  tracePrettyM "result" (getRight result)
+                  simplify <$> result `shouldBe` Right (simplify expectedExpr)
         )
         [ (mempty, ["1 + 2"], ["1 + 2"]),
-          ( M.singleton "blah1" (Constraint "Eq" [tyInt]),
+          ( M.singleton (TypeclassCall "equals" 1) (Constraint "Eq" [tyInt]),
             ["equals (1: Int) (2: Int)"],
-            [ "\\instances -> case (instances : Int -> Int -> Bool) of tcequals1 ->",
-              "tcequals1 (1 : Int) (2 : Int)"
+            [ "\\instances -> case (instances : Int -> Int -> Bool) of tcnewname1 ->",
+              "tcnewname1 (1 : Int) (2 : Int)"
             ]
           ),
           ( M.fromList

--- a/smol-core/test/Test/Typecheck/TypeclassSpec.hs
+++ b/smol-core/test/Test/Typecheck/TypeclassSpec.hs
@@ -257,6 +257,13 @@ spec = do
 
       simplify <$> createTypeclassDict typecheckEnv constraints `shouldBe` simplify <$> expected
 
+  describe "isConcrete" $ do
+    it "yes, because it has no vars" $ do
+      isConcrete @() (Constraint "Eq" [tyInt]) `shouldBe` True
+
+    it "no, because it has a var" $ do
+      isConcrete @() (Constraint "Eq" [tcVar "a"]) `shouldBe` False
+
   describe "Convert expr to use typeclass dictionaries" $ do
     traverse_
       ( \(typeclasses, parts, expectedConstraints, expectedParts) ->

--- a/smol-core/test/Test/Typecheck/TypeclassSpec.hs
+++ b/smol-core/test/Test/Typecheck/TypeclassSpec.hs
@@ -7,45 +7,35 @@
 
 module Test.Typecheck.TypeclassSpec (spec) where
 
-import Smol.Core.Helpers
 import Control.Monad.Identity
-import qualified Data.Char as Char
+import Data.Bifunctor (bimap)
 import Data.Either
 import Data.Foldable (traverse_)
 import Data.Functor
 import qualified Data.Map.Strict as M
+import Data.String (fromString)
 import Data.Text (Text)
 import Smol.Core
+import Smol.Core.Helpers
 import Smol.Core.Modules.ResolveDeps
 import Smol.Core.Typecheck.FromParsedExpr (fromParsedExpr)
 import Smol.Core.Typecheck.Typeclass
 import Test.Helpers
 import Test.Hspec
 
--- this is really grubby, soz
-unresolve :: (Show a) => ResolvedDep a -> String
-unresolve (LocalDefinition a) = filter Char.isAlphaNum (show a)
-unresolve (UniqueDefinition a i) = filter Char.isAlphaNum (show a <> show i)
-unresolve (TypeclassCall a i) = filter Char.isAlphaNum ("tc" <> show a <> show i)
-
-newtype CompareWrapper a = CompareWrapper (ResolvedDep a)
-  deriving newtype (Ord, Show)
-
-instance (Show a) => Eq (CompareWrapper a) where
-  (CompareWrapper a) == (CompareWrapper b) =
-    unresolve a == unresolve b
-
 evalExpr ::
+  [Constraint Annotation] ->
   Text ->
   Either (TCError Annotation) (ResolvedExpr (Type ResolvedDep Annotation))
-evalExpr input = case parseExprAndFormatError input of
-  Left e -> error (show e)
-  Right expr ->
-    case resolveExprDeps expr (getTypeclassMethodNames @() typecheckEnv) of
-      Left e -> error (show e)
-      Right resolvedExpr -> case elaborate typecheckEnv resolvedExpr of
-        Right (typedExpr, _typeclassUses) -> pure typedExpr
-        Left e -> Left e
+evalExpr constraints input =
+  case parseExprAndFormatError input of
+    Left e -> error (show e)
+    Right expr ->
+      case resolveExprDeps expr (getTypeclassMethodNames @() typecheckEnv) of
+        Left e -> error $ "error getting method names :" <> show e
+        Right resolvedExpr -> case elaborate (typecheckEnv {tceConstraints = constraints}) resolvedExpr of
+          Right (typedExpr, _typeclassUses) -> pure typedExpr
+          Left e -> Left e
 
 -- | elaborate but don't do clever resolving so we can construct the
 -- expectations we want
@@ -65,219 +55,237 @@ getRight (Left e) = error (show e)
 
 spec :: Spec
 spec = do
-  describe "TypeclassSpec" $ do
-    describe "recoverTypeclassUses" $ do
-      it "No classes, nothing to find" $ do
-        recoverTypeclassUses @() [] `shouldBe` mempty
-      it "Uses Eq Int" $ do
-        recoverTypeclassUses @()
-          [ TCWTypeclassUse (UniqueDefinition "a" 123) "Eq" [("a", 10)],
-            TCWSubstitution (Substitution (SubUnknown 10) tyInt)
-          ]
-          `shouldBe` M.singleton (UniqueDefinition "a" 123) (Constraint "Eq" [tyInt])
-
-    describe "instanceMatchesType" $ do
-      it "Eq (a,Bool) does not match Eq (Int, Int)" $ do
-        instanceMatchesType @() [tyTuple tyInt [tyInt]] [tyTuple (tcVar "a") [tyBool]]
-          `shouldBe` Left (tyInt, tyBool)
-
-      it "Eq (a,b) matches Eq (Int, Int)" $ do
-        instanceMatchesType @() [tyTuple tyInt [tyInt]] [tyTuple (tcVar "a") [tcVar "b"]]
-          `shouldBe` Right
-            [ Substitution (SubId (Identity "a")) tyInt,
-              Substitution (SubId (Identity "b")) tyInt
-            ]
-
-    describe "lookupTypeclassInstance" $ do
-      it "Is not there" $ do
-        lookupTypeclassInstance @() typecheckEnv (Constraint "Eq" [tyBool])
-          `shouldSatisfy` isLeft
-
-      it "Is there" $ do
-        let result = lookupTypeclassInstance @() typecheckEnv (Constraint "Eq" [tyInt])
-        inConstraints <$> result `shouldBe` Right []
-
-      it "Nested item is there" $ do
-        let result = lookupTypeclassInstance @() typecheckEnv (Constraint "Eq" [tyTuple tyInt [tyInt]])
-        inConstraints <$> result `shouldBe` Right [Constraint "Eq" [tyInt], Constraint "Eq" [tyInt]]
-
-      it "Doubly nested item is there" $ do
-        let result = lookupTypeclassInstance @() typecheckEnv (Constraint "Eq" [tyTuple tyInt [tyTuple tyInt [tyInt]]])
-        result `shouldSatisfy` isRight
-
-      it "Other nested item is there" $ do
-        lookupTypeclassInstance @() typecheckEnv (Constraint "Eq" [tyTuple tyBool [tyInt]])
-          `shouldSatisfy` isLeft
-
-    describe "lookupTypeclassConstraint" $ do
-      it "Is not there" $ do
-        lookupTypeclassConstraint @() typecheckEnv (Constraint "Eq" [tcVar "a"])
-          `shouldSatisfy` isLeft
-
-      it "Is there" $ do
-        let tcEnvWithConstraint = typecheckEnv {tceConstraints = [Constraint "Eq" [tcVar "a"]]}
-        lookupTypeclassConstraint @() tcEnvWithConstraint (Constraint "Eq" [tcVar "a"])
-          `shouldSatisfy` isRight
-
-    describe "Check instances" $ do
-      it "Good Show instance" $ do
-        checkInstance @()
-          typecheckEnv
-          showTypeclass
-          (Constraint "Show" [tyUnit])
-          ( Instance
-              { inExpr = unsafeParseInstanceExpr "\\a -> \"Unit\"",
-                inConstraints = []
-              }
-          )
-          `shouldSatisfy` isRight
-
-      it "Bad Show instance" $ do
-        checkInstance @()
-          typecheckEnv
-          showTypeclass
-          (Constraint "Show" [tyUnit])
-          ( Instance
-              { inExpr = unsafeParseInstanceExpr "\\a -> 123",
-                inConstraints = []
-              }
-          )
-          `shouldSatisfy` isLeft
-
-      it "Good Eq instance" $ do
-        checkInstance @()
-          typecheckEnv
-          eqTypeclass
-          (Constraint "Eq" [tyInt])
-          ( Instance
-              { inExpr = unsafeParseInstanceExpr "\\a -> \\b -> a == b",
-                inConstraints = []
-              }
-          )
-          `shouldSatisfy` isRight
-
-      it "Bad Eq instance" $ do
-        checkInstance @()
-          typecheckEnv
-          eqTypeclass
-          (Constraint "Show" [tyUnit])
-          ( Instance
-              { inExpr = unsafeParseInstanceExpr "\\a -> \\b -> 123",
-                inConstraints = []
-              }
-          )
-          `shouldSatisfy` isLeft
-
-      it "Tuple Eq instance" $ do
-        checkInstance @()
-          typecheckEnv
-          eqTypeclass
-          (Constraint "Eq" [tyTuple (tcVar "a") [tcVar "b"]])
-          ( Instance
-              { inExpr =
-                  unsafeParseInstanceExpr "\\a -> \\b -> case (a,b) of ((a1, a2), (b1, b2)) -> if equals a1 b1 then equals a2 b2 else False",
-                inConstraints =
-                  [ Constraint "Eq" [tcVar "a"],
-                    Constraint "Eq" [tcVar "b"]
-                  ]
-              }
-          )
-          `shouldSatisfy` isRight
-
-      it "Tuple Eq instance missing a constraint" $ do
-        checkInstance @()
-          typecheckEnv
-          eqTypeclass
-          (Constraint "Eq" [tyTuple (tcVar "a") [tcVar "b"]])
-          ( Instance
-              { inExpr =
-                  unsafeParseInstanceExpr "\\a -> \\b -> case (a,b) of ((a1, a2), (b1, b2)) -> if equals a1 b1 then equals a2 b2 else False",
-                inConstraints =
-                  [ Constraint "Eq" [tcVar "a"]
-                  ]
-              }
-          )
-          `shouldSatisfy` isLeft
-
-    fdescribe "dedupeConstraints" $ do
-      it "Empty is empty" $ do
-        dedupeConstraints @() mempty `shouldBe` (mempty, mempty)
-
-      it "One is one and gets a new name" $ do
-        dedupeConstraints @() (M.singleton "oldname" (Constraint "Eq" [tyInt]))
-          `shouldBe` ( [ ( TypeclassCall "newname" 1,
-                           Constraint "Eq" [tyInt]
-                         )
-                       ],
-                       M.singleton "oldname" (TypeclassCall "newname" 1)
-                     )
-
-      it "Two functions, each used twice become one of each" $ do
-        dedupeConstraints @()
-          ( M.fromList
-              [ ("eqInt1", Constraint "Eq" [tyInt]),
-                ("eqInt2", Constraint "Eq" [tyInt]),
-                ("eqBool1", Constraint "Eq" [tyBool]),
-                ("eqBool2", Constraint "Eq" [tyBool])
-              ]
-          )
-          `shouldBe` ( [ ( TypeclassCall "newname" 1,
-                           Constraint "Eq" [tyInt]
-                         ),
-                         ( TypeclassCall "newname" 2,
-                           Constraint "Eq" [tyBool]
-                         )
-                       ],
-                       M.fromList
-                         [ ("eqInt1", TypeclassCall "newname" 1),
-                           ("eqInt2", TypeclassCall "newname" 1),
-                           ("eqBool1", TypeclassCall "newname" 2),
-                           ("eqBool2", TypeclassCall "newname" 2)
-                         ]
-                     )
-
-    fdescribe "Inline typeclass functions" $ do
-      let simplify :: Expr ResolvedDep ann -> Expr CompareWrapper ()
-          simplify = void . mapExprDep CompareWrapper
-
-      it "Test Eq instance even works" $ do
-        (CompareWrapper (LocalDefinition ("a1" :: String))) `shouldBe` (CompareWrapper (UniqueDefinition "a" 1))
-
-      traverse_
-        ( \(typeclasses, parts, expectedParts) ->
-            let input = joinText parts
-                expected = joinText expectedParts
-             in it ("Successfully inlined " <> show input) $ do
-                  let expr = getRight $ evalExpr input
-                      expectedExpr = getRight $ evalExprUnsafe expected
-                      result = inlineTypeclassFunctions typecheckEnv typeclasses expr
-                  tracePrettyM "expected" expectedExpr
-                  tracePrettyM "result" (getRight result)
-                  simplify <$> result `shouldBe` Right (simplify expectedExpr)
-        )
-        [ (mempty, ["1 + 2"], ["1 + 2"]),
-          ( M.singleton (TypeclassCall "equals" 1) (Constraint "Eq" [tyInt]),
-            ["equals (1: Int) (2: Int)"],
-            [ "\\instances -> case (instances : Int -> Int -> Bool) of tcnewname1 ->",
-              "tcnewname1 (1 : Int) (2 : Int)"
-            ]
-          ),
-          ( M.fromList
-              [ ("blah1", Constraint "Eq" [tyInt]),
-                ("blah2", Constraint "Eq" [tyInt])
-              ],
-            ["if equals (1: Int) (2: Int) then equals (2: Int) (3: Int) else False"],
-            [ "\\instances1 -> case (instances1 : Int -> Int -> Bool) of tcequals1 ->",
-              "if tcequals1 (1 : Int) (2 : Int) then tcequals1 (2: Int) (3: Int) else False"
-            ]
-          ),
-          ( M.fromList [("eqA", Constraint "Eq" [tcVar "a"]), ("eqB", Constraint "Eq" [tcVar "b"])],
-            [ "(\\a -> \\b -> case (a,b) of ((a1, b1), (a2, b2)) -> ",
-              "if equals a1 a2 then equals b1 b2 else False : (a,b) -> (a,b) -> Bool)"
-            ],
-            [ "\\instances -> case (instances : (a -> a -> Bool, b -> b -> Bool)) of (eqA, eqB) -> ",
-              "(\\a -> \\b -> case (a,b) of ((a1, a2), (b1, b2)) ->",
-              "if a1 b1 then eqB b1 b2 else False : (a,b) -> (a,b) -> Bool)"
-            ]
-          )
+  describe "recoverTypeclassUses" $ do
+    it "No classes, nothing to find" $ do
+      recoverTypeclassUses @() [] `shouldBe` mempty
+    it "Uses Eq Int" $ do
+      recoverTypeclassUses @()
+        [ TCWTypeclassUse (UniqueDefinition "a" 123) "Eq" [("a", 10)],
+          TCWSubstitution (Substitution (SubUnknown 10) tyInt)
         ]
+        `shouldBe` M.singleton (UniqueDefinition "a" 123) (Constraint "Eq" [tyInt])
+
+  describe "instanceMatchesType" $ do
+    it "Eq (a,Bool) does not match Eq (Int, Int)" $ do
+      instanceMatchesType @() [tyTuple tyInt [tyInt]] [tyTuple (tcVar "a") [tyBool]]
+        `shouldBe` Left (tyInt, tyBool)
+
+    it "Eq (a,b) matches Eq (Int, Int)" $ do
+      instanceMatchesType @() [tyTuple tyInt [tyInt]] [tyTuple (tcVar "a") [tcVar "b"]]
+        `shouldBe` Right
+          [ Substitution (SubId (Identity "a")) tyInt,
+            Substitution (SubId (Identity "b")) tyInt
+          ]
+
+  describe "lookupTypeclassInstance" $ do
+    it "Is not there" $ do
+      lookupTypeclassInstance @() typecheckEnv (Constraint "Eq" [tyBool])
+        `shouldSatisfy` isLeft
+
+    it "Is there" $ do
+      let result = lookupTypeclassInstance @() typecheckEnv (Constraint "Eq" [tyInt])
+      inConstraints <$> result `shouldBe` Right []
+
+    it "Nested item is there" $ do
+      let result = lookupTypeclassInstance @() typecheckEnv (Constraint "Eq" [tyTuple tyInt [tyInt]])
+      inConstraints <$> result `shouldBe` Right [Constraint "Eq" [tyInt], Constraint "Eq" [tyInt]]
+
+    it "Doubly nested item is there" $ do
+      let result = lookupTypeclassInstance @() typecheckEnv (Constraint "Eq" [tyTuple tyInt [tyTuple tyInt [tyInt]]])
+      result `shouldSatisfy` isRight
+
+    it "Other nested item is there" $ do
+      lookupTypeclassInstance @() typecheckEnv (Constraint "Eq" [tyTuple tyBool [tyInt]])
+        `shouldSatisfy` isLeft
+
+  describe "lookupTypeclassConstraint" $ do
+    it "Is not there" $ do
+      lookupTypeclassConstraint @() typecheckEnv (Constraint "Eq" [tcVar "a"])
+        `shouldSatisfy` isLeft
+
+    it "Is there" $ do
+      let tcEnvWithConstraint = typecheckEnv {tceConstraints = [Constraint "Eq" [tcVar "a"]]}
+      lookupTypeclassConstraint @() tcEnvWithConstraint (Constraint "Eq" [tcVar "a"])
+        `shouldSatisfy` isRight
+
+  describe "Check instances" $ do
+    it "Good Show instance" $ do
+      checkInstance @()
+        typecheckEnv
+        showTypeclass
+        (Constraint "Show" [tyUnit])
+        ( Instance
+            { inExpr = unsafeParseInstanceExpr "\\a -> \"Unit\"",
+              inConstraints = []
+            }
+        )
+        `shouldSatisfy` isRight
+
+    it "Bad Show instance" $ do
+      checkInstance @()
+        typecheckEnv
+        showTypeclass
+        (Constraint "Show" [tyUnit])
+        ( Instance
+            { inExpr = unsafeParseInstanceExpr "\\a -> 123",
+              inConstraints = []
+            }
+        )
+        `shouldSatisfy` isLeft
+
+    it "Good Eq instance" $ do
+      checkInstance @()
+        typecheckEnv
+        eqTypeclass
+        (Constraint "Eq" [tyInt])
+        ( Instance
+            { inExpr = unsafeParseInstanceExpr "\\a -> \\b -> a == b",
+              inConstraints = []
+            }
+        )
+        `shouldSatisfy` isRight
+
+    it "Bad Eq instance" $ do
+      checkInstance @()
+        typecheckEnv
+        eqTypeclass
+        (Constraint "Show" [tyUnit])
+        ( Instance
+            { inExpr = unsafeParseInstanceExpr "\\a -> \\b -> 123",
+              inConstraints = []
+            }
+        )
+        `shouldSatisfy` isLeft
+
+    it "Tuple Eq instance" $ do
+      checkInstance @()
+        typecheckEnv
+        eqTypeclass
+        (Constraint "Eq" [tyTuple (tcVar "a") [tcVar "b"]])
+        ( Instance
+            { inExpr =
+                unsafeParseInstanceExpr "\\a -> \\b -> case (a,b) of ((a1, a2), (b1, b2)) -> if equals a1 b1 then equals a2 b2 else False",
+              inConstraints =
+                [ Constraint "Eq" [tcVar "a"],
+                  Constraint "Eq" [tcVar "b"]
+                ]
+            }
+        )
+        `shouldSatisfy` isRight
+
+    it "Tuple Eq instance missing a constraint" $ do
+      checkInstance @()
+        typecheckEnv
+        eqTypeclass
+        (Constraint "Eq" [tyTuple (tcVar "a") [tcVar "b"]])
+        ( Instance
+            { inExpr =
+                unsafeParseInstanceExpr "\\a -> \\b -> case (a,b) of ((a1, a2), (b1, b2)) -> if equals a1 b1 then equals a2 b2 else False",
+              inConstraints =
+                [ Constraint "Eq" [tcVar "a"]
+                ]
+            }
+        )
+        `shouldSatisfy` isLeft
+
+  fdescribe "dedupeConstraints" $ do
+    it "Empty is empty" $ do
+      dedupeConstraints @() mempty `shouldBe` (mempty, mempty)
+
+    it "One is one and gets a new name" $ do
+      dedupeConstraints @() (M.singleton "oldname" (Constraint "Eq" [tyInt]))
+        `shouldBe` ( [ ( TypeclassCall "newname" 1,
+                         Constraint "Eq" [tyInt]
+                       )
+                     ],
+                     M.singleton "oldname" (TypeclassCall "newname" 1)
+                   )
+
+    it "Two functions, each used twice become one of each" $ do
+      dedupeConstraints @()
+        ( M.fromList
+            [ ("eqInt1", Constraint "Eq" [tyInt]),
+              ("eqInt2", Constraint "Eq" [tyInt]),
+              ("eqBool1", Constraint "Eq" [tyBool]),
+              ("eqBool2", Constraint "Eq" [tyBool])
+            ]
+        )
+        `shouldBe` ( [ ( TypeclassCall "newname" 1,
+                         Constraint "Eq" [tyInt]
+                       ),
+                       ( TypeclassCall "newname" 2,
+                         Constraint "Eq" [tyBool]
+                       )
+                     ],
+                     M.fromList
+                       [ ("eqInt1", TypeclassCall "newname" 1),
+                         ("eqInt2", TypeclassCall "newname" 1),
+                         ("eqBool1", TypeclassCall "newname" 2),
+                         ("eqBool2", TypeclassCall "newname" 2)
+                       ]
+                   )
+
+  fdescribe "Inline typeclass functions" $ do
+    let simplify :: Expr ResolvedDep ann -> Expr ResolvedDep ()
+        simplify = void . goExpr
+          where
+            changeIdent (TypeclassCall ident i) =
+              LocalDefinition $ "tc" <> ident <> fromString (show i)
+            changeIdent (UniqueDefinition ident i) =
+              LocalDefinition $ ident <> fromString (show i)
+            changeIdent ident = ident
+
+            goExpr (EVar ann ident) =
+              EVar ann (changeIdent ident)
+            goExpr (EAnn ann ty rest) =
+              EAnn ann (typeForComparison ty) (goExpr rest)
+            goExpr (EPatternMatch ann matchExpr pats) =
+              EPatternMatch ann (goExpr matchExpr) (fmap (bimap goPattern goExpr) pats)
+            goExpr other = mapExpr goExpr other
+
+            goPattern (PVar ann ident) = PVar ann (changeIdent ident)
+            goPattern other = mapPattern goPattern other
+
+    traverse_
+      ( \(typeclasses, parts, expectedParts) ->
+          let input = joinText parts
+              expected = joinText expectedParts
+           in it ("Successfully inlined " <> show input) $ do
+                let expr = getRight $ evalExpr (M.elems typeclasses) input
+                tracePrettyM "expr" expr
+                
+                let env = typecheckEnv { tceConstraints = M.elems typeclasses }
+
+                let expectedExpr = getRight $ evalExprUnsafe expected
+                    result = inlineTypeclassFunctions env typeclasses expr
+
+                tracePrettyM "expected" expectedExpr
+
+                simplify <$> result `shouldBe` Right (simplify expectedExpr)
+      )
+      [ (mempty, ["1 + 2"], ["1 + 2"]),
+        ( M.singleton (TypeclassCall "equals" 1) (Constraint "Eq" [tyInt]),
+          ["equals (1: Int) (2: Int)"],
+          [ "\\instances -> case (instances : Int -> Int -> Bool) of tcnewname1 ->",
+            "tcnewname1 (1 : Int) (2 : Int)"
+          ]
+        ),
+        ( M.fromList
+            [ (TypeclassCall "equals" 1, Constraint "Eq" [tyInt]),
+              (TypeclassCall "equals" 2, Constraint "Eq" [tyInt])
+            ],
+          ["if equals (1: Int) (2: Int) then equals (2: Int) (3: Int) else False"],
+          [ "\\instances -> case (instances : Int -> Int -> Bool) of tcnewname1 ->",
+            "if tcnewname1 (1 : Int) (2 : Int) then tcnewname1 (2: Int) (3: Int) else False"
+          ]
+        ),
+        ( M.fromList [("eqA", Constraint "Eq" [tcVar "a"]), ("eqB", Constraint "Eq" [tcVar "b"])],
+          [ "(\\a -> \\b -> case (a,b) of ((a1, b1), (a2, b2)) -> ",
+            "if equals a1 a2 then equals b1 b2 else False : (a,b) -> (a,b) -> Bool)"
+          ],
+          [ "\\instances -> case (instances : (a -> a -> Bool, b -> b -> Bool)) of (tcnewname1, tcnewname2) -> ",
+            "(\\a -> \\b -> case (a,b) of ((a1, a2), (b1, b2)) ->",
+            "if tcnewname1 a1 b1 then tcnewname2 b1 b2 else False : (a,b) -> (a,b) -> Bool)"
+          ]
+        )
+      ]

--- a/smol-core/test/Test/Typecheck/TypeclassSpec.hs
+++ b/smol-core/test/Test/Typecheck/TypeclassSpec.hs
@@ -249,13 +249,22 @@ spec = do
       let constraints = [Constraint "Eq" [tyInt]]
           expected = evalExprUnsafe "(\\a1 -> \\b2 -> a1 == b2 : Int -> Int -> Bool)"
 
-      simplify <$> createTypeclassDict typecheckEnv constraints `shouldBe` simplify <$> expected
+      (fmap . fmap) simplify (createTypeclassDict typecheckEnv constraints) `shouldBe`
+        Just . simplify <$> expected
 
     it "Tuple for two constraints" $ do
       let constraints = [Constraint "Eq" [tyInt], Constraint "Eq" [tyInt]]
           expected = evalExprUnsafe "((\\a1 -> \\b2 -> a1 == b2 : Int -> Int -> Bool), (\\a1 -> \\b2 -> a1 == b2 : Int -> Int -> Bool))"
 
-      simplify <$> createTypeclassDict typecheckEnv constraints `shouldBe` simplify <$> expected
+      (fmap . fmap) simplify (createTypeclassDict typecheckEnv constraints) `shouldBe`
+        Just . simplify <$> expected
+
+    it "No dictionary for non-concrete type" $ do
+      let constraints = [Constraint "Eq" [tcVar "a"]]
+          expected = Nothing
+
+      createTypeclassDict @() typecheckEnv constraints `shouldBe`
+        Right expected
 
   describe "isConcrete" $ do
     it "yes, because it has no vars" $ do

--- a/smol-core/test/Test/Typecheck/TypeclassSpec.hs
+++ b/smol-core/test/Test/Typecheck/TypeclassSpec.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Typecheck.TypeclassSpec (spec) where
+
+import Smol.Core.Modules.ResolveDeps
+import Data.Either
+import Data.Functor
+import qualified Data.Map.Strict as M
+import Data.Text (Text)
+import Smol.Core
+import Smol.Core.Typecheck.Typeclass
+import Test.Helpers
+import Test.Hspec
+
+evalExpr ::
+  Text ->
+  Either (TCError Annotation) (ResolvedExpr (Type ResolvedDep Annotation))
+evalExpr input = case parseExprAndFormatError input of
+  Left e -> error (show e)
+  Right expr -> testElaborate expr
+
+getRight :: (Show e) => Either e a -> a
+getRight (Right a) = a
+getRight (Left e) = error (show e)
+
+testElaborate ::
+  (Ord ann, Show ann, Monoid ann) =>
+  Expr ParseDep ann ->
+  Either (TCError ann) (Expr ResolvedDep (Type ResolvedDep ann))
+testElaborate expr =
+  case resolveExprDeps expr mempty of
+    Left e -> error (show e)
+    Right resolvedExpr ->   case elaborate typecheckEnv resolvedExpr of
+      Right (typedExpr, _typeclassUses) -> pure typedExpr
+      Left e -> Left e
+
+spec :: Spec
+spec = do
+  describe "TypeclassSpec" $ do
+    describe "recoverTypeclassUses" $ do
+      it "No classes, nothing to find" $ do
+        recoverTypeclassUses @() [] `shouldBe` mempty
+      it "Uses Eq Int" $ do
+        recoverTypeclassUses @()
+          [ TCWTypeclassUse (UniqueDefinition "a" 123) "Eq" [("a", 10)],
+            TCWSubstitution (Substitution (SubUnknown 10) tyInt)
+          ]
+          `shouldBe` M.singleton (UniqueDefinition "a" 123) (TypeclassHead "Eq" [tyInt])
+
+    describe "lookupTypeclassInstance" $ do
+      it "Is not there" $ do
+        lookupTypeclassInstance @() typecheckEnv (TypeclassHead "Eq" [tyBool])
+          `shouldSatisfy` isLeft
+
+      it "Is there" $ do
+        lookupTypeclassInstance @() typecheckEnv (TypeclassHead "Eq" [tyInt])
+          `shouldSatisfy` isRight
+
+    describe "lookupTypeclassConstraint" $ do
+      it "Is not there" $ do
+        lookupTypeclassConstraint @() typecheckEnv (TypeclassHead "Eq" [tcVar "a"])
+          `shouldSatisfy` isLeft
+
+      it "Is there" $ do
+        let tcEnvWithConstraint = typecheckEnv {tceConstraints = [TypeclassHead "Eq" [tcVar "a"]]}
+        lookupTypeclassConstraint @() tcEnvWithConstraint (TypeclassHead "Eq" [tcVar "a"])
+          `shouldSatisfy` isRight
+
+    describe "Check instances" $ do
+      it "Good Show instance" $ do
+        checkInstance @()
+          typecheckEnv
+          showTypeclass
+          (TypeclassHead "Show" [tyUnit])
+          ( Instance
+              { inExpr = unsafeParseInstanceExpr "\\a -> \"Unit\"",
+                inConstraints = []
+              }
+          )
+          `shouldSatisfy` isRight
+
+      it "Bad Show instance" $ do
+        checkInstance @()
+          typecheckEnv
+          showTypeclass
+          (TypeclassHead "Show" [tyUnit])
+          ( Instance
+              { inExpr = unsafeParseInstanceExpr "\\a -> 123",
+                inConstraints = []
+              }
+          )
+          `shouldSatisfy` isLeft
+
+      it "Good Eq instance" $ do
+        checkInstance @()
+          typecheckEnv
+          eqTypeclass
+          (TypeclassHead "Eq" [tyInt])
+          ( Instance
+              { inExpr = unsafeParseInstanceExpr "\\a -> \\b -> a == b",
+                inConstraints = []
+              }
+          )
+          `shouldSatisfy` isRight
+
+      it "Bad Eq instance" $ do
+        checkInstance @()
+          typecheckEnv
+          eqTypeclass
+          (TypeclassHead "Show" [tyUnit])
+          ( Instance
+              { inExpr = unsafeParseInstanceExpr "\\a -> \\b -> 123",
+                inConstraints = []
+              }
+          )
+          `shouldSatisfy` isLeft
+
+      it "Tuple Eq instance" $ do
+        checkInstance @()
+          typecheckEnv
+          eqTypeclass
+          (TypeclassHead "Eq" [tyTuple (tcVar "a") [tcVar "b"]])
+          ( Instance
+              { inExpr =
+                  unsafeParseInstanceExpr "\\a -> \\b -> case (a,b) of ((a1, a2), (b1, b2)) -> if equals a1 b1 then equals a2 b2 else False",
+                inConstraints =
+                  [ TypeclassHead "Eq" [tcVar "a"],
+                    TypeclassHead "Eq" [tcVar "b"]
+                  ]
+              }
+          )
+          `shouldSatisfy` isRight
+
+      it "Tuple Eq instance missing a constraint" $ do
+        checkInstance @()
+          typecheckEnv
+          eqTypeclass
+          (TypeclassHead "Eq" [tyTuple (tcVar "a") [tcVar "b"]])
+          ( Instance
+              { inExpr =
+                  unsafeParseInstanceExpr "\\a -> \\b -> case (a,b) of ((a1, a2), (b1, b2)) -> if equals a1 b1 then equals a2 b2 else False",
+                inConstraints =
+                  [ TypeclassHead "Eq" [tcVar "a"]
+                  ]
+              }
+          )
+          `shouldSatisfy` isLeft
+
+    describe "Inline typeclass functions" $ do
+      it "No functions, no change" $ do
+        let expr = getRight $ evalExpr "1 + 2"
+            expected = getRight $ evalExpr "1 + 2"
+
+        inlineTypeclassFunctions typecheckEnv mempty expr
+          `shouldBe` Right expected
+
+      it "Eq Int functions inlined" $ do
+        let expr = getRight $ evalExpr "equals (1: Int) (2: Int)"
+            expected = void $ getRight $ evalExpr "let equals = (\\a -> \\b -> a == b : Int -> Int -> Bool); equals (1 : Int) (2 : Int)"
+            typeclasses = M.singleton "equals" (TypeclassHead "Eq" [tyInt])
+
+        fmap void (inlineTypeclassFunctions typecheckEnv typeclasses expr)
+          `shouldBe` Right expected
+

--- a/smol-core/test/Test/Typecheck/TypeclassSpec.hs
+++ b/smol-core/test/Test/Typecheck/TypeclassSpec.hs
@@ -323,7 +323,7 @@ spec = do
       ]
 
   -- the whole transformation basically
-  describe "passAllDictionaries" $ do
+  describe "toDictionaryPassing" $ do
     traverse_
       ( \(constraints, parts, expectedParts) ->
           let input = joinText parts
@@ -336,7 +336,7 @@ spec = do
 
                 let expectedExpr = getRight $ evalExprUnsafe expected
                     (dedupedConstraints, tidyExpr) = deduplicateConstraints typeclassUses expr
-                    result = passAllDictionaries varsInScope dedupedConstraints tidyExpr
+                    result = toDictionaryPassing varsInScope dedupedConstraints tidyExpr
 
                 simplify <$> result `shouldBe` Right (simplify expectedExpr)
       )
@@ -345,14 +345,15 @@ spec = do
           ["equals (1: Int) (2: Int)"],
           [ "(\\a1 -> \\b2 -> a1 == b2 : Int -> Int -> Bool) (1 : Int) (2: Int)"
           ]
-        ) {-,
+        ),
           ( mempty,
-            ["if equals (1: Int) (2: Int) then equals (2: Int) (3: Int) else False"],
-            [Constraint "Eq" [tyInt]],
-            [ "\\instances -> case (instances : Int -> Int -> Bool) of tcvaluefromdictionary0 ->",
-              "if tcvaluefromdictionary0 (1 : Int) (2 : Int) then tcvaluefromdictionary0 (2: Int) (3: Int) else False"
-            ]
-          ),
+            ["equals ((1: Int), (2: Int)) ((2: Int), (3: Int))"],
+            ["(\\a1 -> \\b2 -> case (a1,b2) of ((a13, a24), (b15, b26)) ->",
+            "if (\\a1 -> \\b2 -> a1 == b2 : Int -> Int -> Bool) a13 b15 ",
+            "then (\\a1 -> \\b2 -> a1 == b2 : Int -> Int -> Bool) a24 b26",
+            "else False : (Int,Int) -> (Int,Int) -> Bool)",
+            "((1: Int), (2: Int)) ((2: Int), (3: Int))"]
+          ){-,
           ( [ Constraint "Eq" [tcVar "a"],
               Constraint "Eq" [tcVar "b"]
             ],

--- a/smol-core/test/Test/Typecheck/TypeclassSpec.hs
+++ b/smol-core/test/Test/Typecheck/TypeclassSpec.hs
@@ -341,7 +341,7 @@ spec = do
                 let expectedExpr = getRight $ evalExprUnsafe varsInScope expected
                     (dedupedConstraints, tidyExpr) = deduplicateConstraints typeclassUses expr
                     allConstraints = nub (dedupedConstraints <> constraints) -- we lose outer constraints sometimes
-                    result = toDictionaryPassing varsInScope allConstraints tidyExpr
+                    result = toDictionaryPassing varsInScope (tceInstances typecheckEnv) allConstraints tidyExpr
 
                 simplify <$> result `shouldBe` Right (simplify expectedExpr)
       )

--- a/smol-core/test/Test/Typecheck/TypeclassSpec.hs
+++ b/smol-core/test/Test/Typecheck/TypeclassSpec.hs
@@ -7,12 +7,13 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Typecheck.TypeclassSpec (spec) where
-import Data.List (nub)
+
 import Control.Monad.Identity
 import Data.Bifunctor (bimap)
 import Data.Either
 import Data.Foldable (traverse_)
 import Data.Functor
+import Data.List (nub)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import Data.Maybe (mapMaybe)
@@ -22,7 +23,7 @@ import Data.Text (Text)
 import Smol.Core
 import Smol.Core.Modules.ResolveDeps
 import Smol.Core.Modules.Types.DefIdentifier
-import Smol.Core.Typecheck.FromParsedExpr (fromParsedExpr )
+import Smol.Core.Typecheck.FromParsedExpr (fromParsedExpr)
 import Smol.Core.Typecheck.Typeclass
 import Test.Helpers
 import Test.Hspec
@@ -89,10 +90,10 @@ evalExprUnsafe ::
 evalExprUnsafe varsInScope input = case parseExprAndFormatError input of
   Left e -> error (show e)
   Right expr ->
-    let env = typecheckEnv { tceVars = varsInScope }
+    let env = typecheckEnv {tceVars = varsInScope}
      in case elaborate env (fromParsedExpr expr) of
-      Right (typedExpr, _typeclassUses) -> pure typedExpr
-      Left e -> Left e
+          Right (typedExpr, _typeclassUses) -> pure typedExpr
+          Left e -> Left e
 
 getRight :: (Show e) => Either e a -> a
 getRight (Right a) = a

--- a/smol-core/test/Test/Typecheck/TypeclassSpec.hs
+++ b/smol-core/test/Test/Typecheck/TypeclassSpec.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -62,7 +62,7 @@ identityFromParsedExpr = mapExprDep resolve
 showTypeclass :: (Monoid ann) => Typeclass ann
 showTypeclass =
   Typeclass
-    { tcArgs = ["a"],
+    { tcName = "Show",tcArgs = ["a"],
       tcFuncName = "show",
       tcFuncType = tyFunc (tcVar "a") tyString
     }
@@ -70,7 +70,8 @@ showTypeclass =
 eqTypeclass :: (Monoid ann) => Typeclass ann
 eqTypeclass
  = Typeclass
-            { tcArgs = ["a"],
+   { tcName = "Eq",
+   tcArgs = ["a"],
               tcFuncName = "equals",
               tcFuncType = tyFunc (tcVar "a") (tyFunc (tcVar "a") tyBool)
             }
@@ -269,7 +270,8 @@ spec = do
               ("(\\x -> (x 1, x (False,True))) (\\a -> a)", "(1, (False, True))"), -- look! higher rank types
               ("let f = (\\x -> (x 1, x False) : (a -> a) -> (1, False)); let id = \\a -> a; f id", "(1, False)"), -- they need annotation, but that's ok
               ("\\a -> \\b -> if a then a else b", "Bool -> Bool -> Bool"),
-              ("\\a -> case a of (b,c) -> if b then b else c", "(Bool,Bool) -> Bool")
+              ("\\a -> case a of (b,c) -> if b then b else c", "(Bool,Bool) -> Bool"),
+              ("equals (10 : Int) (11: Int)", "Bool") -- using Eq Int typeclass instance
             ]
       traverse_
         ( \(inputExpr, expectedType) -> it (T.unpack inputExpr <> " :: " <> T.unpack expectedType) $ do

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -106,6 +106,25 @@ typecheckEnv =
 spec :: Spec
 spec = do
   describe "TypecheckSpec" $ do
+    fdescribe "recover instance uses" $ do
+      it "No classes, nothing to find" $ do
+        recoverTypeclassUses @() [] `shouldBe` []
+      it "Uses Eq Int" $ do
+        recoverTypeclassUses @()
+          [ TCWTypeclassUse "Eq" [("a", 10)],
+            TCWSubstitution (Substitution (SubUnknown 10) tyInt)
+          ]
+          `shouldBe` [TypeclassHead "Eq" [tyInt]]
+
+    fdescribe "lookupTypeclassHead" $ do
+      it "Is not there" $ do
+        lookupTypeclassHead @() typecheckEnv (TypeclassHead "Eq" [tyBool])
+          `shouldSatisfy` isLeft
+
+      it "Is there" $ do
+        lookupTypeclassHead @() typecheckEnv (TypeclassHead "Eq" [tyInt])
+          `shouldSatisfy` isRight
+
     describe "Check instances" $ do
       it "Good Show instance" $ do
         checkInstance @()
@@ -284,7 +303,7 @@ spec = do
         )
         inputs
 
-    describe "Expected failures" $ do
+    fdescribe "Expected failures" $ do
       let inputs =
             [ "equals (10 : Int) True", -- using Eq Int typeclass instance
               "equals (True : Bool) (False : Bool)" -- there is no Eq Bool instance atm

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -105,7 +105,7 @@ typecheckEnv =
 spec :: Spec
 spec = do
   describe "TypecheckSpec" $ do
-    fdescribe "Check instances" $ do
+    describe "Check instances" $ do
       it "Good Show instance" $ do
         checkInstance @()
           showTypeclass

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -276,7 +276,7 @@ spec = do
               "(\\a -> \\b -> equals a b : a -> a -> Bool)" -- this is missing an `Eq a` constraint
             ]
       traverse_
-        ( \(inputExpr) -> it (T.unpack inputExpr <> " fails typechecking") $ do
+        ( \inputExpr -> it (T.unpack inputExpr <> " fails typechecking") $ do
             first (T.pack . show) (evalExpr inputExpr) `shouldSatisfy` isLeft
         )
         inputs

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -56,7 +56,7 @@ testElaborate expr =
 spec :: Spec
 spec = do
   describe "TypecheckSpec" $ do
-    describe "recover instance uses" $ do
+    describe "recoverTypeclassUses" $ do
       it "No classes, nothing to find" $ do
         recoverTypeclassUses @() [] `shouldBe` mempty
       it "Uses Eq Int" $ do
@@ -114,7 +114,7 @@ spec = do
 
       it "Eq Int functions inlined" $ do
         let expr = getRight $ evalExpr "equals (1: Int) (2: Int)"
-            expected = void $ getRight $ evalExpr "let equals = \\a -> \\b -> a == b; equals (1 : Int) (2 : Int)"
+            expected = void $ getRight $ evalExpr "let equals = (\\a -> \\b -> a == b : Int -> Int -> Bool); equals (1 : Int) (2 : Int)"
             typeclasses = M.singleton "equals" (TypeclassHead "Eq" [tyInt])
 
         fmap void (inlineTypeclassFunctions typecheckEnv typeclasses expr)
@@ -256,7 +256,8 @@ spec = do
               ("let f = (\\x -> (x 1, x False) : (a -> a) -> (1, False)); let id = \\a -> a; f id", "(1, False)"), -- they need annotation, but that's ok
               ("\\a -> \\b -> if a then a else b", "Bool -> Bool -> Bool"),
               ("\\a -> case a of (b,c) -> if b then b else c", "(Bool,Bool) -> Bool"),
-              ("equals (10 : Int) (11: Int)", "Bool") -- using Eq Int typeclass instance
+              ("equals (10 : Int) (11: Int)", "Bool"), -- using Eq Int typeclass instance
+              ("(\\a -> \\b -> equals a b : (Eq a) => a -> a -> Bool)", "(Eq a) => a -> a -> Bool") -- raise polymorphic constraint of `Eq a`
             ]
       traverse_
         ( \(inputExpr, expectedType) -> it (T.unpack inputExpr <> " :: " <> T.unpack expectedType) $ do

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -19,7 +19,6 @@ import Smol.Core.Typecheck.FromParsedExpr
 import Test.Helpers
 import Test.Hspec
 
-
 evalExpr ::
   Text ->
   Either (TCError Annotation) (ResolvedExpr (Type ResolvedDep Annotation))
@@ -37,7 +36,7 @@ testElaborate ::
   Either (TCError ann) (Expr ResolvedDep (Type ResolvedDep ann))
 testElaborate expr =
   case elaborate typecheckEnv (fromParsedExpr expr) of
-    Right (typedExpr ,_) -> pure typedExpr
+    Right (typedExpr, _) -> pure typedExpr
     Left e -> Left e
 
 spec :: Spec

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -106,7 +106,7 @@ typecheckEnv =
 spec :: Spec
 spec = do
   describe "TypecheckSpec" $ do
-    fdescribe "recover instance uses" $ do
+    describe "recover instance uses" $ do
       it "No classes, nothing to find" $ do
         recoverTypeclassUses @() [] `shouldBe` []
       it "Uses Eq Int" $ do
@@ -116,7 +116,7 @@ spec = do
           ]
           `shouldBe` [TypeclassHead "Eq" [tyInt]]
 
-    fdescribe "lookupTypeclassHead" $ do
+    describe "lookupTypeclassHead" $ do
       it "Is not there" $ do
         lookupTypeclassHead @() typecheckEnv (TypeclassHead "Eq" [tyBool])
           `shouldSatisfy` isLeft
@@ -303,10 +303,11 @@ spec = do
         )
         inputs
 
-    fdescribe "Expected failures" $ do
+    describe "Expected failures" $ do
       let inputs =
             [ "equals (10 : Int) True", -- using Eq Int typeclass instance
-              "equals (True : Bool) (False : Bool)" -- there is no Eq Bool instance atm
+              "equals (True : Bool) (False : Bool)", -- there is no Eq Bool instance atm
+              "(\\a -> \\b -> equals a b : a -> a -> Bool)" -- this is missing an `Eq a` constraint
             ]
       traverse_
         ( \(inputExpr) -> it (T.unpack inputExpr <> " fails typechecking") $ do

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -62,25 +62,25 @@ identityFromParsedExpr = mapExprDep resolve
 showTypeclass :: (Monoid ann) => Typeclass ann
 showTypeclass =
   Typeclass
-    { tcName = "Show",tcArgs = ["a"],
+    { tcName = "Show",
+      tcArgs = ["a"],
       tcFuncName = "show",
       tcFuncType = tyFunc (tcVar "a") tyString
     }
 
 eqTypeclass :: (Monoid ann) => Typeclass ann
-eqTypeclass
- = Typeclass
-   { tcName = "Eq",
-   tcArgs = ["a"],
-              tcFuncName = "equals",
-              tcFuncType = tyFunc (tcVar "a") (tyFunc (tcVar "a") tyBool)
-            }
-
+eqTypeclass =
+  Typeclass
+    { tcName = "Eq",
+      tcArgs = ["a"],
+      tcFuncName = "equals",
+      tcFuncType = tyFunc (tcVar "a") (tyFunc (tcVar "a") tyBool)
+    }
 
 classes :: (Monoid ann) => M.Map String (Typeclass ann)
 classes =
   M.fromList
-    [ ( "Eq", eqTypeclass ),
+    [ ("Eq", eqTypeclass),
       ("Show", showTypeclass)
     ]
 
@@ -281,6 +281,17 @@ spec = do
                     expected = fromParsedType (simplifyType typ $> ())
                  in result `shouldBe` expected
               other -> error (show other)
+        )
+        inputs
+
+    describe "Expected failures" $ do
+      let inputs =
+            [ "equals (10 : Int) True", -- using Eq Int typeclass instance
+              "equals (True : Bool) (False : Bool)" -- there is no Eq Bool instance atm
+            ]
+      traverse_
+        ( \(inputExpr) -> it (T.unpack inputExpr <> " fails typechecking") $ do
+            first (T.pack . show) (evalExpr inputExpr) `shouldSatisfy` isLeft
         )
         inputs
 

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -19,6 +19,7 @@ import Smol.Core.Typecheck.FromParsedExpr
 import Test.Helpers
 import Test.Hspec
 
+
 evalExpr ::
   Text ->
   Either (TCError Annotation) (ResolvedExpr (Type ResolvedDep Annotation))
@@ -36,7 +37,7 @@ testElaborate ::
   Either (TCError ann) (Expr ResolvedDep (Type ResolvedDep ann))
 testElaborate expr =
   case elaborate typecheckEnv (fromParsedExpr expr) of
-    Right (typedExpr, _typeclassUses) -> pure typedExpr
+    Right (typedExpr ,_) -> pure typedExpr
     Left e -> Left e
 
 spec :: Spec

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -48,7 +48,7 @@ testElaborate ::
   Either (TCError ann) (Expr ResolvedDep (Type ResolvedDep ann))
 testElaborate expr =
   case elaborate typecheckEnv (fromParsedExpr expr) of
-    Right typedExpr -> pure typedExpr
+    Right (typedExpr, _typeclassUses) -> pure typedExpr
     Left e -> Left e
 
 tcVar :: (Monoid ann) => Identifier -> Type Identity ann
@@ -111,10 +111,10 @@ spec = do
         recoverTypeclassUses @() [] `shouldBe` []
       it "Uses Eq Int" $ do
         recoverTypeclassUses @()
-          [ TCWTypeclassUse "Eq" [("a", 10)],
+          [ TCWTypeclassUse (UniqueDefinition "a" 123) "Eq" [("a", 10)],
             TCWSubstitution (Substitution (SubUnknown 10) tyInt)
           ]
-          `shouldBe` [TypeclassHead "Eq" [tyInt]]
+          `shouldBe` [(UniqueDefinition "a" 123, TypeclassHead "Eq" [tyInt])]
 
     describe "lookupTypeclassHead" $ do
       it "Is not there" $ do

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -30,14 +30,6 @@ getLeft :: (Show a) => Either e a -> e
 getLeft (Left e) = e
 getLeft (Right a) = error (show a)
 
--- simplify type for equality check
--- remove anything that can't be described in a type signature
-simplifyType :: (Ord (dep Identifier)) => Type dep ann -> Type dep ann
-simplifyType (TFunc ann _ fn arg) =
-  TFunc ann mempty (simplifyType fn) (simplifyType arg)
-simplifyType (TArray ann _ as) = TArray ann 0 (simplifyType as)
-simplifyType other = mapType simplifyType other
-
 testElaborate ::
   (Ord ann, Show ann, Monoid ann) =>
   Expr ParseDep ann ->
@@ -192,8 +184,8 @@ spec = do
         ( \(inputExpr, expectedType) -> it (T.unpack inputExpr <> " :: " <> T.unpack expectedType) $ do
             case (,) <$> first (T.pack . show) (evalExpr inputExpr) <*> parseTypeAndFormatError expectedType of
               Right (te, typ) ->
-                let result = simplifyType (getExprAnnotation te) $> ()
-                    expected = fromParsedType (simplifyType typ $> ())
+                let result = typeForComparison (getExprAnnotation te) $> ()
+                    expected = fromParsedType (typeForComparison typ $> ())
                  in result `shouldBe` expected
               other -> error (show other)
         )

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -4,7 +4,6 @@
 
 module Test.TypecheckSpec (spec) where
 
-import Control.Monad.Reader
 import Control.Monad.State
 import Data.Bifunctor
 import Data.Either

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Test.TypecheckSpec (spec) where
 

--- a/smol-core/test/static/Eq.smol
+++ b/smol-core/test/static/Eq.smol
@@ -20,6 +20,18 @@ instance Eq Bool = \a -> \b -> a == b
 
 instance Eq String = \a -> \b -> a == b
 
+/*
+
+let's work up to this yeah
+
+type Maybe a = Just a | Nothing
+
+instance (Eq a) => Eq (Maybe a) = \a -> \b -> case (a,b) of
+        (Just a, Just b) -> equals a b
+      | (Nothing, Nothing) -> True
+      | _ -> False
+*/
+
 def useNewInstances : Bool
 def useNewInstances = if equals (True : Bool) (False : Bool)
                       then equals ("dog" : String) ("log" : String)

--- a/smol-core/test/static/Eq.smol
+++ b/smol-core/test/static/Eq.smol
@@ -15,3 +15,12 @@ def flipPair pair = case pair of (a,b) -> (b,a)
 
 def main : Bool
 def main = notEquals pair (flipPair pair)
+
+instance Eq Bool = \a -> \b -> a == b
+
+instance Eq String = \a -> \b -> a == b
+
+def useNewInstances : Bool
+def useNewInstances = if equals (True : Bool) (False : Bool)
+                      then equals ("dog" : String) ("log" : String)
+                      else False

--- a/smol-core/test/static/Eq.smol
+++ b/smol-core/test/static/Eq.smol
@@ -7,3 +7,11 @@ def useEqualsA a b = equals a b
 def notEquals : (Eq a) => a -> a -> Bool
 def notEquals a b = if useEqualsA a b then False else True
 
+def pair : (Int,Int)
+def pair = (1,2)
+
+def flipPair : (a,b) -> (b, a)
+def flipPair pair = case pair of (a,b) -> (b,a)
+
+def main : Bool
+def main = notEquals pair (flipPair pair)

--- a/smol-core/test/static/Eq.smol
+++ b/smol-core/test/static/Eq.smol
@@ -1,0 +1,5 @@
+def useEqualsInt : Bool
+def useEqualsInt = equals (1: Int) (2: Int)
+
+def useEqualsA : (Eq a) => a -> a -> Bool
+def useEqualsA a b = equals a b

--- a/smol-core/test/static/Eq.smol
+++ b/smol-core/test/static/Eq.smol
@@ -3,3 +3,7 @@ def useEqualsInt = equals (1: Int) (2: Int)
 
 def useEqualsA : (Eq a) => a -> a -> Bool
 def useEqualsA a b = equals a b
+
+def notEquals : (Eq a) => a -> a -> Bool
+def notEquals a b = if useEqualsA a b then False else True
+

--- a/smol-core/test/static/Semigroup.smol
+++ b/smol-core/test/static/Semigroup.smol
@@ -1,0 +1,8 @@
+
+class Semigroup a { mappend: a -> a -> a }
+
+/* it's Sum semigroup */
+instance Semigroup Int = \a -> \b -> a + a
+
+def main : Bool
+def main = equals (mappend (20 : Int) (22 : Int)) (42 : Int)


### PR DESCRIPTION
OK, let's have typeclasses, why not? It's pull request 1000, let's not waste it.

<img width="731" alt="Screenshot 2023-08-18 at 17 43 16" src="https://github.com/danieljharvey/mimsa/assets/4729125/f6ac2309-213f-4e04-af4d-0af18d3df646">


This adds `Eq` and `Show` typeclasses built in, and we can add and use more like this:

```haskell
class Semigroup a { mappend : a -> a -> a }

instance Semigroup String = \a -> \b -> a + b

-- should be `False`
def newString : String
def newString = mappend ("dog" : String) ("log": String)
```

This all works, with some caveats, it's time to merge it and commit to this because it's quite nice.

Limitations:

- Each typeclass has only one method. Not hard to change, just cba atm.
- Only tried making single parameter typeclasses work for now, although the types allow multiple