### PR TITLE
Instances should track dependencies like expressions do

### DIFF
--- a/smol-core/smol-core.cabal
+++ b/smol-core/smol-core.cabal
@@ -121,6 +121,8 @@ library
     Smol.Core.Typecheck.Typeclass.Deduplicate
     Smol.Core.Typecheck.Typeclass.Helpers
     Smol.Core.Typecheck.Typeclass.Types
+    Smol.Core.Typecheck.Typeclass.Types.Constraint
+    Smol.Core.Typecheck.Typeclass.Types.Instance
     Smol.Core.Typecheck.Typeclass.Types.TypeclassName
     Smol.Core.Typecheck.Types
     Smol.Core.Typecheck.Types.Substitution

--- a/smol-core/src/Smol/Core/Interpreter/PatternMatch.hs
+++ b/smol-core/src/Smol/Core/Interpreter/PatternMatch.hs
@@ -54,7 +54,7 @@ patternMatches (PTuple _ pA pAs) (ETuple _ a as) = do
   pure $ matchA <> mconcat matchAs
 patternMatches (PLiteral _ pB) (EPrim _ b)
   | pB == b = pure mempty
-patternMatches (PConstructor _ _pTyCon []) (EConstructor _ _tyCon) =
+patternMatches (PConstructor _ pTyCon []) (EConstructor _ tyCon) | pTyCon == tyCon = do
   pure mempty
 patternMatches (PConstructor _ pTyCon pArgs) (EApp ann fn val) = do
   (tyCon, args) <- consAppToPattern (EApp ann fn val)

--- a/smol-core/src/Smol/Core/Modules/Check.hs
+++ b/smol-core/src/Smol/Core/Modules/Check.hs
@@ -31,7 +31,7 @@ checkModule ::
 checkModule input moduleItems = do
   myModule <- moduleFromModuleParts moduleItems
 
-  let classes = builtInClasses @Annotation <> (resolveTypeclass <$>moClasses myModule)
+  let classes = builtInClasses @Annotation <> (resolveTypeclass <$> moClasses myModule)
       typeclassMethods = S.fromList . M.elems . fmap tcFuncName $ classes
 
   (resolvedModule, deps) <-

--- a/smol-core/src/Smol/Core/Modules/Check.hs
+++ b/smol-core/src/Smol/Core/Modules/Check.hs
@@ -31,7 +31,7 @@ checkModule ::
 checkModule input moduleItems = do
   myModule <- moduleFromModuleParts moduleItems
 
-  let classes = builtInClasses @Annotation <> moClasses myModule
+  let classes = builtInClasses @Annotation <> (resolveTypeclass <$>moClasses myModule)
       typeclassMethods = S.fromList . M.elems . fmap tcFuncName $ classes
 
   (resolvedModule, deps) <-

--- a/smol-core/src/Smol/Core/Modules/Dependencies.hs
+++ b/smol-core/src/Smol/Core/Modules/Dependencies.hs
@@ -203,7 +203,7 @@ getInstanceDependencies ::
   (MonadError ResolveDepsError m) =>
   (Expr dep ann -> Set E.Entity) ->
   Module dep ann ->
-  Instance ann ->
+  Instance dep ann ->
   m (DepType dep ann, Set DefIdentifier, Set E.Entity)
 getInstanceDependencies _getUses _mod' inst = do
   -- for now we say that an instance has no dependencies of it's own

--- a/smol-core/src/Smol/Core/Modules/Dependencies.hs
+++ b/smol-core/src/Smol/Core/Modules/Dependencies.hs
@@ -118,8 +118,11 @@ getTypeDependencies mod' dt = do
   pure (DTData dt, typeDefIds <> exprDefIds, allUses)
 
 getTypeUses ::
-  (MonadError ResolveDepsError m, Ord (dep Constructor), Ord (dep TypeName),
-    Ord (dep Identifier)) =>
+  ( MonadError ResolveDepsError m,
+    Ord (dep Constructor),
+    Ord (dep TypeName),
+    Ord (dep Identifier)
+  ) =>
   Module dep ann ->
   Set E.Entity ->
   m (Set (DefIdentifier dep))
@@ -164,8 +167,11 @@ findTypesForConstructors mod' =
   S.fromList . mapMaybe (findTypenameInModule mod') . S.toList
 
 getConstructorUses ::
-  (MonadError ResolveDepsError m, Ord (dep Constructor), Ord (dep Identifier),
-    Ord (dep TypeName)) =>
+  ( MonadError ResolveDepsError m,
+    Ord (dep Constructor),
+    Ord (dep Identifier),
+    Ord (dep TypeName)
+  ) =>
   Module dep ann ->
   Set E.Entity ->
   m (Set (DefIdentifier dep))
@@ -189,7 +195,7 @@ getConstructorUses mod' uses = do
         else throwError (CannotFindTypes unknownTypeDeps)
 
 getExprDependencies ::
-  (MonadError ResolveDepsError m, Ord (dep Constructor), Ord (dep TypeName),Ord (dep Identifier)) =>
+  (MonadError ResolveDepsError m, Ord (dep Constructor), Ord (dep TypeName), Ord (dep Identifier)) =>
   (Expr dep ann -> Set E.Entity) ->
   Module dep ann ->
   TopLevelExpression dep ann ->
@@ -202,8 +208,7 @@ getExprDependencies getUses mod' expr = do
   pure (DTExpr expr, exprDefIds <> typeDefIds <> consDefIds, allUses)
 
 getInstanceDependencies ::
-  (MonadError ResolveDepsError m, Ord (dep Constructor), Ord (dep TypeName),Ord (dep Identifier)) =>
-
+  (MonadError ResolveDepsError m, Ord (dep Constructor), Ord (dep TypeName), Ord (dep Identifier)) =>
   (Expr dep ann -> Set E.Entity) ->
   Module dep ann ->
   Instance dep ann ->

--- a/smol-core/src/Smol/Core/Modules/FromParts.hs
+++ b/smol-core/src/Smol/Core/Modules/FromParts.hs
@@ -7,7 +7,6 @@
 module Smol.Core.Modules.FromParts (addModulePart, moduleFromModuleParts, exprAndTypeFromParts) where
 
 import Control.Monad.Except
-import Control.Monad.Identity
 import Data.Coerce
 import Data.Functor (void)
 import qualified Data.Map.Strict as M
@@ -31,9 +30,6 @@ moduleFromModuleParts parts =
         mod' <- output
         addModulePart parts part mod'
    in foldr addPart (pure mempty) parts
-
-identityFromParseDep :: Expr ParseDep ann -> Expr Identity ann
-identityFromParseDep = mapExprDep (Identity . pdIdentifier)
 
 addModulePart ::
   (MonadError (ModuleError ann) m, Monoid ann) =>
@@ -75,7 +71,7 @@ addModulePart allParts part mod' =
                 (void constraint)
                 ( Instance
                     { inConstraints = mempty,
-                      inExpr = identityFromParseDep expr
+                      inExpr = expr
                     }
                 )
                 <> moInstances mod'

--- a/smol-core/src/Smol/Core/Modules/FromParts.hs
+++ b/smol-core/src/Smol/Core/Modules/FromParts.hs
@@ -63,14 +63,14 @@ addModulePart allParts part mod' =
     ModuleClass tc ->
       -- TODO: check duplicates and explode
       pure $ mod' {moClasses = M.singleton (tcName tc) tc <> moClasses mod'}
