### PR TITLE
Change `def` syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,6 @@ test-smol-wasm:
 build-smol-repl:
 	cabal build smol-repl
 
-.PHONY: test-backends
-test-backends:
-	cabal run backends:test:backends-tests
-
 .PHONY: freeze
 freeze:
 	cabal freeze --enable-tests --enable-benchmarks

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 some sort of compiler
 
 ```haskell
-def inc : Int -> Int -> Int
-def inc a = a + 1
+def inc (a: Int): Int { 
+    a + 1
+}
 
 class Eq a { equals : a -> a -> Bool }
 

--- a/smol-backend/test/Test/IR/IRSpec.hs
+++ b/smol-backend/test/Test/IR/IRSpec.hs
@@ -32,7 +32,7 @@ run llModule env =
 
 createLLVMModuleFromExpr :: Text -> LLVM.Module
 createLLVMModuleFromExpr input =
-  createLLVMModuleFromModule $ "def main = " <> input
+  createLLVMModuleFromModule $ "def main { " <> input <> " }"
 
 testCompileIR :: (Text, Text) -> Spec
 testCompileIR (input, result) = it ("Via IR " <> show input) $ do
@@ -106,41 +106,40 @@ spec = do
 
     describe "From modules" $ do
       let testModules =
-            [ ( [ "def one = 1",
-                  "def main = one + one"
+            [ ( [ "def one { 1 }",
+                  "def main { one + one }"
                 ],
                 "2"
               ),
-              ( [ "def increment a = (a + 1 : Int)",
-                  "def main = increment 41"
+              ( [ "def increment (a: Int): Int { a + 1 }",
+                  "def main { increment 41 }"
                 ],
                 "42"
               ),
-              ( [ "def add : Int -> Int -> Int",
-                  "def add a b = a + b",
-                  "def main = add 20 22"
-                ],
-                "42"
-              ),
-              ( [ "type Identity a = Identity a",
-                  "def main = case Identity 42 { Identity a -> a }"
+              ( [
+                  "def add (a: Int) (b: Int): Int { a + b }",
+                  "def main { add 20 22 }"
                 ],
                 "42"
               ),
               ( [ "type Identity a = Identity a",
-                  "def main = case Identity (41 + 1) { Identity a -> a }"
+                  "def main { case Identity 42 { Identity a -> a } }"
                 ],
                 "42"
               ),
               ( [ "type Identity a = Identity a",
-                  "def main = let id = (\\a -> a : Int -> Int); case Identity (id 42) { Identity a -> a }"
+                  "def main { case Identity (41 + 1) { Identity a -> a } }"
                 ],
                 "42"
               ),
               ( [ "type Identity a = Identity a",
-                  "def runIdentity : Identity Int -> Int",
-                  "def runIdentity identA = case identA { Identity b -> b }",
-                  "def main = runIdentity (Identity 42)"
+                  "def main { let id = (\\a -> a : Int -> Int); case Identity (id 42) { Identity a -> a } }"
+                ],
+                "42"
+              ),
+              ( [ "type Identity a = Identity a",
+                  "def runIdentity (identA: Identity Int): Int { case identA { Identity b -> b } }",
+                  "def main { runIdentity (Identity 42) }"
                 ],
                 "42"
               )

--- a/smol-backend/test/Test/IR/IRSpec.hs
+++ b/smol-backend/test/Test/IR/IRSpec.hs
@@ -116,8 +116,7 @@ spec = do
                 ],
                 "42"
               ),
-              ( [
-                  "def add (a: Int) (b: Int): Int { a + b }",
+              ( [ "def add (a: Int) (b: Int): Int { a + b }",
                   "def main { add 20 22 }"
                 ],
                 "42"

--- a/smol-modules/src/Smol/Modules/FromParts.hs
+++ b/smol-modules/src/Smol/Modules/FromParts.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 
 module Smol.Modules.FromParts
   ( addModulePart,

--- a/smol-modules/src/Smol/Modules/FromParts.hs
+++ b/smol-modules/src/Smol/Modules/FromParts.hs
@@ -46,7 +46,7 @@ addModulePart ::
 addModulePart allParts part mod' =
   case part of
     ModuleExpression (ModuleExpressionC {meArgs, meReturnType, meExpr, meConstraints, meIdent}) -> do
-      _ <- findExpression meIdent allParts 
+      _ <- findExpression meIdent allParts
       tle <- exprAndTypeFromParts meConstraints meArgs meReturnType meExpr
       pure $
         mod'

--- a/smol-modules/src/Smol/Modules/Parser.hs
+++ b/smol-modules/src/Smol/Modules/Parser.hs
@@ -105,8 +105,9 @@ moduleDefinitionParser =
         args <-
           chainl1 ((: []) <$> argPairParser) (pure (<>))
             <|> pure mempty
-        myString ":"
-        retType <- typeParser
+        retType <-
+          (myString ":" >> Just <$> typeParser)
+            <|> pure Nothing
         myString "{"
         expr <- expressionParser
         myString "}"

--- a/smol-modules/src/Smol/Modules/Parser.hs
+++ b/smol-modules/src/Smol/Modules/Parser.hs
@@ -57,8 +57,7 @@ moduleParser =
 -- we've excluded Export here
 parseModuleItem :: Parser (ModuleItem Annotation)
 parseModuleItem =
-  try moduleTypeDefinitionParser
-    <|> try moduleDefinitionParser
+    try moduleDefinitionParser
     <|> try moduleTypeDeclarationParser
     <|> parseTest
     <|> parseInstance
@@ -85,53 +84,43 @@ moduleTypeDeclarationParser =
 -------
 
 -- definitions
--- def oneHundred = 100
--- def id a = a
--- def const a b = a
---
+-- def oneHundred : Integer = 100
+-- def id (a: a) : a = a
+-- def const (a: a) (b: b): a = a
+-- def withEq (Eq a) => (one: a) (two: a): Boolean { equals one two }
 -- top level definition
 moduleDefinitionParser :: Parser (ModuleItem Annotation)
 moduleDefinitionParser =
-  let parser = do
+  let argPairParser = do
+          myString "("
+          ident <- identifierParser
+          myString ":"
+          ty <- typeParser
+          myString ")"
+          pure (ident, ty)
+      parser = do
         myString "def"
         ident <- identifierParser
+        constraints <- try typeConstraintParser <|> pure mempty
         args <-
-          chainl1 ((: []) <$> identifierParser) (pure (<>))
+          chainl1 ((: []) <$> argPairParser) (pure (<>))
             <|> pure mempty
-        myString "="
-        (,,) ident args <$> expressionParser
+        myString ":"
+        retType <- typeParser
+        myString "{"
+        expr <- expressionParser
+        myString "}"
+        pure (ident, constraints, args, retType, expr)
    in withLocation
-        ( \ann (ident, args, expr) ->
+        ( \ann (ident, constraints, args, retType, expr) ->
             ModuleExpression
               ( ModuleExpressionC
                   { meAnn = ann,
                     meIdent = ident,
+                    meConstraints = constraints,
                     meArgs = args,
+                    meReturnType = retType,
                     meExpr = expr
-                  }
-              )
-        )
-        parser
-
--- top level type definition
--- def id : a -> a
--- def compose : (b -> c) -> (a -> b) -> (a -> c)
-moduleTypeDefinitionParser :: Parser (ModuleItem Annotation)
-moduleTypeDefinitionParser =
-  let parser = do
-        myString "def"
-        ident <- identifierParser
-        myString ":"
-        constraints <- try typeConstraintParser <|> pure mempty
-        (,,) ident constraints <$> typeParser
-   in withLocation
-        ( \ann (ident, constraints, ty) ->
-            ModuleType
-              ( ModuleTypeC
-                  { mtAnn = ann,
-                    mtIdent = ident,
-                    mtConstraints = constraints,
-                    mtType = ty
                   }
               )
         )

--- a/smol-modules/src/Smol/Modules/Parser.hs
+++ b/smol-modules/src/Smol/Modules/Parser.hs
@@ -57,7 +57,7 @@ moduleParser =
 -- we've excluded Export here
 parseModuleItem :: Parser (ModuleItem Annotation)
 parseModuleItem =
-    try moduleDefinitionParser
+  try moduleDefinitionParser
     <|> try moduleTypeDeclarationParser
     <|> parseTest
     <|> parseInstance
@@ -92,12 +92,12 @@ moduleTypeDeclarationParser =
 moduleDefinitionParser :: Parser (ModuleItem Annotation)
 moduleDefinitionParser =
   let argPairParser = do
-          myString "("
-          ident <- identifierParser
-          myString ":"
-          ty <- typeParser
-          myString ")"
-          pure (ident, ty)
+        myString "("
+        ident <- identifierParser
+        myString ":"
+        ty <- typeParser
+        myString ")"
+        pure (ident, ty)
       parser = do
         myString "def"
         ident <- identifierParser

--- a/smol-modules/src/Smol/Modules/Types/ModuleItem.hs
+++ b/smol-modules/src/Smol/Modules/Types/ModuleItem.hs
@@ -140,9 +140,13 @@ printInstance constraints instanceHead expr =
         <> line
         <> "}"
 
-printExpression :: Identifier -> [Constraint ParseDep ann] -> 
-      [(Identifier, Type ParseDep ann)] -> Type ParseDep ann -> 
-          Expr ParseDep ann -> Doc style
+printExpression ::
+  Identifier ->
+  [Constraint ParseDep ann] ->
+  [(Identifier, Type ParseDep ann)] ->
+  Type ParseDep ann ->
+  Expr ParseDep ann ->
+  Doc style
 printExpression name constraints args returnType expr =
   let prettyConstraints = case constraints of
         [] -> ""
@@ -152,17 +156,17 @@ printExpression name constraints args returnType expr =
               (\a b -> a <> ", " <> b)
               (prettyDoc <$> cons)
             <> ") =>"
-
-  in "def"
-    <+> prettyDoc name
-    <> prettyConstraints
-    <> printMany (\(ident, ty) -> "(" <> prettyDoc ident <> ":" <+> prettyDoc ty <>")") args
-    <+> ":" <+> prettyDoc returnType
-    <+> "{"
-    <> line
-    <> indentMulti 2 (prettyDoc expr)
-    <> line
-    <> "}"
+   in "def"
+        <+> prettyDoc name
+        <> prettyConstraints
+        <> printMany (\(ident, ty) -> "(" <> prettyDoc ident <> ":" <+> prettyDoc ty <> ")") args
+        <+> ":"
+        <+> prettyDoc returnType
+        <+> "{"
+        <> line
+        <> indentMulti 2 (prettyDoc expr)
+        <> line
+        <> "}"
 
 printTest :: TestName -> Expr ParseDep ann -> Doc style
 printTest testName expr =

--- a/smol-modules/test/Test/Modules/FromPartsSpec.hs
+++ b/smol-modules/test/Test/Modules/FromPartsSpec.hs
@@ -31,7 +31,7 @@ spec = do
         moduleFromModuleParts modParts `shouldBe` Left expected
 
       it "Can't have an empty test name" $ do
-        let modParts = unsafeParseModuleItems (joinText ["def yes = True", "test \"\" { yes }"])
+        let modParts = unsafeParseModuleItems (joinText ["def yes: Bool { True }", "test \"\" { yes }"])
             expected = EmptyTestName (unsafeParseExpr "yes")
 
         moduleFromModuleParts modParts `shouldBe` Left expected

--- a/smol-modules/test/Test/Modules/FromPartsSpec.hs
+++ b/smol-modules/test/Test/Modules/FromPartsSpec.hs
@@ -13,14 +13,8 @@ spec = do
   describe "Modules" $ do
     describe "FromParts" $ do
       it "Can't have conflicting defs" $ do
-        let modParts = unsafeParseModuleItems (joinText ["def yes = True", "def yes = False"])
+        let modParts = unsafeParseModuleItems (joinText ["def yes: Bool { True }", "def yes: Bool{ False }"])
             expected = DuplicateDefinition (Duplicate "yes" () ())
-
-        moduleFromModuleParts modParts `shouldBe` Left expected
-
-      it "Can't have conflicting type defs" $ do
-        let modParts = unsafeParseModuleItems (joinText ["def yes : True", "def yes : False"])
-            expected = DuplicateTypeDefinition (Duplicate "yes" () ())
 
         moduleFromModuleParts modParts `shouldBe` Left expected
 

--- a/smol-modules/test/Test/Modules/InterpreterSpec.hs
+++ b/smol-modules/test/Test/Modules/InterpreterSpec.hs
@@ -42,82 +42,72 @@ spec = do
   describe "Module InterpreterSpec" $ do
     describe "interpret" $ do
       let cases =
-            [ ( ["def main = 1 + 1"],
+            [ ( ["def main: Int { 1 + 1 }"],
                 "2"
               ),
-              ( [ "def id a = a",
-                  "def main = id -10"
+              ( [ "def id (a: a): a { a }",
+                  "def main : Int { id -10 }"
                 ],
                 "-10"
               ),
-              ( [ "def id a = a",
-                  "def useId a = id a",
-                  "def main = useId 100"
+              ( [ "def id (a: a): a { a }",
+                  "def useId (a: a): a { id a }",
+                  "def main : Int {useId 100 }"
                 ],
                 "100"
               ),
               ( [ "class Eq a { equals: a -> a -> Bool }",
                   "instance Eq Int { \\a -> \\b -> a == b }",
-                  "def main = equals (1: Int) (2: Int)"
+                  "def main : Bool {equals (1: Int) (2: Int) }"
                 ],
                 "False"
               ),
               ( [ "class Eq a { equals: a -> a -> Bool }",
                   "instance Eq Int { \\a -> \\b -> a == b }",
-                  "def useEquals = equals (1: Int) (2: Int)",
-                  "def main = useEquals"
+                  "def useEquals : Bool { equals (1: Int) (2: Int) }",
+                  "def main : Bool { useEquals }"
                 ],
                 "False"
               ),
               ( [ "class Eq a { equals: a -> a -> Bool }",
                   "instance Eq Int { \\a -> \\b -> a == b }",
-                  "def useEquals : Int -> Bool",
-                  "def useEquals a = equals a (1: Int)",
-                  "def main : Bool",
-                  "def main = useEquals 2"
+                  "def useEquals (a: Int): Bool {equals a (1: Int) }",
+                  "def main : Bool { useEquals 2 }"
                 ],
                 "False"
               ),
               ( [ "class Eq a { equals: a -> a -> Bool }",
                   "instance Eq Int { \\a -> \\b -> a == b }",
-                  "def useEquals : Bool -> Bool",
-                  "def useEquals a = equals (2: Int) (1: Int)",
-                  "def main : Bool",
-                  "def main = useEquals True"
+                  "def useEquals (a: Bool): Bool { equals (2: Int) (1: Int) }",
+                  "def main : Bool { useEquals True }"
                 ],
                 "False"
               ),
               ( [ "class Eq a { equals: a -> a -> Bool }",
                   "instance Eq Int { \\a -> \\b -> a == b }",
                   "instance (Eq a, Eq b) => Eq (a,b) { \\a -> \\b -> case (a,b) {((a1, b1), (a2, b2)) -> if equals a1 a2 then equals b1 b2 else False } }",
-                  "def main = equals ((1:Int), (2: Int)) ((1: Int), (2: Int))"
+                  "def main : Bool { equals ((1:Int), (2: Int)) ((1: Int), (2: Int)) }"
                 ],
                 "True"
               ),
               ( [ "class Eq a { equals: a -> a -> Bool }",
                   "instance Eq Int { \\a -> \\b -> a == b }",
-                  "def main : Bool",
-                  "def main = useEquals (1: Int) (2: Int)",
-                  "def useEquals : (Eq a) => a -> a -> Bool",
-                  "def useEquals a b = equals a b"
+                  "def main : Bool { useEquals (1: Int) (2: Int) }",
+                  "def useEquals (Eq a) => (a: a) (b: a) : Bool { equals a b }"
                 ],
                 "False"
               ),
               ( [ "class Eq a { equals: a -> a -> Bool }",
                   "instance Eq Int { \\a -> \\b -> a == b }",
-                  "def main : Bool",
-                  "def main = notEquals (1: Int) (2: Int)",
-                  "def notEquals : (Eq a) => a -> a -> Bool",
-                  "def notEquals a b = if isEquals a b then False else True",
-                  "def isEquals : (Eq a) => a -> a -> Bool",
-                  "def isEquals a b = equals a b"
+                  "def main : Bool { notEquals (1: Int) (2: Int) }",
+                  "def notEquals (Eq a) => (a: a) (b: a): Bool { if isEquals a b then False else True }",
+                  "def isEquals (Eq a) => (a: a) (b: a): Bool { equals a b }"
                 ],
                 "True"
               ),
               ( [ "class Eq a { equals: a -> a -> Bool }",
                   "instance Eq String { \\a -> \\b -> a == b }",
-                  "def main : Bool",
-                  "def main = equals (\"cat\" : String) (\"cat\" : String)"
+                  "def main : Bool { equals (\"cat\" : String) (\"cat\" : String) }"
                 ],
                 "True"
               ),
@@ -125,16 +115,14 @@ spec = do
                   "instance Eq Int { \\a -> \\b -> a == b }",
                   "class Semigroup a { mappend: a -> a -> a }",
                   "instance Semigroup Int { \\a -> \\b -> a + b }",
-                  "def main : Bool",
-                  "def main = equals (mappend (20 : Int) (22 : Int)) (42 : Int)"
+                  "def main : Bool { equals (mappend (20 : Int) (22 : Int)) (42 : Int) }"
                 ],
                 "True"
               ),
               ( [ "type Pet = Dog | Cat | Rat",
                   "class Eq a { equals: a -> a -> Bool }",
                   "instance Eq Pet { \\a -> \\b -> case (a,b) { (Dog, Dog) -> True, (Cat, Cat) -> True, (Rat, Rat) -> True, _ -> False } }",
-                  "def main : Bool",
-                  "def main = equals Dog Rat"
+                  "def main : Bool { equals Dog Rat }"
                 ],
                 "False"
               ),
@@ -142,8 +130,7 @@ spec = do
                   "instance Eq Int { \\a -> \\b -> a == b }",
                   "type Maybe a = Just a | Nothing",
                   "instance (Eq a) => Eq (Maybe a) { \\ma -> \\mb -> case (ma, mb) { (Just a, Just b) -> equals a b, (Nothing, Nothing) -> True, _ -> False } }",
-                  "def main : Bool",
-                  "def main = equals (Just (1: Int)) Nothing"
+                  "def main : Bool { equals (Just (1: Int)) Nothing }"
                 ],
                 "False"
               ),
@@ -152,8 +139,7 @@ spec = do
                   "instance Show Natural { \\nat -> ",
                   "case nat { Suc n -> \"S \" + show n ",
                   ", _ -> \"Z\"} }",
-                  "def main : String",
-                  "def main = show (Suc Zero)"
+                  "def main : String { show (Suc Zero) }"
                 ],
                 "\"S Z\""
               )

--- a/smol-modules/test/Test/Modules/ParserSpec.hs
+++ b/smol-modules/test/Test/Modules/ParserSpec.hs
@@ -21,16 +21,14 @@ testInputs =
 spec :: Spec
 spec = do
   describe "Parser" $ do
-    describe "Module" $ do
+    fdescribe "Module" $ do
       let singleDefs =
             [ "type Dog a = Woof String | Other a",
-              "def id : a -> a",
-              "def id a = a",
-              "def compose f g a = f (g a)",
-              "def compose : (c -> b) -> (a -> b) -> (a -> c)",
-              "def onePlusOneEqualsTwo = 1 + 1 == 2",
+              "def id (a: a) : a { a }",
+              "def compose (f: c -> b) (g: a -> b) (a: a) : c { f (g a) }",
+              "def onePlusOneEqualsTwo: Bool { 1 + 1 == 2 }",
               "test \"one plus one equals two\" { 1 + 1 == 2 }",
-              "def usesEquals : (Eq (a,b)) => (a,b) -> (a,b) -> Bool",
+              "def usesEquals (Eq (a,b)) => (one: (a,b)) (two: (a,b)) : Bool { equals one two }",
               "class Eq a { equals: a -> a -> Bool }",
               "instance Eq Int { eqInt }",
               "instance (Eq a) => Eq (Maybe a) { eqMaybeA }"

--- a/smol-modules/test/Test/Modules/ParserSpec.hs
+++ b/smol-modules/test/Test/Modules/ParserSpec.hs
@@ -21,7 +21,7 @@ testInputs =
 spec :: Spec
 spec = do
   describe "Parser" $ do
-    fdescribe "Module" $ do
+    describe "Module" $ do
       let singleDefs =
             [ "type Dog a = Woof String | Other a",
               "def id (a: a) : a { a }",

--- a/smol-modules/test/Test/Modules/PrettyPrintSpec.hs
+++ b/smol-modules/test/Test/Modules/PrettyPrintSpec.hs
@@ -33,7 +33,7 @@ parseModule input =
 spec :: Spec
 spec = do
   describe "Modules" $ do
-    fdescribe "PrettyPrint" $ do
+    describe "PrettyPrint" $ do
       let printModule (filepath, input) =
             it ("Pretty pretting " <> filepath <> " round trips successfully") $ do
               let parts = parseModule input

--- a/smol-modules/test/Test/Modules/PrettyPrintSpec.hs
+++ b/smol-modules/test/Test/Modules/PrettyPrintSpec.hs
@@ -33,7 +33,7 @@ parseModule input =
 spec :: Spec
 spec = do
   describe "Modules" $ do
-    describe "PrettyPrint" $ do
+    fdescribe "PrettyPrint" $ do
       let printModule (filepath, input) =
             it ("Pretty pretting " <> filepath <> " round trips successfully") $ do
               let parts = parseModule input

--- a/smol-modules/test/Test/Modules/ResolveDepsSpec.hs
+++ b/smol-modules/test/Test/Modules/ResolveDepsSpec.hs
@@ -26,7 +26,7 @@ spec = do
 
             expected =
               mempty
-                { moExpressions = M.singleton "main" (TopLevelExpression mempty expr (Just tyInt) )
+                { moExpressions = M.singleton "main" (TopLevelExpression mempty expr (Just tyInt))
                 }
 
         fst <$> resolveModuleDeps mempty mod' `shouldBe` Right expected
@@ -78,7 +78,7 @@ spec = do
 
             expected =
               mempty
-                { moExpressions = M.singleton "main" (TopLevelExpression mempty expr (Just $ tyFunc (TVar () "a") (TVar () "a") ))
+                { moExpressions = M.singleton "main" (TopLevelExpression mempty expr (Just $ tyFunc (TVar () "a") (TVar () "a")))
                 }
 
         fst <$> resolveModuleDeps mempty mod' `shouldBe` Right expected
@@ -97,8 +97,10 @@ spec = do
                 )
             expected =
               mempty
-                { moExpressions = M.singleton "main"
-                      (TopLevelExpression mempty expr (Just $ tyFunc (tyTuple (TVar () "a") [TVar () "b"]) (TVar () "a")) )
+                { moExpressions =
+                    M.singleton
+                      "main"
+                      (TopLevelExpression mempty expr (Just $ tyFunc (tyTuple (TVar () "a") [TVar () "b"]) (TVar () "a")))
                 }
 
         fst <$> resolveModuleDeps mempty mod' `shouldBe` Right expected
@@ -145,7 +147,7 @@ spec = do
             expected =
               mempty
                 { moExpressions =
-                    M.singleton "main" (TopLevelExpression mempty mainExpr (Just $ tyCons "Moybe" [tyInt ] )),
+                    M.singleton "main" (TopLevelExpression mempty mainExpr (Just $ tyCons "Moybe" [tyInt])),
                   moDataTypes =
                     M.singleton
                       "Moybe"

--- a/smol-modules/test/Test/Modules/RunTestsSpec.hs
+++ b/smol-modules/test/Test/Modules/RunTestsSpec.hs
@@ -29,15 +29,15 @@ spec = do
   describe "Modules" $ do
     describe "Run tests" $ do
       it "No tests, no results" $ do
-        let typedMod = testTypecheck (joinText ["def id a = a"])
+        let typedMod = testTypecheck (joinText ["def id (a: a): a { a }"])
         runTests <$> typedMod `shouldBe` Right mempty
 
       it "Two tests, one pass, one fail, no deps" $ do
         let typedMod =
               testTypecheck
                 ( joinText
-                    [ "def yes = True",
-                      "def no = False",
+                    [ "def yes : Bool { True }",
+                      "def no : Bool { False }",
                       "test \"pass\" { yes }",
                       "test \"fail\" { no }"
                     ]
@@ -48,9 +48,9 @@ spec = do
         let typedMod =
               testTypecheck
                 ( joinText
-                    [ "def id a = a",
-                      "def yes = id True",
-                      "def no = id False",
+                    [ "def id (a:a): a { a }",
+                      "def yes : Bool { id True }",
+                      "def no : Bool { id False }",
                       "test \"pass\" { yes }",
                       "test \"fail\" { no }"
                     ]

--- a/smol-modules/test/Test/Modules/TypecheckSpec.hs
+++ b/smol-modules/test/Test/Modules/TypecheckSpec.hs
@@ -42,7 +42,7 @@ spec = do
         testTypecheck
           ( joinText
               [ "test \"it's fine\" { yes }",
-                "def yes = True"
+                "def yes: Bool { True }"
               ]
           )
           `shouldSatisfy` isRight
@@ -51,7 +51,7 @@ spec = do
         let input =
               joinText
                 [ "test \"it's fine\" { yes }",
-                  "def yes = 100"
+                  "def yes : Int { 100 }"
                 ]
         testTypecheck input
           `shouldSatisfy` \case

--- a/smol-modules/test/static/Either.smol
+++ b/smol-modules/test/static/Either.smol
@@ -1,6 +1,6 @@
 type Either e a = Left e | Right a
 
-def orDefault (default: a) (value: Either e a): a {
+def orDefault (default: a) (value: Either e a) : a {
   case value {
     Right a ->
        a,
@@ -9,7 +9,7 @@ def orDefault (default: a) (value: Either e a): a {
   }
 }
 
-def fmap (f: a -> b) (value: Either e a): Either e b {
+def fmap (f: a -> b) (value: Either e a) : Either e b {
   case value {
     Right a ->
        Right (f a),
@@ -17,3 +17,4 @@ def fmap (f: a -> b) (value: Either e a): Either e b {
        Left e
   }
 }
+

--- a/smol-modules/test/static/Either.smol
+++ b/smol-modules/test/static/Either.smol
@@ -1,22 +1,19 @@
 type Either e a = Left e | Right a
 
-def orDefault : 
-  a -> (Either e a) -> a
-def orDefault default value =
+def orDefault (default: a) (value: Either e a): a {
   case value {
     Right a ->
        a,
     Left _ ->
        default
   }
+}
 
-def fmap : 
-  (a -> b) -> (Either e a) -> Either e b
-def fmap f value =
+def fmap (f: a -> b) (value: Either e a): Either e b {
   case value {
     Right a ->
        Right (f a),
     Left e ->
        Left e
   }
-
+}

--- a/smol-modules/test/static/Eq.smol
+++ b/smol-modules/test/static/Eq.smol
@@ -35,49 +35,41 @@ instance (Eq a) => Eq Maybe a {
       }
 }
 
-def useEqualsInt : 
-  Bool
-def useEqualsInt =
+def useEqualsInt : Bool {
   equals (1 : Int) (2 : Int)
+}
 
-def useEqualsA :(Eq a) =>
-  a -> a -> Bool
-def useEqualsA a b =
+def useEqualsA (Eq a) => (a: a) (b: a): Bool {
   equals a b
+}
 
-def notEquals :(Eq a) =>
-  a -> a -> Bool
-def notEquals a b =
+def notEquals (Eq a) => (a: a) (b: a): Bool {
   if (useEqualsA a b) then False else True
+}
 
-def pair : 
-  (Int, Int)
-def pair =
+def pair: (Int,Int) {
   (1, 2)
+}
 
-def flipPair : 
-  (a, b) -> (b, a)
-def flipPair pair =
+def flipPair (pair: (a,b)): (b,a) {
   let (a, b) = pair;
 
   (b, a)
+}
 
-def main : 
-  Bool
-def main =
+def main: Bool {
   notEquals pair (flipPair pair)
+}
 
-def useMaybe : 
-  Bool
-def useMaybe =
+def useMaybe : Bool {
   equals Nothing (Just (1 : Int))
+}
 
-def useNewInstances : 
-  Bool
-def useNewInstances =
+def useNewInstances: Bool {
   if (equals (True : Bool) (False : Bool))
   then
     (equals ("dog" : String) ("log" : String))
   else
     False
+}
 

--- a/smol-modules/test/static/Eq.smol
+++ b/smol-modules/test/static/Eq.smol
@@ -57,15 +57,15 @@ def flipPair (pair: (a, b)) : (b, a) {
   (b, a)
 }
 
-def main : Bool {
+def main {
   notEquals pair (flipPair pair)
 }
 
-def useMaybe : Bool {
+def useMaybe {
   equals Nothing (Just (1 : Int))
 }
 
-def useNewInstances : Bool {
+def useNewInstances {
   if (equals (True : Bool) (False : Bool))
   then
     (equals ("dog" : String) ("log" : String))

--- a/smol-modules/test/static/Eq.smol
+++ b/smol-modules/test/static/Eq.smol
@@ -39,25 +39,25 @@ def useEqualsInt : Bool {
   equals (1 : Int) (2 : Int)
 }
 
-def useEqualsA (Eq a) => (a: a) (b: a): Bool {
+def useEqualsA (Eq a) => (a: a) (b: a) : Bool {
   equals a b
 }
 
-def notEquals (Eq a) => (a: a) (b: a): Bool {
+def notEquals (Eq a) => (a: a) (b: a) : Bool {
   if (useEqualsA a b) then False else True
 }
 
-def pair: (Int,Int) {
+def pair : (Int, Int) {
   (1, 2)
 }
 
-def flipPair (pair: (a,b)): (b,a) {
+def flipPair (pair: (a, b)) : (b, a) {
   let (a, b) = pair;
 
   (b, a)
 }
 
-def main: Bool {
+def main : Bool {
   notEquals pair (flipPair pair)
 }
 
@@ -65,7 +65,7 @@ def useMaybe : Bool {
   equals Nothing (Just (1 : Int))
 }
 
-def useNewInstances: Bool {
+def useNewInstances : Bool {
   if (equals (True : Bool) (False : Bool))
   then
     (equals ("dog" : String) ("log" : String))

--- a/smol-modules/test/static/Expr.smol
+++ b/smol-modules/test/static/Expr.smol
@@ -23,7 +23,7 @@ def run2 (expr: Expr ann) : Int {
   go expr
 }
 
-def main : Int {
+def main {
   run (EAdd Unit (ENumber Unit 1) (ENumber Unit 41))
 }
 

--- a/smol-modules/test/static/Expr.smol
+++ b/smol-modules/test/static/Expr.smol
@@ -1,14 +1,15 @@
 type Expr ann = EAdd ann (Expr ann) (Expr ann) | ENumber ann Int
 
-def run expr =
+def run (expr: Expr ann) : Int {
   case expr {
     ENumber _ i ->
        i,
     EAdd _ _ _ ->
        100
   }
+}
 
-def run2 expr =
+def run2 (expr: Expr ann) : Int {
   let go inner = 
     case inner {
       ENumber _ i ->
@@ -20,7 +21,9 @@ def run2 expr =
     };
 
   go expr
+}
 
-def main =
+def main : Int {
   run (EAdd Unit (ENumber Unit 1) (ENumber Unit 41))
+}
 

--- a/smol-modules/test/static/Maybe.smol
+++ b/smol-modules/test/static/Maybe.smol
@@ -1,24 +1,22 @@
 type Maybe a = Just a | Nothing
 
-def fromMaybe : 
-  (Maybe a) -> a -> a
-def fromMaybe val fallback =
+def fromMaybe (val: Maybe a) (fallback: a) : a {
   case val {
     Just a ->
        a,
     _ ->
        fallback
   }
+}
 
-def fmap : 
-  (a -> b) -> (Maybe a) -> Maybe b
-def fmap f maybeA =
+def fmap (f: a -> b) (maybeA: Maybe a) : Maybe b {
   case maybeA {
     Just a ->
        Just (f a),
     _ ->
        Nothing
   }
+}
 
 test "fmap id does nothing" {
   let id a = a in (fromMaybe (fmap id (Just True)) False) == True

--- a/smol-modules/test/static/Monoid.smol
+++ b/smol-modules/test/static/Monoid.smol
@@ -12,12 +12,11 @@ instance Monoid Int {
 
 type All  = All Bool
 
-def runAll : 
-  All -> Bool
-def runAll all =
+def runAll (all: All) : Bool {
   let All a = all;
 
   a
+}
 
 instance Semigroup All {
   \All a -> \All b -> case ((a, b)) { (True, True) -> All True, _ -> All False }

--- a/smol-modules/test/static/Prelude.smol
+++ b/smol-modules/test/static/Prelude.smol
@@ -1,53 +1,44 @@
-def id : 
-  a -> a
-def id a =
+def id (a: a) : a {
   a
+}
 
-def compose : 
-  (b -> c) -> (a -> b) -> a -> c
-def compose f g a =
+def compose (f: b -> c) (g: a -> b) (a: a) : c {
   f (g a)
+}
 
-def not : 
-  Bool -> Bool
-def not a =
+def not (a: Bool) : Bool {
   if a then False else True
+}
 
-def and : 
-  Bool -> Bool -> Bool
-def and a b =
+def and (a: Bool) (b: Bool) : Bool {
   if a then b else False
+}
 
-def or : 
-  Bool -> Bool -> Bool
-def or a b =
+def or (a: Bool) (b: Bool) : Bool {
   if a then True else b
+}
 
-def fst : 
-  (a, b) -> a
-def fst pair =
+def fst (pair: (a, b)) : a {
   let (a, _) = pair;
 
   a
+}
 
-def snd : 
-  (a, b) -> b
-def snd pair =
+def snd (pair: (a, b)) : b {
   let (_, b) = pair;
 
   b
+}
 
-def const : 
-  a -> b -> a
-def const a b =
+def const (a: a) (b: b) : a {
   a
+}
 
 type Identity a = Identity a
 
-def runIdentity : 
-  (Identity a) -> a
-def runIdentity identity =
+def runIdentity (identity: Identity a) : a {
   let Identity a = identity;
 
   a
+}
 

--- a/smol-modules/test/static/Reader.smol
+++ b/smol-modules/test/static/Reader.smol
@@ -1,24 +1,20 @@
 type Reader r a = Reader (r -> a)
 
-def run : 
-  (Reader (r -> a)) -> r -> a
-def run reader r =
+def run (reader: Reader (r -> a)) (r: r) : a {
   let Reader ra = reader;
 
   ra r
+}
 
-def pure : 
-  a -> Reader r a
-def pure a =
+def pure (a: a) : Reader r a {
   Reader (\r -> a)
+}
 
-def ask : 
-  Reader (r -> r)
-def ask =
+def ask : Reader (r -> r) {
   let id a = a in Reader id
+}
 
-def local : 
-  (r -> r) -> (Reader (r -> a)) -> Reader (r -> a)
-def local envF reader =
+def local (envF: r -> r) (reader: Reader (r -> a)) : Reader (r -> a) {
   Reader (\r -> run reader (envF r))
+}
 

--- a/smol-modules/test/static/Semigroup.smol
+++ b/smol-modules/test/static/Semigroup.smol
@@ -12,24 +12,21 @@ instance Semigroup Int {
 
 type First a = First a
 
-def runFirst : 
-  (First a) -> a
-def runFirst firstA =
+def runFirst (firstA: First a) : a {
   let First a = firstA;
 
   a
+}
 
 instance Semigroup First a {
   \a -> \b -> a
 }
 
-def true : 
-  Bool
-def true =
+def true : Bool {
   runFirst (mappend (First (True : Bool)) (First (False : Bool)))
+}
 
-def main : 
-  Bool
-def main =
+def main : Bool {
   equals (mappend (20 : Int) (22 : Int)) (42 : Int)
+}
 

--- a/smol-modules/test/static/Semigroup.smol
+++ b/smol-modules/test/static/Semigroup.smol
@@ -22,11 +22,11 @@ instance Semigroup First a {
   \a -> \b -> a
 }
 
-def true : Bool {
+def true {
   runFirst (mappend (First (True : Bool)) (First (False : Bool)))
 }
 
-def main : Bool {
+def main {
   equals (mappend (20 : Int) (22 : Int)) (42 : Int)
 }
 

--- a/smol-modules/test/static/Show.smol
+++ b/smol-modules/test/static/Show.smol
@@ -38,17 +38,11 @@ instance (Show a) => Show List a {
     }
 }
 
-def showBoolList =
-  (show (Cons (True : Bool) (Cons (False : Bool) Nil))) == "True:False:Nil"
-
 test "Show Bool List" {
-  showBoolList
+  (show (Cons (True : Bool) (Cons (False : Bool) Nil))) == "True:False:Nil"
 }
 
-def showNaturalList =
-  (show (Cons (Suc Zero) (Cons Zero Nil))) == "S (Z):Z:Nil"
-
 test "Show Natural List" {
-  showNaturalList
+  (show (Cons (Suc Zero) (Cons Zero Nil))) == "S (Z):Z:Nil"
 }
 

--- a/smol-modules/test/static/State.smol
+++ b/smol-modules/test/static/State.smol
@@ -1,30 +1,24 @@
 type State s a = State (s -> (a, s))
 
-def pure : 
-  a -> State s a
-def pure a =
+def pure (a: a) : State s a {
   State (\s -> (a, s))
+}
 
-def get : 
-  State s s
-def get =
+def get : State s s {
   State (\s -> (s, s))
+}
 
-def put : 
-  s -> State s Unit
-def put s =
+def put (s: s) : State s Unit {
   State (\oldS -> (Unit, s))
+}
 
-def fmap : 
-  (a -> b) -> (State s a) -> State s b
-def fmap f state =
+def fmap (f: a -> b) (state: State s a) : State s b {
   let State sas = state;
 
   State (\s -> let (a, s) = (sas s) in ((f a), s))
+}
 
-def ap : 
-  (State s (a -> b)) -> (State s a) -> State s b
-def ap stateF stateA =
+def ap (stateF: State s (a -> b)) (stateA: State s a) : State s b {
   State (\s ->
     let State sfs = stateF;
 
@@ -36,10 +30,9 @@ def ap stateF stateA =
     let State sas = stateA;
 
     let as = sas ss in let (a, sss) = as in ((f a), sss))
+}
 
-def bind : 
-  (a -> State s b) -> (State s a) -> State s b
-def bind f state =
+def bind (f: a -> State s b) (state: State s a) : State s b {
   State (\s ->
     let State sas = state;
 
@@ -48,11 +41,11 @@ def bind f state =
     let State sbs = (f a);
 
     sbs ss)
+}
 
-def run : 
-  (State s a) -> s -> (a, s)
-def run state s =
+def run (state: State s a) (s: s) : (a, s) {
   let State sas = state;
 
   sas s
+}
 

--- a/smol-modules/test/static/Tree.smol
+++ b/smol-modules/test/static/Tree.smol
@@ -1,8 +1,6 @@
 type Tree a = Branch (Tree a) a (Tree a) | Leaf a
 
-def fmap : 
-  (a -> b) -> (Tree a) -> Tree b
-def fmap f =
+def fmap (f: a -> b) : (Tree a) -> Tree b {
   let map innerTree = 
     case innerTree {
       Branch left a right ->
@@ -12,10 +10,9 @@ def fmap f =
     };
 
   map
+}
 
-def invert : 
-  (Tree a) -> Tree b
-def invert =
+def invert : (Tree a) -> Tree b {
   let invertTree innerTree = 
     case innerTree {
       Branch left a right ->
@@ -25,4 +22,5 @@ def invert =
     };
 
   invertTree
+}
 


### PR DESCRIPTION
Resolves #1046 

```haskell
def mappend (a: Int) (b: Int) : Int {
  a + b
}

/* no annotations required for non-functions */
def dog { "dog" }
```

Works.