### PR TITLE
Improve type inference of tuples in patterns

### DIFF
--- a/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
@@ -39,9 +39,9 @@ elaborate ::
   TCEnv ann ->
   ResolvedExpr ann ->
   m (ResolvedExpr (ResolvedType ann))
-elaborate env expr =
-  fmap simplifyType . fst
-    <$> runReaderT
+elaborate env expr = do
+  (typedExpr, subs) <-
+    runReaderT
       ( runWriterT
           ( evalStateT
               (infer expr)
@@ -49,6 +49,7 @@ elaborate env expr =
           )
       )
       env
+  pure (simplifyType . substituteMany subs <$> typedExpr)
 
 inferInfix ::
   ( Ord ann,


### PR DESCRIPTION
Previously if we did `\a -> case a of (b,c) -> ....` we'd choke because we couldn't match `TUnknown` with the tuple.

Now we fill that tuple with new `TUnknown`s, vomit out a constraint and march onwards.