### PR TITLE
Curly boys around pattern matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,15 @@ class Functor f { fmap : (a -> b) -> f a -> f b }
 type Maybe a = Just a | Nothing
 
 instance (Eq a) => Eq (Maybe a) =
-    \maybeA -> \maybeB -> case (maybeA, maybeB) of
-                            (Just a, Just b) -> equals a b
-                          | (Nothing, Nothing) -> True
-                          | _ -> False
+    \maybeA -> \maybeB -> 
+        case (maybeA, maybeB) {
+          (Just a, Just b) -> equals a b,
+          (Nothing, Nothing) -> True,
+          _ -> False
+        }
 
 instance Functor Maybe =
-    \f -> \maybe -> case maybe of Just a -> Just (f a) | Nothing -> Nothing
+    \f -> \maybe -> case maybe { Just a -> Just (f a), Nothing -> Nothing }
 
 test "fmap works with Just" =
     let result = fmap inc (Just 1);

--- a/smol-backend/test/Test/IR/FromExprSpec.hs
+++ b/smol-backend/test/Test/IR/FromExprSpec.hs
@@ -272,7 +272,7 @@ spec = do
           ]
 
     it "Pattern matches enum" $ do
-      getMainExpr "(case LT of GT -> 21 | EQ -> 23 | LT -> 42 : Int)"
+      getMainExpr "(case LT { GT -> 21, EQ -> 23, LT -> 42 } : Int)"
         `shouldBe` IRMatch
           (IRPrim (IRPrimInt32 2))
           IRInt32
@@ -303,7 +303,7 @@ spec = do
           thisIntInt = IRStruct [IRInt32, IRInt32]
           thatIntInt = IRStruct [IRInt32, IRInt32]
           theseIntInt = IRStruct [IRInt32, IRInt32, IRInt32]