-    ModuleInstance constraint expr ->
+    ModuleInstance constraints constraint expr ->
       pure $
         mod'
           { moInstances =
               M.singleton
                 (void constraint)
                 ( Instance
-                    { inConstraints = mempty,
+                    { inConstraints = constraints,
                       inExpr = expr
                     }
                 )

--- a/smol-core/src/Smol/Core/Modules/FromParts.hs
+++ b/smol-core/src/Smol/Core/Modules/FromParts.hs
@@ -131,7 +131,7 @@ findExpression ident moduleItems =
 expressionExists :: (Monoid ann) => Identifier -> [ModuleItem ann] -> Bool
 expressionExists ident moduleItems = isJust (findExpression ident moduleItems)
 
-findTypeExpression :: Identifier -> [ModuleItem ann] -> Maybe ([Constraint ann], Type ParseDep ann)
+findTypeExpression :: Identifier -> [ModuleItem ann] -> Maybe ([Constraint ParseDep ann], Type ParseDep ann)
 findTypeExpression ident moduleItems =
   case mapMaybe
     ( \case

--- a/smol-core/src/Smol/Core/Modules/Helpers.hs
+++ b/smol-core/src/Smol/Core/Modules/Helpers.hs
@@ -13,7 +13,7 @@ import Smol.Core
 import Smol.Core.Helpers (filterMapKeys)
 import Smol.Core.Modules.Types.DefIdentifier
 
-filterNameDefs :: Map DefIdentifier a -> Map Identifier a
+filterNameDefs :: Map (DefIdentifier dep) a -> Map Identifier a
 filterNameDefs =
   filterMapKeys
     ( \case
@@ -21,7 +21,7 @@ filterNameDefs =
         _ -> Nothing
     )
 
-filterTypeDefs :: Map DefIdentifier a -> Map TypeName a
+filterTypeDefs :: Map (DefIdentifier dep) a -> Map TypeName a
 filterTypeDefs =
   filterMapKeys
     ( \case

--- a/smol-core/src/Smol/Core/Modules/ResolveDeps.hs
+++ b/smol-core/src/Smol/Core/Modules/ResolveDeps.hs
@@ -32,7 +32,7 @@ resolveExprDeps ::
   (Show ann, MonadError ResolveDepsError m) =>
   Expr ParseDep ann ->
   Set Identifier ->
-  Set DefIdentifier ->
+  Set (DefIdentifier ParseDep) ->
   m (Expr ResolvedDep ann)
 resolveExprDeps expr typeclassMethods localDefs =
   evalStateT (resolveExpr expr typeclassMethods localDefs mempty) (ResolveState 0)
@@ -41,7 +41,7 @@ resolveExpr ::
   (Show ann, MonadError ResolveDepsError m, MonadState ResolveState m) =>
   Expr ParseDep ann ->
   Set Identifier ->
-  Set DefIdentifier ->
+  Set (DefIdentifier ParseDep) ->
   Set Constructor ->
   m (Expr ResolvedDep ann)
 resolveExpr expr typeclassMethods localDefs localTypes =
@@ -55,15 +55,17 @@ resolveModuleDeps ::
   (Show ann, Eq ann, MonadError ResolveDepsError m) =>
   Set Identifier ->
   Module ParseDep ann ->
-  m (Module ResolvedDep ann, Map DefIdentifier (Set DefIdentifier))
+  m (Module ResolvedDep ann, Map (DefIdentifier ResolvedDep) (Set (DefIdentifier ResolvedDep)))
 resolveModuleDeps typeclassMethods parsedModule = do
   map' <- getDependencies extractUses parsedModule
   let resolveIt (DTData dt, _, _) =
         pure (DTData (resolveDataType dt))
       resolveIt (DTExpr expr, defIds, _entities) =
         DTExpr <$> resolveTopLevelExpression expr typeclassMethods defIds (allConstructors parsedModule)
-      resolveIt (DTInstance inst, _defIds, _entities) =
-        pure (DTInstance inst)
+      resolveIt (DTInstance inst, defIds, _entities) = do
+        resolvedExpr <- resolveExpr (inExpr inst) typeclassMethods defIds (allConstructors parsedModule)
+        pure (DTInstance (Instance {inConstraints = resolveConstraint <$> inConstraints inst,
+            inExpr = resolvedExpr}))
 
   resolvedMap <- evalStateT (traverse resolveIt map') (ResolveState 0)
 
@@ -93,13 +95,14 @@ resolveModuleDeps typeclassMethods parsedModule = do
 
       dependencies = (\(_, b, _) -> b) <$> map'
    in pure
-        ( parsedModule
+        ( Module
             { moExpressions = resolvedExpressions,
               moDataTypes = resolvedDataTypes,
-              moInstances = resolvedInstances,
-              moClasses = moClasses parsedModule
+              moTests = moTests parsedModule,
+              moInstances = M.mapKeys resolveConstraint resolvedInstances,
+              moClasses = resolveTypeclass <$> moClasses parsedModule
             },
-          dependencies
+          dependencies -- TODO: need to resolve the DefIdentifiers here
         )
 
 mapMaybeWithKey :: (Ord k2) => (k -> a -> Maybe (k2, b)) -> Map k a -> Map k2 b
@@ -109,12 +112,22 @@ allConstructors :: Module dep ann -> Set Constructor
 allConstructors Module {moDataTypes} =
   foldMap (\(DataType {dtConstructors}) -> M.keysSet dtConstructors) moDataTypes
 
+
+
+resolveTypeclass :: Typeclass ParseDep ann -> Typeclass ResolvedDep ann
+resolveTypeclass (Typeclass {} )
+  = Typeclass {}
+
 resolveDataType :: DataType ParseDep ann -> DataType ResolvedDep ann
 resolveDataType (DataType {dtName, dtVars, dtConstructors}) =
   DataType dtName dtVars (resolveDataConstructor <$> dtConstructors)
   where
     resolveDataConstructor tys =
       resolveType <$> tys
+
+resolveConstraint :: Constraint ParseDep ann -> Constraint ResolvedDep ann
+resolveConstraint (Constraint tcn tys)
+  = Constraint tcn (resolveType <$> tys)
 
 resolveType :: Type ParseDep ann -> Type ResolvedDep ann
 resolveType (TVar ann (ParseDep v _)) = TVar ann (LocalDefinition v)
@@ -138,7 +151,7 @@ resolveTopLevelExpression ::
   (Show ann, MonadState ResolveState m, MonadError ResolveDepsError m) =>
   TopLevelExpression ParseDep ann ->
   Set Identifier ->
-  Set DefIdentifier ->
+  Set (DefIdentifier ParseDep) ->
   Set Constructor ->
   m (TopLevelExpression ResolvedDep ann)
 resolveTopLevelExpression tle typeclassMethods localDefs localTypes = flip runReaderT initialEnv $ do
@@ -147,7 +160,7 @@ resolveTopLevelExpression tle typeclassMethods localDefs localTypes = flip runRe
 
   pure
     ( TopLevelExpression
-        { tleConstraints = tleConstraints tle,
+        { tleConstraints = resolveConstraint <$> tleConstraints tle,
           tleExpr = resolvedExpr,
           tleType = resolvedType
         }
@@ -241,7 +254,7 @@ withNewIdentifiers resolvedIdentifiers =
 
 data ResolveEnv = ResolveEnv
   { reExisting :: Map Identifier Int,
-    reLocal :: Set DefIdentifier,
+    reLocal :: Set (DefIdentifier ParseDep),
     reLocalConstructor :: Set Constructor,
     reTypeclassMethods :: Set Identifier
   }

--- a/smol-core/src/Smol/Core/Modules/Typecheck.hs
+++ b/smol-core/src/Smol/Core/Modules/Typecheck.hs
@@ -22,7 +22,7 @@ import Smol.Core.Modules.Types
 import Smol.Core.Modules.Types.DepType
 import Smol.Core.Modules.Types.ModuleError
 import Smol.Core.Typecheck.Typecheck (typecheck)
-import Smol.Core.Typecheck.Typeclass (checkInstance, lookupTypeclass )
+import Smol.Core.Typecheck.Typeclass (checkInstance, lookupTypeclass)
 import Smol.Core.Typecheck.Typeclass.BuiltIns
 
 -- go through the module, and wrap all the items in DefIdentifier keys and
@@ -31,7 +31,7 @@ getModuleDefIdentifiers ::
   (Ord (dep Constructor), Ord (dep TypeName), Ord (dep Identifier)) =>
   Map (DefIdentifier dep) (Set (DefIdentifier dep)) ->
   Module dep ann ->
-  Map (DefIdentifier dep) (DefIdentifier dep , DepType dep ann, Set (DefIdentifier dep))
+  Map (DefIdentifier dep) (DefIdentifier dep, DepType dep ann, Set (DefIdentifier dep))
 getModuleDefIdentifiers depMap inputModule =
   let getDeps di = fromMaybe mempty (M.lookup di depMap)
       exprs =
@@ -93,7 +93,6 @@ moduleFromDepTypes oldModule definitions =
       typedClasses =
         (\tc -> tc $> tcFuncType tc)
           <$> moClasses oldModule
-
    in -- replace input module with typechecked versions
 
       oldModule

--- a/smol-core/src/Smol/Core/Modules/Types/DefIdentifier.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/DefIdentifier.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/smol-core/src/Smol/Core/Modules/Types/DefIdentifier.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/DefIdentifier.hs
@@ -3,7 +3,8 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
-  {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Smol.Core.Modules.Types.DefIdentifier
   ( DefIdentifier (..),
   )
@@ -23,19 +24,19 @@ data DefIdentifier dep
   | DIType TypeName
   | DITest TestName
   | DIInstance (Constraint dep ())
-  deriving stock (  Generic)
+  deriving stock (Generic)
 
-deriving stock instance (Eq (dep Constructor), Eq (dep TypeName), Eq (dep Identifier)) =>
+deriving stock instance
+  (Eq (dep Constructor), Eq (dep TypeName), Eq (dep Identifier)) =>
   Eq (DefIdentifier dep)
 
-deriving stock instance (Ord (dep Constructor), Ord ( dep TypeName), Ord (dep Identifier)) =>
+deriving stock instance
+  (Ord (dep Constructor), Ord (dep TypeName), Ord (dep Identifier)) =>
   Ord (DefIdentifier dep)
 
-
-deriving stock instance (Show (dep Constructor), Show (dep TypeName), Show (dep Identifier)) =>
+deriving stock instance
+  (Show (dep Constructor), Show (dep TypeName), Show (dep Identifier)) =>
   Show (DefIdentifier dep)
-
-
 
 instance (Printer (dep Identifier), Printer (dep TypeName)) => Printer (DefIdentifier dep) where
   prettyDoc (DIName name) = prettyDoc name

--- a/smol-core/src/Smol/Core/Modules/Types/DefIdentifier.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/DefIdentifier.hs
@@ -2,35 +2,42 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
-
+{-# LANGUAGE StandaloneDeriving #-}
+  {-# LANGUAGE UndecidableInstances #-}
 module Smol.Core.Modules.Types.DefIdentifier
   ( DefIdentifier (..),
   )
 where
 
-import qualified Data.Aeson as JSON
-import GHC.Generics
+import GHC.Generics (Generic)
 import Smol.Core.Modules.Types.TestName
 import Smol.Core.Printer
 import Smol.Core.Typecheck.Typeclass.Types
+import Smol.Core.Types.Constructor
 import Smol.Core.Types.Identifier
 import Smol.Core.Types.TypeName
 
 -- | different kinds of top-level definitions
-data DefIdentifier
+data DefIdentifier dep
   = DIName Identifier
   | DIType TypeName
   | DITest TestName
-  | DIInstance (Constraint ())
-  deriving stock (Eq, Ord, Show, Generic)
-  deriving anyclass
-    ( JSON.ToJSON,
-      JSON.ToJSONKey,
-      JSON.FromJSON,
-      JSON.FromJSONKey
-    )
+  | DIInstance (Constraint dep ())
+  deriving stock (  Generic)
 
-instance Printer DefIdentifier where
+deriving stock instance (Eq (dep Constructor), Eq (dep TypeName), Eq (dep Identifier)) =>
+  Eq (DefIdentifier dep)
+
+deriving stock instance (Ord (dep Constructor), Ord ( dep TypeName), Ord (dep Identifier)) =>
+  Ord (DefIdentifier dep)
+
+
+deriving stock instance (Show (dep Constructor), Show (dep TypeName), Show (dep Identifier)) =>
+  Show (DefIdentifier dep)
+
+
+
+instance (Printer (dep Identifier), Printer (dep TypeName)) => Printer (DefIdentifier dep) where
   prettyDoc (DIName name) = prettyDoc name
   -- prettyDoc (DIInfix infixOp) = prettyDoc infixOp
   prettyDoc (DIType typeName) = prettyDoc typeName

--- a/smol-core/src/Smol/Core/Modules/Types/DepType.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/DepType.hs
@@ -12,7 +12,7 @@ import Smol.Core.Modules.Types.TopLevelExpression
 
 data DepType dep ann
   = DTExpr (TopLevelExpression dep ann)
-  | DTInstance (Instance ann)
+  | DTInstance (Instance dep ann)
   | DTData (DataType dep ann)
 
 deriving stock instance

--- a/smol-core/src/Smol/Core/Modules/Types/Module.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/Module.hs
@@ -41,8 +41,8 @@ data Module dep ann = Module
   { moExpressions :: Map Identifier (TopLevelExpression dep ann),
     moDataTypes :: Map TypeName (DataType dep ann),
     moTests :: [Test],
-    moInstances :: Map (Constraint ()) (Instance dep ann),
-    moClasses :: Map TypeclassName (Typeclass ann)
+    moInstances :: Map (Constraint dep ()) (Instance dep ann),
+    moClasses :: Map TypeclassName (Typeclass dep ann)
   }
   deriving stock (Functor, Generic)
 
@@ -81,6 +81,8 @@ deriving anyclass instance
 
 deriving anyclass instance
   ( Ord (dep Identifier),
+    Ord (dep Constructor),
+    Ord (dep TypeName),
     FromJSONKey (dep Identifier),
     FromJSON ann,
     FromJSON (dep TypeName),
@@ -132,11 +134,11 @@ printDefinition name (TopLevelExpression {tleType, tleExpr}) =
         Nothing -> ""
    in prettyType <> prettyExpr
 
-instance Semigroup (Module dep ann) where
+instance (Ord (dep Constructor), Ord (dep TypeName), Ord (dep Identifier)) => Semigroup (Module dep ann) where
   (Module a b c d e) <> (Module a' b' c' d' e') =
     Module (a <> a') (b <> b') (c <> c') (d <> d') (e <> e')
 
-instance Monoid (Module dep ann) where
+instance (Ord (dep Constructor), Ord (dep Identifier), Ord (dep TypeName)) => Monoid (Module dep ann) where
   mempty =
     Module
       mempty

--- a/smol-core/src/Smol/Core/Modules/Types/Module.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/Module.hs
@@ -41,7 +41,7 @@ data Module dep ann = Module
   { moExpressions :: Map Identifier (TopLevelExpression dep ann),
     moDataTypes :: Map TypeName (DataType dep ann),
     moTests :: [Test],
-    moInstances :: Map (Constraint ()) (Instance ann),
+    moInstances :: Map (Constraint ()) (Instance dep ann),
     moClasses :: Map TypeclassName (Typeclass ann)
   }
   deriving stock (Functor, Generic)

--- a/smol-core/src/Smol/Core/Modules/Types/ModuleError.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/ModuleError.hs
@@ -57,10 +57,8 @@ data ModuleError ann
   | CannotFindValues (Set Identifier)
   | CannotFindConstructors (Set Constructor)
   | ErrorInResolveDeps ResolveDepsError
-  | DefDoesNotTypeCheck Text DefIdentifier (TCError ann)
+  | DefDoesNotTypeCheck Text (DefIdentifier ResolvedDep) (TCError ann)
   | NamedImportNotFound (Set ModuleName) ModuleName
-  | DefMissingReturnType DefIdentifier
-  | DefMissingTypeAnnotation DefIdentifier Identifier
   | EmptyTestName Identifier
   | ErrorInTest TestName (TestError ann)
   | ErrorInInterpreter (InterpreterError ann)

--- a/smol-core/src/Smol/Core/Modules/Types/ModuleItem.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/ModuleItem.hs
@@ -42,12 +42,12 @@ import Smol.Core.Types.TypeName
 -- TODO: add more annotations to everything so we can produce clearer errors
 -- when things don't make sense (duplicate defs etc)
 data ModuleItem ann
-  = ModuleExpression Identifier [Identifier] (ParsedExpr ann)
-  | ModuleExpressionType Identifier [Constraint ann] (Type ParseDep ann)
+  = ModuleExpression Identifier [Identifier] (Expr ParseDep ann)
+  | ModuleExpressionType Identifier [Constraint ParseDep ann] (Type ParseDep ann)
   | ModuleDataType (DataType ParseDep ann)
   | ModuleTest TestName Identifier
-  | ModuleInstance (Constraint ann) (ParsedExpr ann)
-  | ModuleClass (Typeclass ann)
+  | ModuleInstance (Constraint ParseDep ann) (Expr ParseDep ann)
+  | ModuleClass (Typeclass ParseDep ann)
   deriving stock (Eq, Ord, Functor)
 
 deriving stock instance

--- a/smol-core/src/Smol/Core/Modules/Types/ModuleItem.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/ModuleItem.hs
@@ -46,7 +46,7 @@ data ModuleItem ann
   | ModuleExpressionType Identifier [Constraint ParseDep ann] (Type ParseDep ann)
   | ModuleDataType (DataType ParseDep ann)
   | ModuleTest TestName Identifier
-  | ModuleInstance (Constraint ParseDep ann) (Expr ParseDep ann)
+  | ModuleInstance [Constraint ParseDep ann] (Constraint ParseDep ann) (Expr ParseDep ann)
   | ModuleClass (Typeclass ParseDep ann)
   deriving stock (Eq, Ord, Functor)
 

--- a/smol-core/src/Smol/Core/Modules/Types/TopLevelExpression.hs
+++ b/smol-core/src/Smol/Core/Modules/Types/TopLevelExpression.hs
@@ -28,7 +28,7 @@ import Smol.Core.Types.TypeName
 
 -- a single expression of zero or more exprs and an optional type
 data TopLevelExpression dep ann = TopLevelExpression
-  { tleConstraints :: [Constraint ann],
+  { tleConstraints :: [Constraint dep ann],
     tleExpr :: Expr dep ann,
     tleType :: Maybe (Type dep ann)
   }

--- a/smol-core/src/Smol/Core/Parser.hs
+++ b/smol-core/src/Smol/Core/Parser.hs
@@ -49,7 +49,7 @@ parseExprAndFormatError = parseAndFormat (space *> expressionParser <* eof)
 parseModule :: Text -> Either ParseErrorType [ModuleItem Annotation]
 parseModule = parse (space *> moduleParser <* eof) "repl"
 
-parseConstraint :: Text -> Either ParseErrorType (Constraint Annotation)
+parseConstraint :: Text -> Either ParseErrorType (Constraint ParseDep Annotation)
 parseConstraint = parse (space *> constraintParser <* eof) "repl"
 
 parseModuleAndFormatError :: Text -> Either Text [ModuleItem Annotation]
@@ -58,5 +58,5 @@ parseModuleAndFormatError = parseAndFormat (space *> moduleParser <* eof)
 parseDataTypeAndFormatError :: Text -> Either Text (DataType ParseDep Annotation)
 parseDataTypeAndFormatError = parseAndFormat (space *> dataTypeParser <* eof)
 
-parseConstraintAndFormatError :: Text -> Either Text (Constraint Annotation)
+parseConstraintAndFormatError :: Text -> Either Text (Constraint ParseDep Annotation)
 parseConstraintAndFormatError = parseAndFormat (space *> constraintParser <* eof)

--- a/smol-core/src/Smol/Core/Parser/Module.hs
+++ b/smol-core/src/Smol/Core/Parser/Module.hs
@@ -101,9 +101,10 @@ parseTest = do
 parseInstance :: Parser (ModuleItem Annotation)
 parseInstance = do
   myString "instance"
-  constraint <- constraintParser
+  constraints <- try typeConstraintParser <|> pure mempty
+  mainConstraint <- constraintParser
   myString "="
-  ModuleInstance constraint <$> expressionParser
+  ModuleInstance constraints mainConstraint <$> expressionParser
 
 parseClass :: Parser (ModuleItem Annotation)
 parseClass = do

--- a/smol-core/src/Smol/Core/Parser/Module.hs
+++ b/smol-core/src/Smol/Core/Parser/Module.hs
@@ -6,11 +6,9 @@ module Smol.Core.Parser.Module
   )
 where
 
-import Control.Monad.Identity
 import qualified Data.List.NonEmpty as NE
 import Data.Text (Text)
 import Data.Void
-import Smol.Core.ExprUtils
 import Smol.Core.Modules.Types.ModuleItem
 import Smol.Core.Parser.DataType (dataTypeParser)
 import Smol.Core.Parser.Expr
@@ -83,7 +81,7 @@ moduleTypeDefinitionParser = do
   constraints <- try typeConstraintParser <|> pure mempty
   ModuleExpressionType name constraints <$> typeParser
 
-typeConstraintParser :: Parser [Constraint Annotation]
+typeConstraintParser :: Parser [Constraint ParseDep Annotation]
 typeConstraintParser = do
   myString "("
   constraints <- commaSep constraintParser
@@ -117,8 +115,7 @@ parseClass = do
   myString "{"
   fnName <- identifierParser
   myString ":"
-  let resolve (ParseDep a _) = Identity a
-  ty <- mapTypeDep resolve <$> typeParser
+  ty <- typeParser
   myString "}"
 
   pure $

--- a/smol-core/src/Smol/Core/Parser/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Parser/Typeclass.hs
@@ -3,10 +3,8 @@ module Smol.Core.Parser.Typeclass
   )
 where
 
-import Control.Monad.Identity
 import Data.Text (Text)
 import Data.Void
-import Smol.Core.ExprUtils
 import Smol.Core.Parser.Identifiers
 import Smol.Core.Parser.Type
 import Smol.Core.Typecheck.Types
@@ -15,14 +13,9 @@ import Text.Megaparsec hiding (parseTest)
 
 type Parser = Parsec Void Text
 
-toIdentity :: Type ParseDep ann -> Type Identity ann
-toIdentity = mapTypeDep resolve
-  where
-    resolve (ParseDep ident _) = Identity ident
-
-constraintParser :: Parser (Constraint Annotation)
+constraintParser :: Parser (Constraint ParseDep Annotation)
 constraintParser = do
   tcn <- typeclassNameParser
   tys <- many typeParser
 
-  pure $ Constraint tcn (toIdentity <$> tys)
+  pure $ Constraint tcn tys

--- a/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Elaborate.hs
@@ -40,7 +40,7 @@ elaborate ::
   ) =>
   TCEnv ann ->
   ResolvedExpr ann ->
-  m (ResolvedExpr (ResolvedType ann), M.Map (ResolvedDep Identifier) (Constraint ann))
+  m (ResolvedExpr (ResolvedType ann), M.Map (ResolvedDep Identifier) (Constraint ResolvedDep ann))
 elaborate env expr =
   runReaderT
     ( runWriterT

--- a/smol-core/src/Smol/Core/Typecheck/Typecheck.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typecheck.hs
@@ -17,7 +17,7 @@ typecheck ::
   (MonadError (TCError ann) m, Monoid ann, Show ann, Ord ann) =>
   TCEnv ann ->
   ResolvedExpr ann ->
-  m ([Constraint ann], ResolvedExpr (ResolvedType ann))
+  m ([Constraint ResolvedDep ann], ResolvedExpr (ResolvedType ann))
 typecheck env expr = do
   (typedExpr, typeclassUses) <- elaborate env expr
 

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -48,8 +48,10 @@ lookupInstanceAndCheck env tch@(Constraint typeclassName _) = do
     Nothing -> error "fuck"
   checkInstance env typeclass tch tcInstance
 
-applyConstraintTypes :: Typeclass ResolvedDep ann ->
-    Constraint ResolvedDep ann -> Type ResolvedDep ann
+applyConstraintTypes ::
+  Typeclass ResolvedDep ann ->
+  Constraint ResolvedDep ann ->
+  Type ResolvedDep ann
 applyConstraintTypes (Typeclass _ args _ ty) (Constraint _ tys) =
   let subs =
         ( \(ident, tySub) ->
@@ -158,7 +160,7 @@ convertExprToUseTypeclassDictionary env constraints expr = do
 createTypeclassDict ::
   (Show ann, Ord ann, Monoid ann, MonadError (TCError ann) m) =>
   TCEnv ann ->
-  NE.NonEmpty (Constraint ResolvedDep  ann) ->
+  NE.NonEmpty (Constraint ResolvedDep ann) ->
   m (Expr ResolvedDep (Type ResolvedDep ann))
 createTypeclassDict env constraints = do
   instances <-

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Smol.Core.Typecheck.Typeclass

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -4,8 +4,6 @@
 
 module Smol.Core.Typecheck.Typeclass
   ( checkInstance,
-    resolveType,
-    toIdentityExpr,
     lookupInstanceAndCheck,
     convertExprToUseTypeclassDictionary,
     getTypeclassMethodNames,
@@ -19,16 +17,13 @@ where
 
 import Control.Monad
 import Control.Monad.Except
-import Control.Monad.Identity
 import Data.Functor
 import Data.List (elemIndex)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
-import Data.Maybe (mapMaybe)
 import qualified Data.Set as S
 import Smol.Core.ExprUtils
 import Smol.Core.Helpers
-import Smol.Core.Modules.ResolveDeps
 import Smol.Core.Typecheck.Shared
 import Smol.Core.Typecheck.Substitute
 import Smol.Core.Typecheck.Typecheck (typecheck)
@@ -37,30 +32,13 @@ import Smol.Core.Typecheck.Typeclass.Helpers
 import Smol.Core.Typecheck.Types
 import Smol.Core.Types
 
-toParseExpr :: Expr Identity ann -> Expr ParseDep ann
-toParseExpr = mapExprDep resolve
-  where
-    resolve (Identity a) = emptyParseDep a
-
-toIdentityExpr :: Expr ResolvedDep ann -> Expr Identity ann
-toIdentityExpr = mapExprDep resolve
-  where
-    resolve (LocalDefinition a) = Identity a
-    resolve (UniqueDefinition a _) = Identity a
-    resolve (TypeclassCall a _) = Identity a
-
-resolveType :: Type Identity ann -> Type ResolvedDep ann
-resolveType = mapTypeDep resolve
-  where
-    resolve (Identity a) = emptyResolvedDep a
-
 lookupInstanceAndCheck ::
   (Ord ann, Monoid ann, Show ann, MonadError (TCError ann) m) =>
   TCEnv ann ->
-  Constraint ann ->
+  Constraint ResolvedDep ann ->
   m
     ( Identifier,
-      [Constraint ann],
+      [Constraint ResolvedDep ann],
       Expr ResolvedDep (Type ResolvedDep ann)
     )
 lookupInstanceAndCheck env tch@(Constraint typeclassName _) = do
@@ -70,11 +48,12 @@ lookupInstanceAndCheck env tch@(Constraint typeclassName _) = do
     Nothing -> error "fuck"
   checkInstance env typeclass tch tcInstance
 
-applyConstraintTypes :: Typeclass ann -> Constraint ann -> Type Identity ann
+applyConstraintTypes :: Typeclass ResolvedDep ann ->
+    Constraint ResolvedDep ann -> Type ResolvedDep ann
 applyConstraintTypes (Typeclass _ args _ ty) (Constraint _ tys) =
   let subs =
         ( \(ident, tySub) ->
-            Substitution (SubId $ Identity ident) tySub
+            Substitution (SubId $ LocalDefinition ident) tySub
         )
           <$> zip args tys
    in substituteMany subs ty
@@ -82,37 +61,22 @@ applyConstraintTypes (Typeclass _ args _ ty) (Constraint _ tys) =
 checkInstance ::
   (MonadError (TCError ann) m, Monoid ann, Ord ann, Show ann) =>
   TCEnv ann ->
-  Typeclass ann ->
-  Constraint ann ->
+  Typeclass ResolvedDep ann ->
+  Constraint ResolvedDep ann ->
   Instance ResolvedDep ann ->
-  m (Identifier, [Constraint ann], Expr ResolvedDep (Type ResolvedDep ann))
+  m (Identifier, [Constraint ResolvedDep ann], Expr ResolvedDep (Type ResolvedDep ann))
 checkInstance tcEnv typeclass constraint (Instance constraints expr) =
   do
     let subbedType = applyConstraintTypes typeclass constraint
         funcName = tcFuncName typeclass
 
-    let -- we add the instance's constraints (so typechecker forgives a missing `Eq a` etc)
-        typecheckEnv = tcEnv {tceConstraints = constraints}
+    -- we add the instance's constraints (so typechecker forgives a missing `Eq a` etc)
+    let typecheckEnv = tcEnv {tceConstraints = constraints}
+        annotatedExpr = EAnn (getExprAnnotation expr) subbedType expr
 
-        annotatedExpr = EAnn (getExprAnnotation expr) subbedType undefined --expr
+    (newConstraints, typedExpr) <- typecheck typecheckEnv annotatedExpr
 
-        -- let's get all the method names from the Typeclasses
-        -- mentioned in the instance constraints
-        typeclassMethodNames =
-          S.fromList $
-            mapMaybe
-              ( \(Constraint tcn _) -> case M.lookup tcn (tceClasses tcEnv) of
-                  Just (Typeclass {tcFuncName}) -> Just tcFuncName
-                  _ -> Nothing
-              )
-              constraints
-
-    case resolveExprDeps annotatedExpr typeclassMethodNames mempty of
-      Left resolveErr -> error $ "Resolve error: " <> show resolveErr
-      Right resolvedExpr -> do
-        (newConstraints, typedExpr) <- typecheck typecheckEnv resolvedExpr
-
-        pure (funcName, newConstraints, typedExpr)
+    pure (funcName, newConstraints, typedExpr)
 
 -- let's get all the method names from the Typeclasses
 -- mentioned in the instance constraints
@@ -128,7 +92,7 @@ getTypeForDictionary ::
     Monoid ann
   ) =>
   TCEnv ann ->
-  [Constraint ann] ->
+  [Constraint ResolvedDep ann] ->
   m (Maybe (Pattern ResolvedDep (Type ResolvedDep ann)))
 getTypeForDictionary env constraints = do
   let getConstraintPattern constraint i = do
@@ -140,7 +104,7 @@ getTypeForDictionary env constraints = do
           -- we didn't find an instance, but we can get the type from the
           -- constraint
           Left e -> case typeForConstraint env constraint of
-            Just ty -> pure (resolveType ty)
+            Just ty -> pure ty
             Nothing -> throwError e
         pure (PVar ty ident)
   case constraints of
@@ -156,7 +120,7 @@ getTypeForDictionary env constraints = do
 -- them, however for constraints we don't have concrete code yet
 -- however, we can just substitute the types from the Constraint to the Typeclass
 -- to see what type we should get
-typeForConstraint :: TCEnv ann -> Constraint ann -> Maybe (Type Identity ann)
+typeForConstraint :: TCEnv ann -> Constraint ResolvedDep ann -> Maybe (Type ResolvedDep ann)
 typeForConstraint env constraint@(Constraint tcn _) = do
   M.lookup tcn (tceClasses env)
     <&> \typeclass -> applyConstraintTypes typeclass constraint
@@ -167,7 +131,7 @@ typeForConstraint env constraint@(Constraint tcn _) = do
 convertExprToUseTypeclassDictionary ::
   (MonadError (TCError ann) m, Ord ann, Show ann, Monoid ann) =>
   TCEnv ann ->
-  [Constraint ann] ->
+  [Constraint ResolvedDep ann] ->
   Expr ResolvedDep (Type ResolvedDep ann) ->
   m (Expr ResolvedDep (Type ResolvedDep ann))
 convertExprToUseTypeclassDictionary env constraints expr = do
@@ -194,7 +158,7 @@ convertExprToUseTypeclassDictionary env constraints expr = do
 createTypeclassDict ::
   (Show ann, Ord ann, Monoid ann, MonadError (TCError ann) m) =>
   TCEnv ann ->
-  NE.NonEmpty (Constraint ann) ->
+  NE.NonEmpty (Constraint ResolvedDep  ann) ->
   m (Expr ResolvedDep (Type ResolvedDep ann))
 createTypeclassDict env constraints = do
   instances <-
@@ -209,7 +173,7 @@ createTypeclassDict env constraints = do
               -- no concrete instance, maybe we can pass through a constraint
               -- from the current function
               case (,) <$> elemIndex constraint (tceConstraints env) <*> typeForConstraint env constraint of
-                Just (index, ty) -> pure (EVar (resolveType ty) (identForConstraint $ fromIntegral index))
+                Just (index, ty) -> pure (EVar ty (identForConstraint $ fromIntegral index))
                 Nothing -> throwError e
       )
       constraints
@@ -219,7 +183,7 @@ createTypeclassDict env constraints = do
       let ty = TTuple mempty (getExprAnnotation theFirst) (getExprAnnotation <$> theRest)
        in pure $ ETuple ty theFirst theRest
 
-filterNotConcrete :: [Constraint ann] -> [Constraint ann]
+filterNotConcrete :: [Constraint ResolvedDep ann] -> [Constraint ResolvedDep ann]
 filterNotConcrete = filter (not . isConcrete)
 
 -- given we know the types of all our deps
@@ -257,7 +221,7 @@ passDictionaries env =
 toDictionaryPassing ::
   (MonadError (TCError ann) m, Show ann, Ord ann, Monoid ann) =>
   TCEnv ann ->
-  [Constraint ann] ->
+  [Constraint ResolvedDep ann] ->
   Expr ResolvedDep (Type ResolvedDep ann) ->
   m (Expr ResolvedDep (Type ResolvedDep ann))
 toDictionaryPassing env constraints expr = do

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass.hs
@@ -84,7 +84,7 @@ checkInstance ::
   TCEnv ann ->
   Typeclass ann ->
   Constraint ann ->
-  Instance ann ->
+  Instance ResolvedDep ann ->
   m (Identifier, [Constraint ann], Expr ResolvedDep (Type ResolvedDep ann))
 checkInstance tcEnv typeclass constraint (Instance constraints expr) =
   do
@@ -94,7 +94,7 @@ checkInstance tcEnv typeclass constraint (Instance constraints expr) =
     let -- we add the instance's constraints (so typechecker forgives a missing `Eq a` etc)
         typecheckEnv = tcEnv {tceConstraints = constraints}
 
-        annotatedExpr = EAnn (getExprAnnotation expr) subbedType expr
+        annotatedExpr = EAnn (getExprAnnotation expr) subbedType undefined --expr
 
         -- let's get all the method names from the Typeclasses
         -- mentioned in the instance constraints
@@ -107,7 +107,7 @@ checkInstance tcEnv typeclass constraint (Instance constraints expr) =
               )
               constraints
 
-    case resolveExprDeps (toParseExpr annotatedExpr) typeclassMethodNames mempty of
+    case resolveExprDeps annotatedExpr typeclassMethodNames mempty of
       Left resolveErr -> error $ "Resolve error: " <> show resolveErr
       Right resolvedExpr -> do
         (newConstraints, typedExpr) <- typecheck typecheckEnv resolvedExpr

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Deduplicate.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Deduplicate.hs
@@ -19,9 +19,9 @@ import Smol.Core.Types
 -- | find deduplicated constraints and apply them to expr
 deduplicateConstraints ::
   (Ord ann) =>
-  M.Map (ResolvedDep Identifier) (Constraint ann) ->
+  M.Map (ResolvedDep Identifier) (Constraint ResolvedDep ann) ->
   Expr ResolvedDep (Type ResolvedDep ann) ->
-  ([Constraint ann], Expr ResolvedDep (Type ResolvedDep ann))
+  ([Constraint ResolvedDep ann], Expr ResolvedDep (Type ResolvedDep ann))
 deduplicateConstraints constraints expr = do
   let (dedupedConstraints, nameSwaps) = findDedupedConstraints constraints
    in (dedupedConstraints, swapExprVarnames nameSwaps expr)
@@ -35,8 +35,8 @@ identForConstraint = TypeclassCall "valuefromdictionary" . fromIntegral
 -- work
 findDedupedConstraints ::
   (Ord ann) =>
-  M.Map (ResolvedDep Identifier) (Constraint ann) ->
-  ([Constraint ann], M.Map (ResolvedDep Identifier) (ResolvedDep Identifier))
+  M.Map (ResolvedDep Identifier) (Constraint ResolvedDep ann) ->
+  ([Constraint ResolvedDep ann], M.Map (ResolvedDep Identifier) (ResolvedDep Identifier))
 findDedupedConstraints dupes =
   let initial = (mempty, mempty, 0)
       deduped =

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
@@ -84,7 +84,11 @@ instanceMatchesType needleTys haystackTys =
 -- | wipe out annotations when looking for instances
 -- this is fragile and depends on us manually creating instances with `mempty`
 -- annotations in the first place
-lookupConcreteInstance :: (Monoid ann, Ord ann) => TCEnv ann -> Constraint ann -> Maybe (Instance ann)
+lookupConcreteInstance ::
+  (Monoid ann, Ord ann) =>
+  TCEnv ann ->
+  Constraint ann ->
+  Maybe (Instance ResolvedDep ann)
 lookupConcreteInstance env constraint =
   M.lookup (constraint $> mempty) (tceInstances env)
 
@@ -95,7 +99,7 @@ lookupTypeclassInstance ::
   (MonadError (TCError ann) m, Monoid ann, Ord ann, Show ann) =>
   TCEnv ann ->
   Constraint ann ->
-  m (Instance ann)
+  m (Instance ResolvedDep ann)
 lookupTypeclassInstance env constraint@(Constraint name tys) = do
   -- first, do we have a concrete instance?
   case lookupConcreteInstance env constraint of

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Helpers.hs
@@ -36,7 +36,8 @@ import Smol.Core.Types
 
 -- this just chucks types in any order and will break on multi-parameter type
 -- classes
-recoverTypeclassUses :: (Monoid ann) => [TCWrite ann] -> M.Map (ResolvedDep Identifier) (Constraint ResolvedDep ann)
+recoverTypeclassUses :: (Monoid ann) =>
+    [TCWrite ann] -> M.Map (ResolvedDep Identifier) (Constraint ResolvedDep ann)
 recoverTypeclassUses events =
   let allSubs = filterSubstitutions events
       allTCs = filterTypeclassUses events

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
@@ -31,7 +31,6 @@ data Typeclass dep ann = Typeclass
   }
   deriving stock (Functor, Generic)
 
-
 deriving stock instance
   ( Eq ann,
     Eq (dep Constructor),
@@ -74,5 +73,3 @@ deriving anyclass instance
     FromJSON (dep TypeName)
   ) =>
   FromJSON (Typeclass dep ann)
-
-

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Types.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
 module Smol.Core.Typecheck.Typeclass.Types

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Types/Constraint.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Types/Constraint.hs
@@ -7,9 +7,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 
 module Smol.Core.Typecheck.Typeclass.Types.Constraint
-  (
-    Constraint (..),
-
+  ( Constraint (..),
   )
 where
 
@@ -68,7 +66,6 @@ deriving anyclass instance
   ) =>
   ToJSONKey (Constraint dep ann)
 
-
 deriving anyclass instance
   ( FromJSON ann,
     FromJSON (dep Constructor),
@@ -90,12 +87,14 @@ deriving anyclass instance
   ) =>
   FromJSONKey (Constraint dep ann)
 
-
-instance (Printer (dep Identifier),
-  Printer (dep TypeName)) => Printer (Constraint dep ann) where
+instance
+  ( Printer (dep Identifier),
+    Printer (dep TypeName)
+  ) =>
+  Printer (Constraint dep ann)
+  where
   prettyDoc (Constraint tcn tys) =
     prettyDoc tcn
       PP.<+> PP.concatWith
         (\a b -> a <> " " <> b)
         (prettyDoc <$> tys)
-

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Types/Instance.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Types/Instance.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Types/Instance.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Types/Instance.hs
@@ -6,31 +6,25 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
 
-module Smol.Core.Typecheck.Typeclass.Types
-  ( Typeclass (..),
-    module Smol.Core.Typecheck.Typeclass.Types.Constraint,
-    module Smol.Core.Typecheck.Typeclass.Types.Instance,
-    module Smol.Core.Typecheck.Typeclass.Types.TypeclassName,
+module Smol.Core.Typecheck.Typeclass.Types.Instance
+  (
+
+    Instance (..),
   )
 where
 
+import Smol.Core.Typecheck.Typeclass.Types.Constraint
 import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import GHC.Generics (Generic)
-import Smol.Core.Typecheck.Typeclass.Types.Constraint
-import Smol.Core.Typecheck.Typeclass.Types.Instance
-import Smol.Core.Typecheck.Typeclass.Types.TypeclassName
+import qualified Prettyprinter as PP
+import Smol.Core.Printer
 import Smol.Core.Types
 
--- | the typeclass described in it's most general form, ie
--- class Show a where show :: a -> String
-data Typeclass dep ann = Typeclass
-  { tcName :: TypeclassName,
-    tcArgs :: [Identifier],
-    tcFuncName :: Identifier,
-    tcFuncType :: Type dep ann
+data Instance dep ann = Instance
+  { inConstraints :: [Constraint dep ann],
+    inExpr :: Expr dep ann
   }
   deriving stock (Functor, Generic)
-
 
 deriving stock instance
   ( Eq ann,
@@ -38,7 +32,7 @@ deriving stock instance
     Eq (dep TypeName),
     Eq (dep Identifier)
   ) =>
-  Eq (Typeclass dep ann)
+  Eq (Instance dep ann)
 
 deriving stock instance
   ( Ord ann,
@@ -46,7 +40,7 @@ deriving stock instance
     Ord (dep TypeName),
     Ord (dep Identifier)
   ) =>
-  Ord (Typeclass dep ann)
+  Ord (Instance dep ann)
 
 deriving stock instance
   ( Show ann,
@@ -54,7 +48,7 @@ deriving stock instance
     Show (dep TypeName),
     Show (dep Identifier)
   ) =>
-  Show (Typeclass dep ann)
+  Show (Instance dep ann)
 
 deriving anyclass instance
   ( ToJSONKey (dep Identifier),
@@ -63,7 +57,7 @@ deriving anyclass instance
     ToJSON (dep Constructor),
     ToJSON (dep TypeName)
   ) =>
-  ToJSON (Typeclass dep ann)
+  ToJSON (Instance dep ann)
 
 deriving anyclass instance
   ( FromJSON ann,
@@ -73,6 +67,15 @@ deriving anyclass instance
     Ord (dep Identifier),
     FromJSON (dep TypeName)
   ) =>
-  FromJSON (Typeclass dep ann)
+  FromJSON (Instance dep ann)
 
-
+instance
+  ( Printer (dep Constructor),
+    Printer (dep TypeName),
+    Printer (dep Identifier)
+  ) =>
+  Printer (Instance dep ann)
+  where
+  prettyDoc (Instance [] expr) = prettyDoc expr
+  prettyDoc (Instance constraints expr) =
+    "(" <> PP.concatWith (\a b -> a <> ", " <> b) (prettyDoc <$> constraints) <> ") => " <> prettyDoc expr

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Types/Instance.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Types/Instance.hs
@@ -7,17 +7,15 @@
 {-# LANGUAGE StandaloneDeriving #-}
 
 module Smol.Core.Typecheck.Typeclass.Types.Instance
-  (
-
-    Instance (..),
+  ( Instance (..),
   )
 where
 
-import Smol.Core.Typecheck.Typeclass.Types.Constraint
 import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import GHC.Generics (Generic)
 import qualified Prettyprinter as PP
 import Smol.Core.Printer
+import Smol.Core.Typecheck.Typeclass.Types.Constraint
 import Smol.Core.Types
 
 data Instance dep ann = Instance

--- a/smol-core/src/Smol/Core/Typecheck/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types.hs
@@ -18,6 +18,6 @@ data TCEnv ann = TCEnv
   { tceVars :: Map (ResolvedDep Identifier) ([Constraint ann], ResolvedType ann),
     tceDataTypes :: Map (ResolvedDep TypeName) (DataType ResolvedDep ann),
     tceClasses :: Map TypeclassName (Typeclass ann),
-    tceInstances :: Map (Constraint ann) (Instance ann),
+    tceInstances :: Map (Constraint ann) (Instance ResolvedDep ann),
     tceConstraints :: [Constraint ann]
   }

--- a/smol-core/src/Smol/Core/Typecheck/Types.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types.hs
@@ -15,9 +15,9 @@ import Smol.Core.Typecheck.Types.TCWrite
 import Smol.Core.Types
 
 data TCEnv ann = TCEnv
-  { tceVars :: Map (ResolvedDep Identifier) ([Constraint ann], ResolvedType ann),
+  { tceVars :: Map (ResolvedDep Identifier) ([Constraint ResolvedDep ann], ResolvedType ann),
     tceDataTypes :: Map (ResolvedDep TypeName) (DataType ResolvedDep ann),
-    tceClasses :: Map TypeclassName (Typeclass ann),
-    tceInstances :: Map (Constraint ann) (Instance ResolvedDep ann),
-    tceConstraints :: [Constraint ann]
+    tceClasses :: Map TypeclassName (Typeclass ResolvedDep ann),
+    tceInstances :: Map (Constraint ResolvedDep ann) (Instance ResolvedDep ann),
+    tceConstraints :: [Constraint ResolvedDep ann]
   }

--- a/smol-core/src/Smol/Core/Typecheck/Types/TCError.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Types/TCError.hs
@@ -6,7 +6,6 @@ module Smol.Core.Typecheck.Types.TCError
   )
 where
 
-import Control.Monad.Identity
 import Data.Set (Set)
 import Smol.Core.Typecheck.Typeclass.Types
 import Smol.Core.Types
@@ -29,6 +28,6 @@ data TCError ann
   | TCCompoundTypeInEquality (ResolvedType ann) -- for now we only do primitive equality
   | TCPatternMatchError (PatternMatchError (ResolvedType ann))
   | TCTypeclassNotFound TypeclassName
-  | TCTypeclassInstanceNotFound TypeclassName [Type Identity ann] [Constraint ann]
-  | TCConflictingTypeclassInstancesFound [Constraint ann]
+  | TCTypeclassInstanceNotFound TypeclassName [Type ResolvedDep ann] [Constraint ResolvedDep ann]
+  | TCConflictingTypeclassInstancesFound [Constraint ResolvedDep ann]
   deriving stock (Eq, Ord, Show, Foldable)

--- a/smol-core/test/Test/Helpers.hs
+++ b/smol-core/test/Test/Helpers.hs
@@ -196,11 +196,6 @@ runTypecheckM env action =
 tcVar :: (Monoid ann) => Identifier -> Type Identity ann
 tcVar = TVar mempty . Identity
 
-identityFromParsedExpr :: Expr ParseDep ann -> Expr Identity ann
-identityFromParsedExpr = mapExprDep resolve
-  where
-    resolve (ParseDep a _) = Identity a
-
 showTypeclass :: (Monoid ann) => Typeclass ann
 showTypeclass =
   Typeclass
@@ -226,11 +221,11 @@ classes =
       ("Show", showTypeclass)
     ]
 
-unsafeParseInstanceExpr :: (Monoid ann) => Text -> Expr Identity ann
+unsafeParseInstanceExpr :: (Monoid ann) => Text -> Expr ResolvedDep ann
 unsafeParseInstanceExpr =
-  fmap (const mempty) . identityFromParsedExpr . unsafeParseExpr
+  fmap (const mempty) . fromParsedExpr . unsafeParseExpr
 
-instances :: (Ord ann, Monoid ann) => M.Map (Constraint ann) (Instance ann)
+instances :: (Ord ann, Monoid ann) => M.Map (Constraint ann) (Instance ResolvedDep ann)
 instances =
   M.fromList
     [ ( Constraint "Eq" [tyInt],

--- a/smol-core/test/Test/Helpers.hs
+++ b/smol-core/test/Test/Helpers.hs
@@ -38,7 +38,6 @@ module Test.Helpers
   )
 where
 
-import Control.Monad.Identity
 import Control.Monad.Reader
 import Control.Monad.State
 import Control.Monad.Writer
@@ -193,10 +192,10 @@ runTypecheckM env action =
 
 ------
 
-tcVar :: (Monoid ann) => Identifier -> Type Identity ann
-tcVar = TVar mempty . Identity
+tcVar :: (Monoid ann) => Identifier -> Type ResolvedDep ann
+tcVar = TVar mempty . LocalDefinition
 
-showTypeclass :: (Monoid ann) => Typeclass ann
+showTypeclass :: (Monoid ann) => Typeclass ResolvedDep ann
 showTypeclass =
   Typeclass
     { tcName = "Show",
@@ -205,7 +204,7 @@ showTypeclass =
       tcFuncType = tyFunc (tcVar "a") tyString
     }
 
-eqTypeclass :: (Monoid ann) => Typeclass ann
+eqTypeclass :: (Monoid ann) => Typeclass ResolvedDep ann
 eqTypeclass =
   Typeclass
     { tcName = "Eq",
@@ -214,7 +213,7 @@ eqTypeclass =
       tcFuncType = tyFunc (tcVar "a") (tyFunc (tcVar "a") tyBool)
     }
 
-classes :: (Monoid ann) => M.Map TypeclassName (Typeclass ann)
+classes :: (Monoid ann) => M.Map TypeclassName (Typeclass ResolvedDep ann)
 classes =
   M.fromList
     [ ("Eq", eqTypeclass),
@@ -225,7 +224,7 @@ unsafeParseInstanceExpr :: (Monoid ann) => Text -> Expr ResolvedDep ann
 unsafeParseInstanceExpr =
   fmap (const mempty) . fromParsedExpr . unsafeParseExpr
 
-instances :: (Ord ann, Monoid ann) => M.Map (Constraint ann) (Instance ResolvedDep ann)
+instances :: (Ord ann, Monoid ann) => M.Map (Constraint ResolvedDep ann) (Instance ResolvedDep ann)
 instances =
   M.fromList
     [ ( Constraint "Eq" [tyInt],

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -103,9 +103,15 @@ spec = do
                 "True"
               ),
               ( [ "type Pet = Dog | Cat | Rat",
-                  "instance Eq Pet = \\a -> \\b -> case (a,b) of (Dog,Dog) -> True | (Cat, Cat) -> True | (Rat,Rat) -> True | _ -> False",
                   "def main : Bool",
-                  "def main = equals Dog Cat"
+                  "def main = let eqPet = \\a -> \\b -> case (a,b) of (Dog, Dog) -> True | (Cat, Cat) -> True | (Rat, Rat) -> True | _ -> False; eqPet Dog Cat"
+                ],
+                "False"
+              ),
+              ( [ "type Pet = Dog | Cat | Rat",
+                  "instance Eq Pet = \\a -> \\b -> case (a,b) of (Dog, Dog) -> True | (Cat, Cat) -> True | (Rat, Rat) -> True | _ -> False",
+                  "def main : Bool",
+                  "def main = equals Dog Rat"
                 ],
                 "False"
               )

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -101,17 +101,14 @@ spec = do
                   "def main = equals (mappend (20 : Int) (22 : Int)) (42 : Int)"
                 ],
                 "True"
-              )
-              {-
-                  -- next we need to work out the dependencies of our typeclass
-                  -- functions
-              ( ["type Pet = Dog | Cat | Rat",
+              ),
+              ( [ "type Pet = Dog | Cat | Rat",
                   "instance Eq Pet = \\a -> \\b -> case (a,b) of (Dog,Dog) -> True | (Cat, Cat) -> True | (Rat,Rat) -> True | _ -> False",
                   "def main : Bool",
-                  "def main = equals Dog Cat"],
-                  "False"
-
-              ) -}
+                  "def main = equals Dog Cat"
+                ],
+                "False"
+              )
             ]
       traverse_
         ( \(parts, expect) ->

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -104,7 +104,7 @@ spec = do
               ),
               ( [ "type Pet = Dog | Cat | Rat",
                   "def main : Bool",
-                  "def main = let eqPet = \\a -> \\b -> case (a,b) of (Dog, Dog) -> True | (Cat, Cat) -> True | (Rat, Rat) -> True | _ -> False; eqPet Dog Cat"
+                  "def main = case (Cat,Rat) of (Dog, Dog) -> True | (Cat, Cat) -> True | (Rat, Rat) -> True | _ -> False"
                 ],
                 "False"
               ),
@@ -114,7 +114,14 @@ spec = do
                   "def main = equals Dog Rat"
                 ],
                 "False"
-              )
+              ) {-,
+                ( [ "type Maybe a = Just a | Nothing",
+                    "instance (Eq a) => Eq (Maybe a) = \\ma -> \\mb -> case (ma, mb) of (Just a, Just b) -> equals a b | (Nothing, Nothing) -> True | _ -> False",
+                    "def main : Bool",
+                    "def main = equals (Just (1: Int)) Nothing"
+                  ],
+                  "False"
+                )-}
             ]
       traverse_
         ( \(parts, expect) ->

--- a/smol-core/test/Test/ParserSpec.hs
+++ b/smol-core/test/Test/ParserSpec.hs
@@ -53,7 +53,8 @@ spec = do
               "test \"one plus one equals two\" using onePlusOneEqualsTwo",
               "def usesEquals : (Eq (a,b)) => (a,b) -> (a,b) -> Bool",
               "class Eq a { equals: a -> a -> Bool }",
-              "instance Eq Int = eqInt"
+              "instance Eq Int = eqInt",
+              "instance (Eq a) => Eq (Maybe a) = eqMaybeA"
             ]
 
       it "All defs" $ do

--- a/smol-core/test/Test/ParserSpec.hs
+++ b/smol-core/test/Test/ParserSpec.hs
@@ -32,7 +32,7 @@ spec = do
                 Constraint "Eq" [tyInt]
               ),
               ( "Eq (a,b)",
-                Constraint "Eq" [tyTuple (tcVar "a") [tcVar "b"]]
+                Constraint "Eq" [tyTuple (tyVar "a") [tyVar "b"]]
               )
             ]
       traverse_


### PR DESCRIPTION
We can't have instances for data types until those instance expressions can track their dependencies. We used `Expr Identity ann` in a lot of places but that won't fly (esp as it won't let us track outside-module-deps in future). This removes all the `Expr Identity` hacks we used everywhere so that we can make this work:

```haskell
type Pet = Dog | Cat | Rat

instance Eq Pet = 
  \a -> \b -> 
    case (a,b) of 
    (Dog, Dog) -> True 
  | (Cat, Cat) -> True 
  | (Rat, Rat) -> True 
  | _ -> False
  
def main : Bool
def main = equals Dog Cat
```