### PR TITLE
Destructure in lambda

### DIFF
--- a/smol-core/src/Smol/Core/Parser/Expr.hs
+++ b/smol-core/src/Smol/Core/Parser/Expr.hs
@@ -53,12 +53,36 @@ complexParser =
 
 lambdaParser :: Parser ParserExpr
 lambdaParser =
+  try regularLambdaParser
+    <|> patternLambdaParser
+
+regularLambdaParser :: Parser ParserExpr
+regularLambdaParser =
   label "lambda" $
     addLocation $ do
       _ <- myString "\\"
       ident <- emptyParseDep <$> identifierParser
       _ <- myString "->"
       ELambda mempty ident <$> expressionParser
+
+patternLambdaParser :: Parser ParserExpr
+patternLambdaParser =
+  label "lambda" $
+    addLocation $ do
+      _ <- myString "\\"
+      pat <- patternParser
+      _ <- myString "->"
+      expr <- expressionParser
+      pure
+        ( ELambda
+            mempty
+            (emptyParseDep "lambdaArg")
+            ( EPatternMatch
+                mempty
+                (EVar mempty (emptyParseDep "lambdaArg"))
+                (NE.singleton (pat, expr))
+            )
+        )
 
 -----
 

--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/Types/Instance.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/Types/Instance.hs
@@ -67,7 +67,8 @@ deriving anyclass instance
   FromJSON (Instance dep ann)
 
 instance
-  ( Printer (dep Constructor),
+  ( Eq (dep Identifier),
+    Printer (dep Constructor),
     Printer (dep TypeName),
     Printer (dep Identifier)
   ) =>

--- a/smol-core/test/Test/ParserSpec.hs
+++ b/smol-core/test/Test/ParserSpec.hs
@@ -137,7 +137,21 @@ spec = do
               ("fmap inc (Just 1)", EApp () (EApp () (var "fmap") (var "inc")) (EApp () (constructor "Just") (int 1))),
               ("Just (1 + 1)", EApp () (constructor "Just") (EInfix () OpAdd (int 1) (int 1))),
               ("[]", EArray () mempty),
-              ("[1,2,3,4]", EArray () (Seq.fromList [int 1, int 2, int 3, int 4]))
+              ("[1,2,3,4]", EArray () (Seq.fromList [int 1, int 2, int 3, int 4])),
+              ( "\\(a,_) -> a",
+                ELambda
+                  ()
+                  "lambdaArg"
+                  ( EPatternMatch
+                      ()
+                      (var "lambdaArg")
+                      ( NE.singleton
+                          ( PTuple () (PVar () "a") (NE.singleton $ PWildcard ()),
+                            var "a"
+                          )
+                      )
+                  )
+              )
             ]
       traverse_
         ( \(str, expr) -> it (T.unpack str) $ do

--- a/smol-core/test/static/Functor.smol
+++ b/smol-core/test/static/Functor.smol
@@ -1,5 +1,29 @@
 class Functor f { fmap: (a -> b) -> (f a) -> f b }
 
+type Identity a = Identity a
+
+instance Functor Identity {
+  \f -> \Identity a -> Identity (f a)
+}
+
+test "fmap works with Identity" {
+  let runIdentity identity = 
+    let Identity a = identity;
+
+    a;
+
+  let inc = 
+    (\a -> a + 1 : Int -> Int);
+
+  let result = 
+    runIdentity (fmap inc (Identity (1 : Int)));
+
+  let expected = 
+    runIdentity (Identity (2 : Int));
+
+  (result : Int) == (expected : Int)
+}
+
 type Maybe a = Just a | Nothing
 
 instance Functor Maybe {

--- a/smol-core/test/static/Monoid.smol
+++ b/smol-core/test/static/Monoid.smol
@@ -20,8 +20,8 @@ def runAll all =
   a
 
 instance Semigroup All {
-  \a ->
-    \b -> case ((a, b)) { (All True, All True) -> (All True), _ -> (All False) }
+  \All a ->
+    \All b -> case ((a, b)) { (True, True) -> (All True), _ -> (All False) }
 }
 
 instance Monoid All {


### PR DESCRIPTION
```haskell
\(Identity a) -> a
```

which is actually

```haskell
\lambdaArg -> case lambdaArg { Identity a -> a }
```