### PR TITLE
Broken Eq List example

### DIFF
--- a/smol-core/src/Smol/Core/Typecheck/Typeclass/ToDictionaryPassing.hs
+++ b/smol-core/src/Smol/Core/Typecheck/Typeclass/ToDictionaryPassing.hs
@@ -354,5 +354,8 @@ toDictionaryPassing ::
   [Constraint ResolvedDep (Type ResolvedDep ann)] ->
   Expr ResolvedDep (Type ResolvedDep ann) ->
   m (Expr ResolvedDep (Type ResolvedDep ann))
-toDictionaryPassing env subs constraints expr =
-  runReaderT (toDictionaryPassingInternal env subs constraints expr) emptyPassDictEnv
+toDictionaryPassing env subs constraints expr = do
+  tracePrettyM "expr" expr
+  newExpr <- runReaderT (toDictionaryPassingInternal env subs constraints expr) emptyPassDictEnv
+  tracePrettyM "toDictionaryPassing" newExpr
+  pure newExpr

--- a/smol-modules/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-modules/test/Test/Modules/InterpreterSpec.hs
@@ -156,7 +156,21 @@ spec = do
                   "def main = show (Suc Zero)"
                 ],
                 "\"S Z\""
-              )
+              ){-,
+              ( ["class Eq a { equals : a -> a -> Bool }",
+                  "instance Eq Bool { \\a -> \\b -> a == b }",
+                          "type List a = Nil | Cons a (List a)",
+                          "instance (Eq a) => Eq (List a) { ",
+                          "\\listA -> \\listB -> case ((listA, listB)) { ",
+                          "(Nil, Nil) -> True,",
+                          "(Cons a as, Cons b bs) -> ",
+                          "if (equals a b) then (equals as bs) else False,",
+                          "_ -> False } }",
+                          "def main : Bool",
+                          "def main = equals (Cons (True : Bool) Nil) (Cons (True : Bool) Nil)"
+
+                  ],
+              "True") -}
             ]
       traverse_
         ( \(parts, expect) ->

--- a/smol-modules/test/Test/Typecheck/ToDictionaryPassingSpec.hs
+++ b/smol-modules/test/Test/Typecheck/ToDictionaryPassingSpec.hs
@@ -162,7 +162,7 @@ spec = do
         ]
 
     -- the whole transformation basically
-    describe "toDictionaryPassing" $ do
+    fdescribe "toDictionaryPassing" $ do
       traverse_
         ( \(constraints, parts, expectedParts) -> do
             let input = joinText parts
@@ -217,5 +217,11 @@ spec = do
               ", _ -> \"\" } : Natural -> String); ",
               "shownatural Zero"
             ]
+          ),
+          ( mempty,
+            ["equals (Nil : List Bool) (Nil : List Bool)"],
+            ["equals (Nil : List Bool) (Nil : List Bool)"]
           )
+
+
         ]

--- a/smol-modules/test/static/Eq.smol
+++ b/smol-modules/test/static/Eq.smol
@@ -35,6 +35,25 @@ instance (Eq a) => Eq Maybe a {
       }
 }
 
+type List a = Cons a (List a) | Nil
+
+instance (Eq a) => Eq (List a) {
+    \listA -> \listB -> case ((listA, listB)) {
+        (Nil, Nil) -> True,
+        (Cons a as, Cons b bs) ->
+                          if (equals a b) then (equals as bs) else False,
+        _ -> False }
+        }
+
+test "whoa" { equals (Nil : List Bool) (Nil : List Bool) }
+
+/*test "whoa" { equals (Cons (True : Bool) Nil) (Cons (True : Bool) Nil) } */
+
+
+
+
+
+
 def useEqualsInt : 
   Bool
 def useEqualsInt =


### PR DESCRIPTION
Generating instances for this test causes an infinite loop to happen.

```haskell
type List a = Cons a (List a) | Nil

instance Eq Bool {
  \a -> \b -> a == b
}

instance (Eq a) => Eq (List a) {
    \listA -> \listB -> case ((listA, listB)) {
        (Nil, Nil) -> True,
        (Cons a as, Cons b bs) ->
                          if (equals a b) then (equals as bs) else False,
        _ -> False }
        }

/* you need this there to ensure the instance is created */
test "whoa" { equals (Nil : List Bool) (Nil : List Bool) }
```