-      getMainExpr "(case (This 42 : These Int Int) of This a -> a | That b -> 0 | These tA tB -> tA + tB : Int)"
+      getMainExpr "(case (This 42 : These Int Int) { This a -> a, That b -> 0, These tA tB -> tA + tB } : Int)"
         `shouldBe` IRMatch
           ( IRInitialiseDataType
               (IRAlloc typeTheseIntInt)

--- a/smol-core/src/Smol/Core/Parser/Expr.hs
+++ b/smol-core/src/Smol/Core/Parser/Expr.hs
@@ -281,10 +281,12 @@ match a with
 patternMatchParser :: Parser ParserExpr
 patternMatchParser = addLocation $ do
   matchExpr <- matchExprWithParser
+  myString "{"
   patterns <-
     try patternMatchesParser
       <|> pure
       <$> patternCaseParser
+  myString "}"
   case NE.nonEmpty patterns of
     (Just nePatterns) -> pure $ EPatternMatch mempty matchExpr nePatterns
     _ -> error "need at least one pattern"
@@ -292,15 +294,13 @@ patternMatchParser = addLocation $ do
 matchExprWithParser :: Parser ParserExpr
 matchExprWithParser = do
   myString "case"
-  sumExpr <- expressionParser
-  myString "of"
-  pure sumExpr
+  expressionParser
 
 patternMatchesParser :: Parser [(ParserPattern, ParserExpr)]
 patternMatchesParser =
   sepBy
     patternCaseParser
-    (myString "|")
+    (myString ",")
 
 patternCaseParser :: Parser (ParserPattern, ParserExpr)
 patternCaseParser = do

--- a/smol-core/src/Smol/Core/Types/Expr.hs
+++ b/smol-core/src/Smol/Core/Types/Expr.hs
@@ -305,7 +305,7 @@ prettyPatternMatch sumExpr matches =
       printSubPattern construct
         <+> "->"
         <> PP.softline
-        <> indentMulti 2 (printSubExpr expr')
+        <> printSubExpr expr'
         <> if index < length matches then "," else ""
 
 prettyArray ::

--- a/smol-core/src/Smol/Core/Types/Expr.hs
+++ b/smol-core/src/Smol/Core/Types/Expr.hs
@@ -397,5 +397,4 @@ printSubExpr expr = case expr of
   all'@EIf {} -> inParens all'
   all'@EApp {} -> inParens all'
   all'@ETuple {} -> inParens all'
-  all'@EPatternMatch {} -> inParens all'
   a -> prettyDoc a

--- a/smol-core/src/Smol/Core/Types/Expr.hs
+++ b/smol-core/src/Smol/Core/Types/Expr.hs
@@ -288,7 +288,7 @@ prettyPatternMatch ::
 prettyPatternMatch sumExpr matches =
   "case"
     <+> printSubExpr sumExpr
-    <+> "of"
+    <+> "{"
     <+> PP.line
     <> indentMulti
       2
@@ -296,10 +296,10 @@ prettyPatternMatch sumExpr matches =
           PP.vsep
             ( zipWith
                 (<+>)
-                (" " : repeat "|")
+                (" " : repeat ",")
                 (printMatch <$> NE.toList matches)
             )
-      )
+      ) <> PP.line <> "}"
   where
     printMatch (construct, expr') =
       printSubPattern construct

--- a/smol-core/src/Smol/Core/Types/Expr.hs
+++ b/smol-core/src/Smol/Core/Types/Expr.hs
@@ -289,23 +289,23 @@ prettyPatternMatch sumExpr matches =
   "case"
     <+> printSubExpr sumExpr
     <+> "{"
-    <+> PP.line
+    <> PP.line
     <> indentMulti
       2
       ( PP.align $
-          PP.vsep
-            ( zipWith
-                (<+>)
-                (" " : repeat ",")
-                (printMatch <$> NE.toList matches)
-            )
+          PP.vsep (printMatch <$> addNums matches)
+
       ) <> PP.line <> "}"
   where
-    printMatch (construct, expr') =
+    addNums :: NE.NonEmpty a -> [(Int, a)]
+    addNums = zip [1..] . NE.toList
+
+    printMatch (index,(construct, expr')) =
       printSubPattern construct
         <+> "->"
         <> PP.softline
         <> indentMulti 2 (printSubExpr expr')
+        <> if index < length matches then "," else ""
 
 prettyArray ::
   ( Printer (dep Constructor),

--- a/smol-core/src/Smol/Core/Types/Expr.hs
+++ b/smol-core/src/Smol/Core/Types/Expr.hs
@@ -294,13 +294,14 @@ prettyPatternMatch sumExpr matches =
       2
       ( PP.align $
           PP.vsep (printMatch <$> addNums matches)
-
-      ) <> PP.line <> "}"
+      )
+    <> PP.line
+    <> "}"
   where
     addNums :: NE.NonEmpty a -> [(Int, a)]
-    addNums = zip [1..] . NE.toList
+    addNums = zip [1 ..] . NE.toList
 
-    printMatch (index,(construct, expr')) =
+    printMatch (index, (construct, expr')) =
       printSubPattern construct
         <+> "->"
         <> PP.softline

--- a/smol-core/src/Smol/Core/Types/Expr.hs
+++ b/smol-core/src/Smol/Core/Types/Expr.hs
@@ -394,7 +394,6 @@ printSubExpr :: (Printer (dep Constructor), Printer (dep Identifier), Printer (d
 printSubExpr expr = case expr of
   all'@ELet {} -> inParens all'
   all'@ELambda {} -> inParens all'
-  all'@EIf {} -> inParens all'
   all'@EApp {} -> inParens all'
   all'@ETuple {} -> inParens all'
   a -> prettyDoc a

--- a/smol-core/test/Test/Helpers.hs
+++ b/smol-core/test/Test/Helpers.hs
@@ -98,11 +98,11 @@ testModule =
           "instance Eq Bool = \\a -> \\b -> a == b",
           "instance Eq String = \\a -> \\b -> a == b",
           "instance (Eq a, Eq b) => Eq (a,b) = ",
-          "\\pairA -> \\pairB -> case (pairA, pairB) of ((a1, b1), (a2, b2)) -> ",
-          "if equals a1 a2 then equals b1 b2 else False",
+          "\\pairA -> \\pairB -> case (pairA, pairB) {((a1, b1), (a2, b2)) -> ",
+          "if equals a1 a2 then equals b1 b2 else False}",
           "type Natural = Suc Natural | Zero",
           "class Show a { show: a -> String }",
-          "instance Show Natural = \\nat -> case nat of Suc n -> \"S \" + show n | _ -> \"\""
+          "instance Show Natural = \\nat -> case nat { Suc n -> \"S \" + show n , _ -> \"\"}"
         ]
 
 tyBool :: (Monoid ann) => Type dep ann
@@ -302,7 +302,7 @@ instances =
       ( Constraint "Eq" [tyTuple (tcVar "a") [tcVar "b"]],
         Instance
           { inExpr =
-              unsafeParseInstanceExpr "\\a -> \\b -> case (a,b) of ((a1, a2), (b1, b2)) -> if equals a1 b1 then equals a2 b2 else False",
+              unsafeParseInstanceExpr "\\a -> \\b -> case (a,b) { ((a1, a2), (b1, b2)) -> if equals a1 b1 then equals a2 b2 else False }",
             inConstraints =
               [ Constraint "Eq" [tcVar "a"],
                 Constraint "Eq" [tcVar "b"]
@@ -312,7 +312,7 @@ instances =
       ( Constraint "Functor" [tyCons "Maybe" [tcVar "a"]],
         Instance
           { inExpr =
-              unsafeParseInstanceExpr "\\f -> \\maybe -> case maybe of Just a -> Just (f a) | Nothing -> Nothing",
+              unsafeParseInstanceExpr "\\f -> \\maybe -> case maybe { Just a -> Just (f a), Nothing -> Nothing }",
             inConstraints = mempty
           }
       )

--- a/smol-core/test/Test/Interpreter/InterpreterSpec.hs
+++ b/smol-core/test/Test/Interpreter/InterpreterSpec.hs
@@ -66,12 +66,12 @@ spec = do
               ("(\\a -> if a then 1 else 2) True", "1"),
               ("let a = 41 in a + 1", "42"),
               ("Just (1 + 1)", "Just 2"),
-              ("case (Just 1) of Just a -> a + 41 | Nothing -> 0", "42"),
-              ("case Nothing of Just a -> a + 41 | Nothing -> 0", "0"),
+              ("case (Just 1) { Just a -> a + 41, Nothing -> 0 }", "42"),
+              ("case Nothing { Just a -> a + 41, Nothing -> 0 }", "0"),
               ("let stuff = { x: 1, y : 2 }; stuff.x + stuff.y", "3"),
               ("let id = \\a -> a; (id 1, id 2, id 3)", "(1,2,3)"),
               ("[1,2 + 3]", "[1,5]"),
-              ("case [1,2,3] of [_, ...rest] -> rest | _ -> [42]", "[2,3]"),
+              ("case [1,2,3] { [_, ...rest] -> rest, _ -> [42] }", "[2,3]"),
               ("let f = \\a -> if a == 10 then a else a + f (a + 1); f 0", "55")
             ]
       traverse_

--- a/smol-core/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-core/test/Test/Modules/InterpreterSpec.hs
@@ -88,7 +88,7 @@ spec = do
               ),
               ( [ "class Eq a { equals: a -> a -> Bool }",
                   "instance Eq Int = \\a -> \\b -> a == b",
-                  "instance (Eq a, Eq b) => Eq (a,b) = \\a -> \\b -> case (a,b) of ((a1, b1), (a2, b2)) -> if equals a1 a2 then equals b1 b2 else False",
+                  "instance (Eq a, Eq b) => Eq (a,b) = \\a -> \\b -> case (a,b) {((a1, b1), (a2, b2)) -> if equals a1 a2 then equals b1 b2 else False }",
                   "def main = equals ((1:Int), (2: Int)) ((1: Int), (2: Int))"
                 ],
                 "True"
@@ -131,7 +131,7 @@ spec = do
               ),
               ( [ "type Pet = Dog | Cat | Rat",
                   "class Eq a { equals: a -> a -> Bool }",
-                  "instance Eq Pet = \\a -> \\b -> case (a,b) of (Dog, Dog) -> True | (Cat, Cat) -> True | (Rat, Rat) -> True | _ -> False",
+                  "instance Eq Pet = \\a -> \\b -> case (a,b) { (Dog, Dog) -> True, (Cat, Cat) -> True, (Rat, Rat) -> True, _ -> False }",
                   "def main : Bool",
                   "def main = equals Dog Rat"
                 ],
@@ -140,7 +140,7 @@ spec = do
               ( [ "class Eq a { equals: a -> a -> Bool }",
                   "instance Eq Int = \\a -> \\b -> a == b",
                   "type Maybe a = Just a | Nothing",
-                  "instance (Eq a) => Eq (Maybe a) = \\ma -> \\mb -> case (ma, mb) of (Just a, Just b) -> equals a b | (Nothing, Nothing) -> True | _ -> False",
+                  "instance (Eq a) => Eq (Maybe a) = \\ma -> \\mb -> case (ma, mb) { (Just a, Just b) -> equals a b, (Nothing, Nothing) -> True, _ -> False }",
                   "def main : Bool",
                   "def main = equals (Just (1: Int)) Nothing"
                 ],
@@ -149,8 +149,8 @@ spec = do
               ( [ "type Natural = Suc Natural | Zero",
                   "class Show a { show: a -> String }",
                   "instance Show Natural = \\nat -> ",
-                  "case nat of Suc n -> \"S \" + show n ",
-                  "| _ -> \"Z\"",
+                  "case nat { Suc n -> \"S \" + show n ",
+                  ", _ -> \"Z\"}",
                   "def main : String",
                   "def main = show (Suc Zero)"
                 ],

--- a/smol-core/test/Test/Modules/PrettyPrintSpec.hs
+++ b/smol-core/test/Test/Modules/PrettyPrintSpec.hs
@@ -37,7 +37,15 @@ spec = do
       let printModule (filepath, input) =
             it ("Pretty pretting " <> filepath <> " round trips successfully") $ do
               let parts = parseModule input
-                  printed = renderWithWidth 40 $ printModuleParts parts
+                  printed = renderWithWidth 80 $ printModuleParts parts
               let parts2 = parseModule printed
               parts `shouldBe` parts2
+      traverse_ printModule testInputs
+
+    describe "PrettyPrint is saved" $ do
+      let printModule (filepath, input) =
+            it ("Pretty pretting " <> filepath <> " is the same") $ do
+              let parts = parseModule input
+                  printed = renderWithWidth 80 $ printModuleParts parts
+              input `shouldBe` printed
       traverse_ printModule testInputs

--- a/smol-core/test/Test/Modules/ResolveDepsSpec.hs
+++ b/smol-core/test/Test/Modules/ResolveDepsSpec.hs
@@ -84,7 +84,7 @@ spec = do
         fst <$> resolveModuleDeps mempty mod' `shouldBe` Right expected
 
       it "Variables added in pattern matches are unique" $ do
-        let mod' = unsafeParseModule "def main pair = case pair of (a,_) -> a"
+        let mod' = unsafeParseModule "def main pair = case pair { (a,_) -> a }"
             expr =
               ELambda
                 ()

--- a/smol-core/test/Test/ParserSpec.hs
+++ b/smol-core/test/Test/ParserSpec.hs
@@ -106,20 +106,20 @@ spec = do
               ("Maybe.Just", EConstructor () (ParseDep "Just" (Just "Maybe"))),
               ("Just True", EApp () (constructor "Just") (bool True)),
               ("These 1 False", EApp () (EApp () (constructor "These") (int 1)) (bool False)),
-              ( "case a of (b, c) -> b + c",
+              ( "case a {(b, c) -> b + c}",
                 patternMatch (var "a") [(PTuple () (PVar () "b") (NE.fromList [PVar () "c"]), EInfix () OpAdd (var "b") (var "c"))]
               ),
-              ( "case (1,2) of (a,_) -> a",
+              ( "case (1,2) {(a,_) -> a }",
                 patternMatch (tuple (int 1) [int 2]) [(PTuple () (PVar () "a") (NE.fromList [PWildcard ()]), var "a")]
               ),
-              ( "case (True, 1) of (True, a) -> a | (False,_) -> 0",
+              ( "case (True, 1) {(True, a) -> a, (False,_) -> 0}",
                 patternMatch
                   (tuple (bool True) [int 1])
                   [ (PTuple () (PLiteral () (PBool True)) (NE.fromList [PVar () "a"]), var "a"),
                     (PTuple () (PLiteral () (PBool False)) (NE.fromList [PWildcard ()]), int 0)
                   ]
               ),
-              ( "case [1,2,3] of [_, ...b] -> b | other -> other",
+              ( "case [1,2,3] { [_, ...b] -> b, other -> other }",
                 patternMatch
                   (array [int 1, int 2, int 3])
                   [ (PArray () [PWildcard ()] (SpreadValue () "b"), var "b"),

--- a/smol-core/test/Test/TransformSpec.hs
+++ b/smol-core/test/Test/TransformSpec.hs
@@ -75,11 +75,11 @@ spec = do
   describe "FloatDown" $ do
     let singleDefs =
           [ ("id", "id"),
-            ( "let a = 1; case a of True -> 1 | False -> 2",
-              "let a = 1; case a of True -> 1 | False -> 2"
+            ( "let a = 1; case a { True -> 1, False -> 2 }",
+              "let a = 1; case a { True -> 1, False -> 2 }"
             ),
-            ( "let a = 1; case b of True -> 1 | False -> 2",
-              "case b of True -> let a = 1; 1 | False -> let a = 1; 2"
+            ( "let a = 1; case b { True -> 1, False -> 2 }",
+              "case b { True -> let a = 1; 1, False -> let a = 1; 2}"
             ),
             ("let a = 1; if a then 1 else 2", "let a = 1; if a then 1 else 2"),
             ( "let a = 1; if b then 1 else 2",

--- a/smol-core/test/Test/Typecheck/ToDictionaryPassingSpec.hs
+++ b/smol-core/test/Test/Typecheck/ToDictionaryPassingSpec.hs
@@ -148,15 +148,15 @@ spec = do
           ( [ Constraint "Eq" [tcVar "a"],
               Constraint "Eq" [tcVar "b"]
             ],
-            [ "(\\a -> \\b -> case (a,b) of ((leftA, leftB), (rightA, rightB)) -> ",
-              "if equals leftA rightA then equals leftB rightB else False : (a,b) -> (a,b) -> Bool)"
+            [ "(\\a -> \\b -> case (a,b) { ((leftA, leftB), (rightA, rightB)) -> ",
+              "if equals leftA rightA then equals leftB rightB else False }: (a,b) -> (a,b) -> Bool)"
             ],
             [ Constraint "Eq" [tcVar "a"],
               Constraint "Eq" [tcVar "b"]
             ],
-            [ "\\instances -> case (instances : (a -> a -> Bool, b -> b -> Bool)) of (tcvaluefromdictionary0, tcvaluefromdictionary1) -> ",
-              "(\\a1 -> \\b2 -> case (a1,b2) of ((leftA3, leftB4), (rightA5, rightB6)) ->",
-              "if tcvaluefromdictionary0 leftA3 rightA5 then tcvaluefromdictionary1 leftB4 rightB6 else False : (a,b) -> (a,b) -> Bool)"
+            [ "\\instances -> case (instances : (a -> a -> Bool, b -> b -> Bool)) { (tcvaluefromdictionary0, tcvaluefromdictionary1) -> ",
+              "(\\a1 -> \\b2 -> case (a1,b2) { ((leftA3, leftB4), (rightA5, rightB6)) ->",
+              "if tcvaluefromdictionary0 leftA3 rightA5 then tcvaluefromdictionary1 leftB4 rightB6 else False } : (a,b) -> (a,b) -> Bool)}"
             ]
           )
         ]
@@ -197,24 +197,24 @@ spec = do
           ( mempty,
             ["equals ((1: Int), (2: Int)) ((2: Int), (3: Int))"],
             [ "let eqintint = let eqint = (\\a1 -> \\b2 -> a1 == b2 : Int -> Int -> Bool);",
-              "(\\pairA7 -> \\pairB8 -> case (pairA7, pairB8) of ((a19, b110), (a211, b212)) ->",
+              "(\\pairA7 -> \\pairB8 -> case (pairA7, pairB8) {((a19, b110), (a211, b212)) ->",
               "if eqint a19 a211 ",
               "then eqint b110 b212",
-              "else False : (a, b) -> (a,b) -> Bool); ",
+              "else False }: (a, b) -> (a,b) -> Bool); ",
               "eqintint ((1: Int), (2: Int)) ((2: Int), (3: Int))"
             ]
           ),
           ( [Constraint "Eq" [tcVar "a"]],
             ["(\\a -> \\b -> equals a b : a -> a -> Bool)"],
-            [ "\\instances -> case (instances : (a -> a -> Bool)) of tcvaluefromdictionary0 -> ",
-              "(\\a1 -> \\b2 -> tcvaluefromdictionary0 a1 b2 : a -> a -> Bool)"
+            [ "\\instances -> case (instances : (a -> a -> Bool)) { tcvaluefromdictionary0 -> ",
+              "(\\a1 -> \\b2 -> tcvaluefromdictionary0 a1 b2 : a -> a -> Bool) }"
             ]
           ),
           ( mempty,
             ["show Zero"],
             [ "let shownatural = (\\nat15 -> ",
-              "case nat15 of Suc n16 -> \"S \" + shownatural n16 ",
-              "| _ -> \"\" : Natural -> String); ",
+              "case nat15 { Suc n16 -> \"S \" + shownatural n16 ",
+              ", _ -> \"\" } : Natural -> String); ",
               "shownatural Zero"
             ]
           )

--- a/smol-core/test/Test/Typecheck/TypeclassSpec.hs
+++ b/smol-core/test/Test/Typecheck/TypeclassSpec.hs
@@ -115,7 +115,7 @@ spec = do
         (addTypesToConstraint (Constraint "Eq" [tyTuple (tcVar "a") [tcVar "b"]]))
         ( Instance
             { inExpr =
-                unsafeParseInstanceExpr "\\a -> \\b -> case (a,b) of ((a1, a2), (b1, b2)) -> if equals a1 b1 then equals a2 b2 else False",
+                unsafeParseInstanceExpr "\\a -> \\b -> case (a,b) { ((a1, a2), (b1, b2)) -> if equals a1 b1 then equals a2 b2 else False }",
               inConstraints =
                 [ Constraint "Eq" [tcVar "a"],
                   Constraint "Eq" [tcVar "b"]
@@ -131,7 +131,7 @@ spec = do
         (addTypesToConstraint (Constraint "Show" [tyCons "Natural" []]))
         ( Instance
             { inExpr =
-                unsafeParseInstanceExpr "\\nat -> case nat of Suc n -> \"S \" + show n | _ -> \"\"",
+                unsafeParseInstanceExpr "\\nat -> case nat { Suc n -> \"S \" + show n, _ -> \"\"}",
               inConstraints =
                 []
             }
@@ -145,7 +145,7 @@ spec = do
         (addTypesToConstraint (Constraint "Functor" [tyCons "Maybe" []]))
         ( Instance
             { inExpr =
-                unsafeParseInstanceExpr "\\f -> \\maybe -> case maybe of Just a -> Just (f a) | Nothing -> Nothing",
+                unsafeParseInstanceExpr "\\f -> \\maybe -> case maybe { Just a -> Just (f a) , Nothing -> Nothing }",
               inConstraints = mempty
             }
         )
@@ -158,7 +158,7 @@ spec = do
         (addTypesToConstraint (Constraint "Functor" [tyCons "Maybe" [tcVar "a"]]))
         ( Instance
             { inExpr =
-                unsafeParseInstanceExpr "\\f -> \\maybe -> case maybe of Just a -> Just (f a) | Nothing -> Nothing",
+                unsafeParseInstanceExpr "\\f -> \\maybe -> case maybe { Just a -> Just (f a), Nothing -> Nothing }",
               inConstraints = mempty
             }
         )

--- a/smol-core/test/Test/TypecheckSpec.hs
+++ b/smol-core/test/Test/TypecheckSpec.hs
@@ -59,7 +59,7 @@ spec = do
               ("1 + 2", "3"),
               ("-1 + 200", "199"),
               ("200 + -100", "100"),
-              ("let f = \\a -> a + 41; let g = f 1 == 42; case g of True -> 1", "1"),
+              ("let f = \\a -> a + 41; let g = f 1 == 42; case g { True -> 1 }", "1"),
               ("1 == 1", "True"),
               ("6 == 7", "False"),
               ("(1 + 2 + 3 : Int)", "Int"),
@@ -67,13 +67,13 @@ spec = do
               ("(\"horse\" : String)", "String"),
               ("\"hor\" + \"se\"", "\"horse\""),
               ("let a = if True then \"eg\" else \"og\"; a + \"g\"", "\"egg\" | \"ogg\""),
-              ( "(\\pair -> case pair of (a,_) -> a : (Bool, Int) -> Bool) (True, 1)",
+              ( "(\\pair -> case pair { (a,_) -> a } : (Bool, Int) -> Bool) (True, 1)",
                 "Bool"
               ),
-              ( "(\\pair -> case pair of (True, a) -> a | (False,_) -> 0 : (Bool, Int) -> Int) (True,1)",
+              ( "(\\pair -> case pair { (True, a) -> a, (False,_) -> 0 } : (Bool, Int) -> Int) (True,1)",
                 "Int"
               ),
-              ( "(case (True, 1) of (True, a) -> a: Int)",
+              ( "(case (True, 1) { (True, a) -> a } : Int)",
                 "Int" -- this should remain total as we know it's always True
               ),
               ( "Just True",
@@ -97,13 +97,13 @@ spec = do
               ( "(Right True : Either e True)",
                 "Either e True"
               ),
-              ( "(case Just 1 of Just a -> a | _ -> 0 : Int)",
+              ( "(case Just 1 { Just a -> a, _ -> 0 }: Int)",
                 "Int"
               ),
-              ( "(\\a -> case a of 1 -> 10 | 2 -> 20 : (1 | 2) -> Int) 1",
+              ( "(\\a -> case a { 1 -> 10, 2 -> 20 }: (1 | 2) -> Int) 1",
                 "Int"
               ),
-              ( "(\\a -> case a of (1,_) -> 10 | (2,_) -> 20 : (1 | 2,Bool) -> Int) (1,False)",
+              ( "(\\a -> case a { (1,_) -> 10,  (2,_) -> 20 } : (1 | 2,Bool) -> Int) (1,False)",
                 "Int"
               ),
               ( "(\\a -> a : Maybe a -> Maybe a) (Nothing : Maybe Int)",
@@ -112,25 +112,25 @@ spec = do
               ( "(\\a -> a : Maybe a -> Maybe a) (Just 1)",
                 "Maybe 1"
               ),
-              ( "(\\f -> \\ident -> case ident of Identity a -> Identity (f a) : (a -> b) -> Identity a -> Identity b)",
+              ( "(\\f -> \\ident -> case ident { Identity a -> Identity (f a) }: (a -> b) -> Identity a -> Identity b)",
                 "(a -> b) -> Identity a -> Identity b"
               ),
-              ( "(\\f -> \\maybe -> case maybe of Just a -> Just (f a) | Nothing -> Nothing : (a -> b) -> Maybe a -> Maybe b)",
+              ( "(\\f -> \\maybe -> case maybe { Just a -> Just (f a), Nothing -> Nothing } : (a -> b) -> Maybe a -> Maybe b)",
                 "(a -> b) -> Maybe a -> Maybe b"
               ),
-              ( "(\\f -> \\maybe -> case maybe of Just a -> Just (f a) | Nothing -> Nothing : (b -> a) -> Maybe b -> Maybe a)",
+              ( "(\\f -> \\maybe -> case maybe { Just a -> Just (f a),  Nothing -> Nothing }: (b -> a) -> Maybe b -> Maybe a)",
                 "(b -> a) -> Maybe b -> Maybe a"
               ),
-              ( "(case (This 42 : These Int Int) of This a -> a : Int)",
+              ( "(case (This 42 : These Int Int) { This a -> a }: Int)",
                 "Int"
               ),
-              ( "let fmap = (\\f -> \\maybe -> case maybe of Just a -> Just (f a) | Nothing -> Nothing : (a -> b) -> Maybe a -> Maybe b); let inc = (\\a -> True : Int -> Bool); fmap inc",
+              ( "let fmap = (\\f -> \\maybe -> case maybe { Just a -> Just (f a), Nothing -> Nothing }: (a -> b) -> Maybe a -> Maybe b); let inc = (\\a -> True : Int -> Bool); fmap inc",
                 "Maybe Int -> Maybe Bool"
               ),
-              ( "let fmap = (\\f -> \\either -> case either of Right a -> Right (f a) | Left e -> Left e : (a -> b) -> Either e a -> Either e b); let inc = (\\a -> True : Int -> Bool); fmap inc",
+              ( "let fmap = (\\f -> \\either -> case either { Right a -> Right (f a), Left e -> Left e }: (a -> b) -> Either e a -> Either e b); let inc = (\\a -> True : Int -> Bool); fmap inc",
                 "Either e Int -> Either e Bool"
               ),
-              ( "let fmap = (\\f -> \\either -> case either of Right a -> Right (f a) | Left e -> Left e : (a -> b) -> Either e a -> Either e b); fmap",
+              ( "let fmap = (\\f -> \\either -> case either { Right a -> Right (f a), Left e -> Left e } : (a -> b) -> Either e a -> Either e b); fmap",
                 "(a -> b) -> Either e a -> Either e b"
               ),
               -- ( "let fmap = (\\f -> \\state -> case state of (State sas) -> State (\\s -> case sas s of (a, s) -> (f a, s)) : (a -> b) -> State s a -> State s b) in fmap",
@@ -145,13 +145,13 @@ spec = do
               ( "let id = (\\a -> a : a -> a); (id True, id 1)",
                 "(True, 1)"
               ),
-              ( "(\\f -> \\maybe -> case maybe of Just a -> Just (f a) | Nothing -> Nothing : (a -> b) -> Maybe a -> Maybe b)",
+              ( "(\\f -> \\maybe -> case maybe { Just a -> Just (f a),  Nothing -> Nothing } : (a -> b) -> Maybe a -> Maybe b)",
                 "(a -> b) -> Maybe a -> Maybe b"
               ),
-              ( "(\\maybeF -> \\maybeA -> case (maybeF, maybeA) of (Just f, Just a) -> Just (f a) | _ -> Nothing : Maybe (a -> b) -> Maybe a -> Maybe b)",
+              ( "(\\maybeF -> \\maybeA -> case (maybeF, maybeA) { (Just f, Just a) -> Just (f a) , _ -> Nothing } : Maybe (a -> b) -> Maybe a -> Maybe b)",
                 "Maybe (a -> b) -> Maybe a -> Maybe b"
               ),
-              ( "(\\value -> \\default -> case value of Right a -> a | Left _ -> default : Either e a -> a -> a)",
+              ( "(\\value -> \\default -> case value { Right a -> a, Left _ -> default }: Either e a -> a -> a)",
                 "Either e a -> a -> a"
               ),
               --              ( "let liftA2 = (\\ap -> \\fmap -> \\f -> \\ma -> \\mb -> ap (fmap f ma) mb : (m (a -> b) -> m a -> m b) -> ((a -> b) -> m a -> m b) -> (a -> b -> c) -> m a -> m b -> m c); let add2 = (\\a -> \\b -> a + b : Int -> Int -> Int); liftA2 add2 (Just 1) (Just 2)",
@@ -164,23 +164,23 @@ spec = do
               ("\"dog\" + \"log\"", "\"doglog\""),
               ("(\"dog\" : String) + (\"log\" : String)", "String"),
               ("let f = \\a -> a + 1; let g = 100; f 1", "2"),
-              ("(\\pair -> case pair of (a,b) -> a + b : (Int,Int) -> Int)", "(Int,Int) -> Int"),
-              ("let id = (\\i -> i : i -> i); case (Just 1) of Just a -> Just (id a) | Nothing -> Nothing", "Maybe 1"),
+              ("(\\pair -> case pair { (a,b) -> a + b } : (Int,Int) -> Int)", "(Int,Int) -> Int"),
+              ("let id = (\\i -> i : i -> i); case (Just 1) { Just a -> Just (id a), Nothing -> Nothing }", "Maybe 1"),
               ("[1,2]", "[ 1 | 2 ]"),
               ("[1,2,3,4]", "[1 | 4 | 2 | 3]"),
               ("[True]", "[True]"),
               ("([1,2,3,4] : [Int])", "[Int]"),
-              ("case (\"dog\" : String) of \"log\" -> True | _ -> False", "Bool"),
-              ("case ([1,2,3] : [Int]) of [a] -> [a] | [_,...b] -> b", "[Int]"),
-              ("case ([1,2]: [Int]) of [a,...] -> a | _ -> 0", "Int"),
+              ("case (\"dog\" : String) { \"log\" -> True, _ -> False }", "Bool"),
+              ("case ([1,2,3] : [Int]) { [a] -> [a],  [_,...b] -> b }", "[Int]"),
+              ("case ([1,2]: [Int]) { [a,...] -> a, _ -> 0 }", "Int"),
               ("let a = if True then 1 else 2; let b = if True then 7 else 9; a + b", "8 | 9 | 10 | 11"),
               ("\\a -> a == True", "Bool -> Bool"),
               ("(\\x -> (x 1, x (False,True))) (\\a -> a)", "(1, (False, True))"), -- look! higher rank types
               ("let f = (\\x -> (x 1, x False) : (a -> a) -> (1, False)); let id = \\a -> a; f id", "(1, False)"), -- they need annotation, but that's ok
               ("\\a -> \\b -> if a then a else b", "Bool -> Bool -> Bool"),
-              ("\\a -> case a of (b,c) -> if b then b else c", "(Bool,Bool) -> Bool"),
+              ("\\a -> case a { (b,c) -> if b then b else c }", "(Bool,Bool) -> Bool"),
               ("equals (10 : Int) (11: Int)", "Bool"), -- using Eq Int typeclass instance
-              ("let maybeFmap = \\f -> \\maybe -> case maybe of Just a -> Just (f a) | Nothing -> Nothing; let useFmap = (\\fmap -> fmap (\\a -> a + 1 : Int -> Int) : ((a -> b) -> f a -> f b) -> f Int -> f Int); useFmap maybeFmap", "Maybe Int -> Maybe Int")
+              ("let maybeFmap = \\f -> \\maybe -> case maybe { Just a -> Just (f a), Nothing -> Nothing}; let useFmap = (\\fmap -> fmap (\\a -> a + 1 : Int -> Int) : ((a -> b) -> f a -> f b) -> f Int -> f Int); useFmap maybeFmap", "Maybe Int -> Maybe Int")
             ]
       traverse_
         ( \(inputExpr, expectedType) -> it (T.unpack inputExpr <> " :: " <> T.unpack expectedType) $ do
@@ -326,13 +326,13 @@ spec = do
       let inputs =
             [ "(\\a -> if a then 1 else True) True",
               "(\\a -> True : (1 | 2) -> True) 3",
-              "(\\pair -> case pair of (a,b,c) -> a + b + c : (Int,Int) -> Int) (1,2)",
+              "(\\pair -> case pair { (a,b,c) -> a + b + c } : (Int,Int) -> Int) (1,2)",
               "1 + \"dog\"",
-              "(case (False, 1) of (True, a) -> a: Int)",
-              "(case Just 1 of These a -> a | _ -> 0 : Int)", -- need to lookup constructor
-              "(case Just 1 of Just _ a -> a | _ -> 0 : Int)", -- too many args in pattern
-              "(case Just 1 of Just -> 1 | _ -> 0 : Int)", -- not enough args in pattern
-              "(\\a -> case a of 1 -> 10 | 2 -> 20 | 3 -> 30 : (1 | 2) -> Int) 1" -- pattern contains something not found in union
+              "(case (False, 1) {(True, a) -> a }: Int)",
+              "(case Just 1 { These a -> a, _ -> 0 } : Int)", -- need to lookup constructor
+              "(case Just 1 { Just _ a -> a, _ -> 0 }: Int)", -- too many args in pattern
+              "(case Just 1 { Just -> 1, _ -> 0 } : Int)", -- not enough args in pattern
+              "(\\a -> case a { 1 -> 10, 2 -> 20, 3 -> 30 }: (1 | 2) -> Int) 1" -- pattern contains something not found in union
               -- "Nothing", -- don't know what 'a' is
               -- "This 1" -- don't know what 'b' is
             ]
@@ -694,7 +694,7 @@ spec = do
         testElaborate input `shouldSatisfy` isLeft
 
       it "Patterns have type of input type" $ do
-        let input = unsafeParseExpr "(\\maybe -> case maybe of Just b -> 1 | Nothing -> 0 : Maybe Bool -> Int)"
+        let input = unsafeParseExpr "(\\maybe -> case maybe { Just b -> 1, Nothing -> 0 }: Maybe Bool -> Int)"
             expected = TFunc () mempty (TApp () (TConstructor () "Maybe") tyBool) tyInt
 
         getExprAnnotation <$> testElaborate input `shouldBe` Right expected
@@ -755,7 +755,7 @@ spec = do
       it "OK boys 1" $ do
         let input =
               unsafeParseExpr
-                "let id = (\\i -> i : i -> i); case (Just 1) of Just a -> Just (id a) | Nothing -> Nothing"
+                "let id = (\\i -> i : i -> i); case (Just 1) { Just a -> Just (id a), Nothing -> Nothing }"
             expected = fromParsedType $ unsafeParseType "Maybe 1"
         getExprAnnotation <$> testElaborate input
           `shouldBe` Right
@@ -774,21 +774,21 @@ spec = do
           `shouldBe` Right expected
 
       it "Weird boys 0" $ do
-        let input = unsafeParseExpr "let fmap = (\\f -> case (Just (1 : Int)) of Just a -> Just (f a) : (Int -> b) -> Maybe b); let id = (\\i -> i : Int -> Int); fmap id"
+        let input = unsafeParseExpr "let fmap = (\\f -> case (Just (1 : Int)) { Just a -> Just (f a) } : (Int -> b) -> Maybe b); let id = (\\i -> i : Int -> Int); fmap id"
             expected = fromParsedType $ unsafeParseType "Maybe Int"
         getExprAnnotation <$> testElaborate input `shouldBe` Right expected
 
       it "Weird boys 4" $ do
         let input =
               unsafeParseExpr
-                "let fmap = (\\f -> \\val -> case val of Just aa -> Just (f aa) | Nothing -> Nothing : (a -> b) -> Maybe a -> Maybe b); let id = (\\i -> i : Int -> Int); fmap id (Just 1000)"
+                "let fmap = (\\f -> \\val -> case val { Just aa -> Just (f aa), Nothing -> Nothing } : (a -> b) -> Maybe a -> Maybe b); let id = (\\i -> i : Int -> Int); fmap id (Just 1000)"
             expected = fromParsedType $ unsafeParseType "Maybe Int"
         getExprAnnotation <$> testElaborate input `shouldBe` Right expected
 
       it "Weird boys 5" $ do
         let input =
               unsafeParseExpr
-                "let fmap = (\\f -> \\maybe -> case maybe of Just a -> Just (f a) | Nothing -> Nothing : (a -> b) -> Maybe a -> Maybe b); let id = (\\i -> i : c -> c); (fmap id (Just 1) : Maybe 1)"
+                "let fmap = (\\f -> \\maybe -> case maybe { Just a -> Just (f a), Nothing -> Nothing } : (a -> b) -> Maybe a -> Maybe b); let id = (\\i -> i : c -> c); (fmap id (Just 1) : Maybe 1)"
             expected = fromParsedType $ unsafeParseType "Maybe 1"
         getExprAnnotation <$> testElaborate input `shouldBe` Right expected
 

--- a/smol-core/test/static/Either.smol
+++ b/smol-core/test/static/Either.smol
@@ -3,14 +3,16 @@ type Either e a = Left e | Right a
 def orDefault : 
   a -> (Either e a) -> a
 def orDefault default value =
-  case value of 
-      Right a ->   a
-    | Left _ ->   default
+  case value {
+    Right a ->   a,
+    Left _ ->   default
+  }
 
 def fmap : 
   (a -> b) -> (Either e a) -> Either e b
 def fmap f value =
-  case value of 
-      Right a ->   (Right (f a))
-    | Left e ->   (Left e)
+  case value {
+    Right a ->   (Right (f a)),
+    Left e ->   (Left e)
+  }
 

--- a/smol-core/test/static/Either.smol
+++ b/smol-core/test/static/Either.smol
@@ -4,15 +4,15 @@ def orDefault :
   a -> (Either e a) -> a
 def orDefault default value =
   case value {
-    Right a ->   a,
-    Left _ ->   default
+    Right a -> a,
+    Left _ -> default
   }
 
 def fmap : 
   (a -> b) -> (Either e a) -> Either e b
 def fmap f value =
   case value {
-    Right a ->   (Right (f a)),
-    Left e ->   (Left e)
+    Right a -> (Right (f a)),
+    Left e -> (Left e)
   }
 

--- a/smol-core/test/static/Eq.smol
+++ b/smol-core/test/static/Eq.smol
@@ -12,22 +12,24 @@ instance Eq String =
 instance(Eq a, Eq b) => Eq (a, b) =
   \pairA ->
     \pairB ->
-      case ((pairA, pairB)) of 
+      case ((pairA, pairB)) {
           ((a1,  b1),  (a2,  b2)) ->   (if (equals a1 a2)
                                        then
                                          (equals b1 b2)
                                        else
                                          False)
+      }
 
 type Maybe a = Just a | Nothing
 
 instance(Eq a) => Eq Maybe a =
   \a ->
     \b ->
-      case ((a, b)) of 
-          (Just a,  Just b) ->   (equals a b)
-        | (Nothing,  Nothing) ->   True
-        | _ ->   False
+      case ((a, b)) {
+        (Just a,  Just b) ->   (equals a b),
+        (Nothing,  Nothing) ->   True,
+        _ ->   False
+      }
 
 def useEqualsInt : 
   Bool
@@ -52,8 +54,9 @@ def pair =
 def flipPair : 
   (a, b) -> (b, a)
 def flipPair pair =
-  case pair of 
+  case pair {
       (a,  b) ->   ((b, a))
+  }
 
 def main : 
   Bool

--- a/smol-core/test/static/Eq.smol
+++ b/smol-core/test/static/Eq.smol
@@ -13,11 +13,11 @@ instance(Eq a, Eq b) => Eq (a, b) =
   \pairA ->
     \pairB ->
       case ((pairA, pairB)) {
-          ((a1,  b1),  (a2,  b2)) ->   (if (equals a1 a2)
-                                       then
-                                         (equals b1 b2)
-                                       else
-                                         False)
+        ((a1,  b1),  (a2,  b2)) ->   (if (equals a1 a2)
+                                     then
+                                       (equals b1 b2)
+                                     else
+                                       False)
       }
 
 type Maybe a = Just a | Nothing
@@ -55,7 +55,7 @@ def flipPair :
   (a, b) -> (b, a)
 def flipPair pair =
   case pair {
-      (a,  b) ->   ((b, a))
+    (a,  b) ->   ((b, a))
   }
 
 def main : 

--- a/smol-core/test/static/Eq.smol
+++ b/smol-core/test/static/Eq.smol
@@ -13,11 +13,11 @@ instance(Eq a, Eq b) => Eq (a, b) =
   \pairA ->
     \pairB ->
       case ((pairA, pairB)) {
-        ((a1,  b1),  (a2,  b2)) -> (if (equals a1 a2)
+        ((a1,  b1),  (a2,  b2)) -> if (equals a1 a2)
         then
           (equals b1 b2)
         else
-          False)
+          False
       }
 
 type Maybe a = Just a | Nothing

--- a/smol-core/test/static/Eq.smol
+++ b/smol-core/test/static/Eq.smol
@@ -13,11 +13,11 @@ instance(Eq a, Eq b) => Eq (a, b) =
   \pairA ->
     \pairB ->
       case ((pairA, pairB)) {
-        ((a1,  b1),  (a2,  b2)) ->   (if (equals a1 a2)
-                                     then
-                                       (equals b1 b2)
-                                     else
-                                       False)
+        ((a1,  b1),  (a2,  b2)) -> (if (equals a1 a2)
+        then
+          (equals b1 b2)
+        else
+          False)
       }
 
 type Maybe a = Just a | Nothing
@@ -26,9 +26,9 @@ instance(Eq a) => Eq Maybe a =
   \a ->
     \b ->
       case ((a, b)) {
-        (Just a,  Just b) ->   (equals a b),
-        (Nothing,  Nothing) ->   True,
-        _ ->   False
+        (Just a,  Just b) -> (equals a b),
+        (Nothing,  Nothing) -> True,
+        _ -> False
       }
 
 def useEqualsInt : 
@@ -55,7 +55,7 @@ def flipPair :
   (a, b) -> (b, a)
 def flipPair pair =
   case pair {
-    (a,  b) ->   ((b, a))
+    (a,  b) -> ((b, a))
   }
 
 def main : 

--- a/smol-core/test/static/Expr.smol
+++ b/smol-core/test/static/Expr.smol
@@ -2,15 +2,15 @@ type Expr ann = EAdd ann (Expr ann) (Expr ann) | ENumber ann Int
 
 def run expr =
   case expr {
-    ENumber _ i ->   i,
-    EAdd _ _ _ ->   100
+    ENumber _ i -> i,
+    EAdd _ _ _ -> 100
   }
 
 def run2 expr =
   let go inner =
     case inner {
-      ENumber _ i ->   i,
-      EAdd _ a b ->   (go a) + (go b)
+      ENumber _ i -> i,
+      EAdd _ a b -> (go a) + (go b)
     };
 
   go expr

--- a/smol-core/test/static/Expr.smol
+++ b/smol-core/test/static/Expr.smol
@@ -2,8 +2,8 @@ type Expr ann = EAdd ann (Expr ann) (Expr ann) | ENumber ann Int
 
 def run expr =
   case expr {
-      ENumber _ i ->   i,
-      EAdd _ _ _ ->   100
+    ENumber _ i ->   i,
+    EAdd _ _ _ ->   100
   }
 
 def run2 expr =

--- a/smol-core/test/static/Expr.smol
+++ b/smol-core/test/static/Expr.smol
@@ -1,15 +1,17 @@
 type Expr ann = EAdd ann (Expr ann) (Expr ann) | ENumber ann Int
 
 def run expr =
-  case expr of 
-      ENumber _ i ->   i
-    | EAdd _ _ _ ->   100
+  case expr {
+      ENumber _ i ->   i,
+      EAdd _ _ _ ->   100
+  }
 
 def run2 expr =
   let go inner =
-    case inner of 
-        ENumber _ i ->   i
-      | EAdd _ a b ->   (go a) + (go b);
+    case inner {
+      ENumber _ i ->   i,
+      EAdd _ a b ->   (go a) + (go b)
+    };
 
   go expr
 

--- a/smol-core/test/static/Functor.smol
+++ b/smol-core/test/static/Functor.smol
@@ -3,13 +3,17 @@ class Functor f { fmap: (a -> b) -> (f a) -> f b }
 type Maybe a = Just a | Nothing
 
 instance Functor Maybe =
-  \f -> \maybe -> case maybe of    Just a -> (Just (f a)) | Nothing -> Nothing
+  \f -> \maybe -> case maybe {
+    Just a -> (Just (f a)),
+    Nothing -> Nothing
+  }
 
 test "fmap works with Just" =
   let unwrapMaybe maybe =
-    case maybe of 
-        Just a ->   a
-      | Nothing ->   0;
+    case maybe {
+        Just a ->   a,
+        Nothing ->   0
+    };
 
   let inc =
     (\a -> a + 1 : Int -> Int);
@@ -21,15 +25,17 @@ type List a = Cons a (List a) | Nil
 instance Functor List =
   \f ->
     \list ->
-      case list of 
-          Cons a rest ->   (Cons (f a) (fmap f rest))
-        | Nil ->   Nil
+      case list {
+          Cons a rest ->   (Cons (f a) (fmap f rest)),
+          Nil ->   Nil
+      }
 
 test "fmap works with List" =
   let listHead list =
-    case list of 
-        Cons a _ ->   a
-      | Nil ->   0;
+    case list {
+      Cons a _ ->   a,
+      Nil ->   0
+    };
 
   let inc =
     (\a -> a + 1 : Int -> Int);
@@ -40,13 +46,14 @@ type Either e a = Left e | Right a
 
 instance Functor Either e =
   \f ->
-    \either -> case either of    Right a -> (Right (f a)) | Left e -> (Left e)
+    \either -> case either { Right a -> (Right (f a)), Left e -> (Left e) }
 
 test "fmap works with Either" =
   let unwrapEither either =
-    case either of 
-        Right a ->   a
-      | _ ->   0;
+    case either {
+        Right a ->   a,
+        _ ->   0
+    };
 
   let inc =
     (\a -> a + 1 : Int -> Int);

--- a/smol-core/test/static/Functor.smol
+++ b/smol-core/test/static/Functor.smol
@@ -8,8 +8,8 @@ instance Functor Maybe =
 test "fmap works with Just" =
   let unwrapMaybe maybe =
     case maybe {
-      Just a ->   a,
-      Nothing ->   0
+      Just a -> a,
+      Nothing -> 0
     };
 
   let inc =
@@ -26,8 +26,8 @@ instance Functor List =
 test "fmap works with List" =
   let listHead list =
     case list {
-      Cons a _ ->   a,
-      Nil ->   0
+      Cons a _ -> a,
+      Nil -> 0
     };
 
   let inc =
@@ -43,8 +43,8 @@ instance Functor Either e =
 test "fmap works with Either" =
   let unwrapEither either =
     case either {
-      Right a ->   a,
-      _ ->   0
+      Right a -> a,
+      _ -> 0
     };
 
   let inc =

--- a/smol-core/test/static/Functor.smol
+++ b/smol-core/test/static/Functor.smol
@@ -3,16 +3,13 @@ class Functor f { fmap: (a -> b) -> (f a) -> f b }
 type Maybe a = Just a | Nothing
 
 instance Functor Maybe =
-  \f -> \maybe -> case maybe {
-    Just a -> (Just (f a)),
-    Nothing -> Nothing
-  }
+  \f -> \maybe -> case maybe { Just a -> (Just (f a)), Nothing -> Nothing }
 
 test "fmap works with Just" =
   let unwrapMaybe maybe =
     case maybe {
-        Just a ->   a,
-        Nothing ->   0
+      Just a ->   a,
+      Nothing ->   0
     };
 
   let inc =
@@ -24,11 +21,7 @@ type List a = Cons a (List a) | Nil
 
 instance Functor List =
   \f ->
-    \list ->
-      case list {
-          Cons a rest ->   (Cons (f a) (fmap f rest)),
-          Nil ->   Nil
-      }
+    \list -> case list { Cons a rest -> (Cons (f a) (fmap f rest)), Nil -> Nil }
 
 test "fmap works with List" =
   let listHead list =
@@ -45,14 +38,13 @@ test "fmap works with List" =
 type Either e a = Left e | Right a
 
 instance Functor Either e =
-  \f ->
-    \either -> case either { Right a -> (Right (f a)), Left e -> (Left e) }
+  \f -> \either -> case either { Right a -> (Right (f a)), Left e -> (Left e) }
 
 test "fmap works with Either" =
   let unwrapEither either =
     case either {
-        Right a ->   a,
-        _ ->   0
+      Right a ->   a,
+      _ ->   0
     };
 
   let inc =

--- a/smol-core/test/static/Maybe.smol
+++ b/smol-core/test/static/Maybe.smol
@@ -4,16 +4,16 @@ def fromMaybe :
   (Maybe a) -> a -> a
 def fromMaybe val fallback =
   case val {
-      Just a ->   a,
-      _ ->   fallback
+    Just a ->   a,
+    _ ->   fallback
   }
 
 def fmap : 
   (a -> b) -> (Maybe a) -> Maybe b
 def fmap f maybeA =
   case maybeA {
-      Just a ->   (Just (f a)),
-      _ ->   Nothing
+    Just a ->   (Just (f a)),
+    _ ->   Nothing
   }
 
 test "fmap id does nothing" =

--- a/smol-core/test/static/Maybe.smol
+++ b/smol-core/test/static/Maybe.smol
@@ -3,16 +3,18 @@ type Maybe a = Just a | Nothing
 def fromMaybe : 
   (Maybe a) -> a -> a
 def fromMaybe val fallback =
-  case val of 
-      Just a ->   a
-    | _ ->   fallback
+  case val {
+      Just a ->   a,
+      _ ->   fallback
+  }
 
 def fmap : 
   (a -> b) -> (Maybe a) -> Maybe b
 def fmap f maybeA =
-  case maybeA of 
-      Just a ->   (Just (f a))
-    | _ ->   Nothing
+  case maybeA {
+      Just a ->   (Just (f a)),
+      _ ->   Nothing
+  }
 
 test "fmap id does nothing" =
   let id a = a in (fromMaybe (fmap id (Just True)) False) == True

--- a/smol-core/test/static/Maybe.smol
+++ b/smol-core/test/static/Maybe.smol
@@ -4,16 +4,16 @@ def fromMaybe :
   (Maybe a) -> a -> a
 def fromMaybe val fallback =
   case val {
-    Just a ->   a,
-    _ ->   fallback
+    Just a -> a,
+    _ -> fallback
   }
 
 def fmap : 
   (a -> b) -> (Maybe a) -> Maybe b
 def fmap f maybeA =
   case maybeA {
-    Just a ->   (Just (f a)),
-    _ ->   Nothing
+    Just a -> (Just (f a)),
+    _ -> Nothing
   }
 
 test "fmap id does nothing" =

--- a/smol-core/test/static/Monoid.smol
+++ b/smol-core/test/static/Monoid.smol
@@ -13,15 +13,17 @@ type All  = All Bool
 def runAll : 
   All -> Bool
 def runAll all =
-  case all of 
+  case all {
       All a ->   a
+  }
 
 instance Semigroup All =
   \a ->
     \b ->
-      case ((a, b)) of 
-          (All True,  All True) ->   (All True)
-        | _ ->   (All False)
+      case ((a, b)) {
+          (All True,  All True) ->   (All True),
+          _ ->   (All False)
+      }
 
 instance Monoid All =
   All True

--- a/smol-core/test/static/Monoid.smol
+++ b/smol-core/test/static/Monoid.smol
@@ -14,15 +14,15 @@ def runAll :
   All -> Bool
 def runAll all =
   case all {
-      All a ->   a
+    All a ->   a
   }
 
 instance Semigroup All =
   \a ->
     \b ->
       case ((a, b)) {
-          (All True,  All True) ->   (All True),
-          _ ->   (All False)
+        (All True,  All True) ->   (All True),
+        _ ->   (All False)
       }
 
 instance Monoid All =

--- a/smol-core/test/static/Monoid.smol
+++ b/smol-core/test/static/Monoid.smol
@@ -14,15 +14,15 @@ def runAll :
   All -> Bool
 def runAll all =
   case all {
-    All a ->   a
+    All a -> a
   }
 
 instance Semigroup All =
   \a ->
     \b ->
       case ((a, b)) {
-        (All True,  All True) ->   (All True),
-        _ ->   (All False)
+        (All True,  All True) -> (All True),
+        _ -> (All False)
       }
 
 instance Monoid All =

--- a/smol-core/test/static/Prelude.smol
+++ b/smol-core/test/static/Prelude.smol
@@ -27,14 +27,14 @@ def fst :
   (a, b) -> a
 def fst pair =
   case pair {
-    (a,  _) ->   a
+    (a,  _) -> a
   }
 
 def snd : 
   (a, b) -> b
 def snd pair =
   case pair {
-    (_,  b) ->   b
+    (_,  b) -> b
   }
 
 def const : 
@@ -48,6 +48,6 @@ def runIdentity :
   (Identity a) -> a
 def runIdentity identity =
   case identity {
-    Identity a ->   a
+    Identity a -> a
   }
 

--- a/smol-core/test/static/Prelude.smol
+++ b/smol-core/test/static/Prelude.smol
@@ -26,14 +26,16 @@ def or a b =
 def fst : 
   (a, b) -> a
 def fst pair =
-  case pair of 
+  case pair {
       (a,  _) ->   a
+  }
 
 def snd : 
   (a, b) -> b
 def snd pair =
-  case pair of 
+  case pair {
       (_,  b) ->   b
+  }
 
 def const : 
   a -> b -> a
@@ -45,6 +47,6 @@ type Identity a = Identity a
 def runIdentity : 
   (Identity a) -> a
 def runIdentity identity =
-  case identity of 
+  case identity {
       Identity a ->   a
-
+  }

--- a/smol-core/test/static/Prelude.smol
+++ b/smol-core/test/static/Prelude.smol
@@ -27,14 +27,14 @@ def fst :
   (a, b) -> a
 def fst pair =
   case pair {
-      (a,  _) ->   a
+    (a,  _) ->   a
   }
 
 def snd : 
   (a, b) -> b
 def snd pair =
   case pair {
-      (_,  b) ->   b
+    (_,  b) ->   b
   }
 
 def const : 
@@ -48,5 +48,6 @@ def runIdentity :
   (Identity a) -> a
 def runIdentity identity =
   case identity {
-      Identity a ->   a
+    Identity a ->   a
   }
+

--- a/smol-core/test/static/Reader.smol
+++ b/smol-core/test/static/Reader.smol
@@ -4,7 +4,7 @@ def run :
   (Reader (r -> a)) -> r -> a
 def run reader r =
   case reader {
-    Reader ra ->   (ra r)
+    Reader ra -> (ra r)
   }
 
 def pure : 

--- a/smol-core/test/static/Reader.smol
+++ b/smol-core/test/static/Reader.smol
@@ -3,8 +3,9 @@ type Reader r a = Reader (r -> a)
 def run : 
   (Reader (r -> a)) -> r -> a
 def run reader r =
-  case reader of 
+  case reader {
       Reader ra ->   (ra r)
+  }
 
 def pure : 
   a -> Reader r a

--- a/smol-core/test/static/Reader.smol
+++ b/smol-core/test/static/Reader.smol
@@ -4,7 +4,7 @@ def run :
   (Reader (r -> a)) -> r -> a
 def run reader r =
   case reader {
-      Reader ra ->   (ra r)
+    Reader ra ->   (ra r)
   }
 
 def pure : 

--- a/smol-core/test/static/Semigroup.smol
+++ b/smol-core/test/static/Semigroup.smol
@@ -13,8 +13,9 @@ type First a = First a
 def runFirst : 
   (First a) -> a
 def runFirst firstA =
-  case firstA of 
+  case firstA {
       First a ->   a
+  }
 
 instance Semigroup First a =
   \a -> \b -> a

--- a/smol-core/test/static/Semigroup.smol
+++ b/smol-core/test/static/Semigroup.smol
@@ -14,7 +14,7 @@ def runFirst :
   (First a) -> a
 def runFirst firstA =
   case firstA {
-    First a ->   a
+    First a -> a
   }
 
 instance Semigroup First a =

--- a/smol-core/test/static/Semigroup.smol
+++ b/smol-core/test/static/Semigroup.smol
@@ -14,7 +14,7 @@ def runFirst :
   (First a) -> a
 def runFirst firstA =
   case firstA {
-      First a ->   a
+    First a ->   a
   }
 
 instance Semigroup First a =

--- a/smol-core/test/static/Show.smol
+++ b/smol-core/test/static/Show.smol
@@ -12,7 +12,7 @@ test "Show False" =
 type Natural  = Suc Natural | Zero
 
 instance Show Natural =
-  \nat -> case nat of    Suc n -> "S (" + (show n) + ")" | Zero -> "Z"
+  \nat -> case nat { Suc n -> "S (" + (show n) + ")", Zero -> "Z" }
 
 test "Show Zero" =
   (show Zero) == "Z"
@@ -24,9 +24,10 @@ type List a = Cons a (List a) | Nil
 
 instance(Show a) => Show List a =
   \list ->
-    case list of 
-        Cons a rest ->   (show a) + ":" + (show rest)
-      | Nil ->   "Nil"
+    case list {
+        Cons a rest ->   (show a) + ":" + (show rest),
+        Nil ->   "Nil"
+    }
 
 def showBoolList =
   (show (Cons (True : Bool) (Cons (False : Bool) Nil))) == "True:False:Nil"

--- a/smol-core/test/static/Show.smol
+++ b/smol-core/test/static/Show.smol
@@ -25,8 +25,8 @@ type List a = Cons a (List a) | Nil
 instance(Show a) => Show List a =
   \list ->
     case list {
-      Cons a rest ->   (show a) + ":" + (show rest),
-      Nil ->   "Nil"
+      Cons a rest -> (show a) + ":" + (show rest),
+      Nil -> "Nil"
     }
 
 def showBoolList =

--- a/smol-core/test/static/Show.smol
+++ b/smol-core/test/static/Show.smol
@@ -25,8 +25,8 @@ type List a = Cons a (List a) | Nil
 instance(Show a) => Show List a =
   \list ->
     case list {
-        Cons a rest ->   (show a) + ":" + (show rest),
-        Nil ->   "Nil"
+      Cons a rest ->   (show a) + ":" + (show rest),
+      Nil ->   "Nil"
     }
 
 def showBoolList =

--- a/smol-core/test/static/State.smol
+++ b/smol-core/test/static/State.smol
@@ -31,14 +31,14 @@ def ap stateF stateA =
         sfs s;
 
       case fs {
-        (f,  ss) -> (case stateA {
+        (f,  ss) -> case stateA {
           State sas -> (let as =
             sas ss;
 
           case as {
             (a,  sss) -> (((f a), sss))
           })
-        })
+        }
       })
     })
 
@@ -47,11 +47,11 @@ def bind :
 def bind f state =
   State (\s ->
     case state {
-      State sas -> (case (sas s) {
-        (a,  ss) -> (case (f a) {
+      State sas -> case (sas s) {
+        (a,  ss) -> case (f a) {
           State sbs -> (sbs ss)
-        })
-      })
+        }
+      }
     })
 
 def run : 

--- a/smol-core/test/static/State.smol
+++ b/smol-core/test/static/State.smol
@@ -19,7 +19,7 @@ def fmap :
   (a -> b) -> (State s a) -> State s b
 def fmap f state =
   case state {
-    State sas ->   (State (\s -> case (sas s) { (a,  s) -> (((f a), s)) }))
+    State sas -> (State (\s -> case (sas s) { (a,  s) -> (((f a), s)) }))
   }
 
 def ap : 
@@ -27,20 +27,19 @@ def ap :
 def ap stateF stateA =
   State (\s ->
     case stateF {
-      State sfs ->   (let fs =
-                       sfs s;
+      State sfs -> (let fs =
+        sfs s;
 
-                     case fs {
-                       (f,  ss) ->   (case stateA {
-                                       State sas ->   (let as =
-                                                        sas ss;
+      case fs {
+        (f,  ss) -> (case stateA {
+          State sas -> (let as =
+            sas ss;
 
-                                                      case as {
-                                                        (a,  sss) ->   (((f a),
-                                                                         sss))
-                                                      })
-                                     })
-                     })
+          case as {
+            (a,  sss) -> (((f a), sss))
+          })
+        })
+      })
     })
 
 def bind : 
@@ -48,17 +47,17 @@ def bind :
 def bind f state =
   State (\s ->
     case state {
-      State sas ->   (case (sas s) {
-                       (a,  ss) ->   (case (f a) {
-                                       State sbs ->   (sbs ss)
-                                     })
-                     })
+      State sas -> (case (sas s) {
+        (a,  ss) -> (case (f a) {
+          State sbs -> (sbs ss)
+        })
+      })
     })
 
 def run : 
   (State s a) -> s -> (a, s)
 def run state s =
   case state {
-    State sas ->   (sas s)
+    State sas -> (sas s)
   }
 

--- a/smol-core/test/static/State.smol
+++ b/smol-core/test/static/State.smol
@@ -19,7 +19,7 @@ def fmap :
   (a -> b) -> (State s a) -> State s b
 def fmap f state =
   case state {
-      State sas ->   (State (\s -> case (sas s) { (a,  s) -> (((f a), s))}))
+    State sas ->   (State (\s -> case (sas s) { (a,  s) -> (((f a), s)) }))
   }
 
 def ap : 
@@ -27,36 +27,38 @@ def ap :
 def ap stateF stateA =
   State (\s ->
     case stateF {
-        State sfs -> (let fs =
-                         sfs s;
+      State sfs ->   (let fs =
+                       sfs s;
 
-                       case fs {
-                           (f,  ss) ->   (case stateA {
-                                             State sas ->   (let as =
-                                                              sas ss;
+                     case fs {
+                       (f,  ss) ->   (case stateA {
+                                       State sas ->   (let as =
+                                                        sas ss;
 
-                                                            case as {
-                                                                (a,  sss) ->
-                                                                (((f a),
-                                                                  sss))})
+                                                      case as {
+                                                        (a,  sss) ->   (((f a),
+                                                                         sss))
                                                       })
-                                                                  })
-  })
+                                     })
+                     })
+    })
 
 def bind : 
   (a -> State s b) -> (State s a) -> State s b
 def bind f state =
   State (\s ->
     case state {
-        State sas ->   (case (sas s) {
-                           (a,  ss) ->   (case (f a) {
-                                             State sbs ->   (sbs ss)})})
-                                             })
+      State sas ->   (case (sas s) {
+                       (a,  ss) ->   (case (f a) {
+                                       State sbs ->   (sbs ss)
+                                     })
+                     })
+    })
 
 def run : 
   (State s a) -> s -> (a, s)
 def run state s =
   case state {
-      State sas ->   (sas s)
+    State sas ->   (sas s)
   }
 

--- a/smol-core/test/static/State.smol
+++ b/smol-core/test/static/State.smol
@@ -18,39 +18,45 @@ def put s =
 def fmap : 
   (a -> b) -> (State s a) -> State s b
 def fmap f state =
-  case state of 
-      State sas ->   (State (\s -> case (sas s) of    (a,  s) -> (((f a), s))))
+  case state {
+      State sas ->   (State (\s -> case (sas s) { (a,  s) -> (((f a), s))}))
+  }
 
 def ap : 
   (State s (a -> b)) -> (State s a) -> State s b
 def ap stateF stateA =
   State (\s ->
-    case stateF of 
-        State sfs ->   (let fs =
+    case stateF {
+        State sfs -> (let fs =
                          sfs s;
 
-                       case fs of 
-                           (f,  ss) ->   (case stateA of 
+                       case fs {
+                           (f,  ss) ->   (case stateA {
                                              State sas ->   (let as =
                                                               sas ss;
 
-                                                            case as of 
+                                                            case as {
                                                                 (a,  sss) ->
                                                                 (((f a),
-                                                                  sss))))))
+                                                                  sss))})
+                                                      })
+                                                                  })
+  })
 
 def bind : 
   (a -> State s b) -> (State s a) -> State s b
 def bind f state =
   State (\s ->
-    case state of 
-        State sas ->   (case (sas s) of 
-                           (a,  ss) ->   (case (f a) of 
-                                             State sbs ->   (sbs ss))))
+    case state {
+        State sas ->   (case (sas s) {
+                           (a,  ss) ->   (case (f a) {
+                                             State sbs ->   (sbs ss)})})
+                                             })
 
 def run : 
   (State s a) -> s -> (a, s)
 def run state s =
-  case state of 
+  case state {
       State sas ->   (sas s)
+  }
 

--- a/smol-core/test/static/Tree.smol
+++ b/smol-core/test/static/Tree.smol
@@ -5,8 +5,8 @@ def fmap :
 def fmap f =
   let map innerTree =
     case innerTree {
-      Branch left a right ->   (Branch (map left) (f a) (map right)),
-      Leaf a ->   (Leaf (f a))
+      Branch left a right -> (Branch (map left) (f a) (map right)),
+      Leaf a -> (Leaf (f a))
     };
 
   map
@@ -16,8 +16,8 @@ def invert :
 def invert =
   let invertTree innerTree =
     case innerTree {
-      Branch left a right ->   (Branch (invertTree right) a (invertTree left)),
-      Leaf a ->   (Leaf a)
+      Branch left a right -> (Branch (invertTree right) a (invertTree left)),
+      Leaf a -> (Leaf a)
     };
 
   invertTree

--- a/smol-core/test/static/Tree.smol
+++ b/smol-core/test/static/Tree.smol
@@ -4,9 +4,10 @@ def fmap :
   (a -> b) -> (Tree a) -> Tree b
 def fmap f =
   let map innerTree =
-    case innerTree of 
-        Branch left a right ->   (Branch (map left) (f a) (map right))
-      | Leaf a ->   (Leaf (f a));
+    case innerTree {
+      Branch left a right ->   (Branch (map left) (f a) (map right)),
+      Leaf a ->   (Leaf (f a))
+    };
 
   map
 
@@ -14,9 +15,10 @@ def invert :
   (Tree a) -> Tree b
 def invert =
   let invertTree innerTree =
-    case innerTree of 
-        Branch left a right ->   (Branch (invertTree right) a (invertTree left))
-      | Leaf a ->   (Leaf a);
+    case innerTree {
+      Branch left a right ->   (Branch (invertTree right) a (invertTree left)),
+      Leaf a ->   (Leaf a)
+    };
 
   invertTree
 


### PR DESCRIPTION
Trying to follow whitespace is actually quite hard, let's wrap these pattern matches up.

```haskell
case expr {
    ENumber _ i -> i,
    EAdd _ _ _ -> 100
  }
```